### PR TITLE
ci: fix nightly fuzz manifest target declaration

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,4 +12,10 @@ libfuzzer-sys = "0.4"
 dbt-nova = { path = ".." }
 serde_json = "1.0"
 
+[[bin]]
+name = "manifest_entity"
+path = "fuzz_targets/manifest_entity.rs"
+test = false
+doc = false
+
 [workspace]


### PR DESCRIPTION
## Summary
- add explicit [[bin]] target declaration to fuzz/Cargo.toml for manifest_entity
- align fuzz manifest layout with cargo fuzz run --fuzz-dir fuzz manifest_entity used in nightly CI

## Validation
- cargo metadata --manifest-path fuzz/Cargo.toml --no-deps