### PR TITLE
release: v0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to dbt-nova will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.1] - 2026-02-18
+
+### Fixed
+
+- Bundled model layout normalization now handles both `snapshots/<rev>/model.onnx` and
+  `snapshots/<rev>/onnx/model.onnx` layouts in install and warmup flows.
+- Bundled model discovery now falls back to `~/.local/bin/models` when executable-relative
+  model lookup is unavailable in client runtime environments.
+- Nightly fuzz workflow now uses explicit fuzz directory resolution and cargo-fuzz manifest
+  metadata compatibility.
+- Warmup model readiness now counts distinct snapshot roots, preventing duplicate-path
+  inflation.
+
+### Changed
+
+- Release packaging now requires and bundles all 3 model families by default
+  (embedding, sparse, reranker).
+
 ## [0.0.0] - 2026-02-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "dbt-nova"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbt-nova"
-version = "0.0.0"
+version = "0.0.1"
 rust-version = "1.93"
 edition = "2024"
 description = "High-performance MCP server for searching and analyzing dbt manifest files"


### PR DESCRIPTION
Release branch for v0.0.1.\n\nIncludes:\n- bundled model path compatibility fixes\n- bundled model discovery fallback for ~/.local/bin/models\n- nightly fuzz workflow compatibility fixes\n- release packaging now bundles reranker by default