### PR TITLE
docs: clarify slim install model cache and warmup flow

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -57,6 +57,21 @@ curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
 The installer places `dbt-nova` in `~/.local/bin`. For bundled installs, it also
 places `models/` next to the binary so Nova auto-discovers it.
 
+### Optional: Install + Pre-Warm Models
+
+If you want users to avoid first-run model downloads, pre-warm immediately after install:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/warm_models.sh | \
+  DBT_NOVA_BIN="$HOME/.local/bin/dbt-nova" \
+  DBT_NOVA_EMBEDDINGS_CACHE_DIR="$HOME/.dbt-nova/models" \
+  bash -s partial
+```
+
+Use the same `DBT_NOVA_EMBEDDINGS_CACHE_DIR` value in your MCP client config so every
+client process reuses that cache.
+
 ## Verify Installation
 
 ```bash

--- a/docs/getting-started/mcp-clients.md
+++ b/docs/getting-started/mcp-clients.md
@@ -5,6 +5,9 @@ Databricks variables are required only if you use the `execute_sql` tool with
 `DBT_NOVA_SQL_PROVIDER=databricks` (default).
 BigQuery variables are required only if you use `DBT_NOVA_SQL_PROVIDER=bigquery`.
 
+For slim installs, set a stable `DBT_NOVA_EMBEDDINGS_CACHE_DIR` (for example
+`~/.dbt-nova/models`) so model downloads are reused across sessions/clients.
+
 ## Claude Desktop (`claude_desktop_config.json`)
 
 ```json
@@ -14,6 +17,7 @@ BigQuery variables are required only if you use `DBT_NOVA_SQL_PROVIDER=bigquery`
       "command": "/path/to/dbt-nova",
       "env": {
         "DBT_MANIFEST_PATH": "/path/to/manifest.json",
+        "DBT_NOVA_EMBEDDINGS_CACHE_DIR": "/Users/<you>/.dbt-nova/models",
         "DATABRICKS_HOST": "https://<workspace>.cloud.databricks.com",
         "DATABRICKS_HTTP_PATH": "/sql/1.0/warehouses/<warehouse_id>",
         "DATABRICKS_ACCESS_TOKEN": "<token>"
@@ -35,7 +39,7 @@ DBT_MANIFEST_PATH = "/path/to/manifest.json"
 DATABRICKS_HOST = "https://<workspace>.cloud.databricks.com"
 DATABRICKS_HTTP_PATH = "/sql/1.0/warehouses/<warehouse_id>"
 DATABRICKS_ACCESS_TOKEN = "<token>"
-DBT_NOVA_EMBEDDINGS_CACHE_DIR = "/path/to/models" # optional (not needed for bundled installs)
+DBT_NOVA_EMBEDDINGS_CACHE_DIR = "/Users/<you>/.dbt-nova/models"
 ```
 
 ## Gemini CLI (config JSON)
@@ -56,6 +60,7 @@ hints from tool definitions.
       "command": "/path/to/dbt-nova",
       "env": {
         "DBT_MANIFEST_PATH": "/path/to/manifest.json",
+        "DBT_NOVA_EMBEDDINGS_CACHE_DIR": "/Users/<you>/.dbt-nova/models",
         "DBT_NOVA_DISABLE_TOOL_SCHEMAS": "1",
         "DATABRICKS_HOST": "https://<workspace>.cloud.databricks.com",
         "DATABRICKS_HTTP_PATH": "/sql/1.0/warehouses/<warehouse_id>",

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -22,6 +22,12 @@ GH_TOKEN="$(gh auth token)"
 curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
   https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
   DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash
+
+# Optional: pre-warm models now (instead of waiting for first semantic query)
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/warm_models.sh | \
+  DBT_NOVA_BIN="$HOME/.local/bin/dbt-nova" \
+  DBT_NOVA_EMBEDDINGS_CACHE_DIR="$HOME/.dbt-nova/models" \
+  bash -s partial
 ```
 
 === "macOS (Apple Silicon)"
@@ -61,6 +67,7 @@ Set your manifest path:
 
 ```bash
 export DBT_MANIFEST_PATH=/path/to/your/dbt/project/target/manifest.json
+export DBT_NOVA_EMBEDDINGS_CACHE_DIR="$HOME/.dbt-nova/models"
 ```
 
 !!! tip "Pro Tip"
@@ -98,7 +105,8 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
     "dbt-nova": {
       "command": "dbt-nova",
       "env": {
-        "DBT_MANIFEST_PATH": "/path/to/manifest.json"
+        "DBT_MANIFEST_PATH": "/path/to/manifest.json",
+        "DBT_NOVA_EMBEDDINGS_CACHE_DIR": "/Users/<you>/.dbt-nova/models"
       }
     }
   }
@@ -115,7 +123,8 @@ Add to `.cursor/mcp.json` in your project:
     "dbt-nova": {
       "command": "dbt-nova",
       "env": {
-        "DBT_MANIFEST_PATH": "/path/to/manifest.json"
+        "DBT_MANIFEST_PATH": "/path/to/manifest.json",
+        "DBT_NOVA_EMBEDDINGS_CACHE_DIR": "/Users/<you>/.dbt-nova/models"
       }
     }
   }


### PR DESCRIPTION
## Summary
- add an explicit install + pre-warm command flow for curl installs
- document using a stable DBT_NOVA_EMBEDDINGS_CACHE_DIR across shell and MCP client configs
- update quickstart and MCP client examples to include cache dir

## Validation
- mkdocs build --strict