### PR TITLE
ci: fix nightly fuzz manifest detection

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Run Fuzz Targets (short)
         run: |
-          cargo fuzz run manifest_entity -- -max_total_time=60
+          cargo fuzz run --fuzz-dir fuzz manifest_entity -- -max_total_time=60
 
   deny:
     runs-on: ubuntu-22.04

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.0"
 edition = "2024"
 publish = false
 
+[package.metadata]
+cargo-fuzz = true
+
 [dependencies]
 libfuzzer-sys = "0.4"
 dbt-nova = { path = ".." }


### PR DESCRIPTION
Summary:\n- add cargo-fuzz metadata marker to fuzz/Cargo.toml\n- run nightly fuzz with explicit --fuzz-dir fuzz\n\nWhy:\nNightly failed because cargo-fuzz rejected the fuzz manifest as non-cargo-fuzz format.\n\nScope:\n- CI/nightly only\n- no release workflow changes