### PR TITLE
ci: force GNU target for nightly fuzz

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,11 @@ jobs:
 
       - name: Run Fuzz Targets (short)
         run: |
-          cargo fuzz run --fuzz-dir fuzz manifest_entity -- -max_total_time=60
+          cargo fuzz run \
+            --fuzz-dir fuzz \
+            --target x86_64-unknown-linux-gnu \
+            manifest_entity \
+            -- -max_total_time=60
 
   deny:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Summary: set nightly fuzz command to use explicit x86_64-unknown-linux-gnu target to avoid ASAN+musl failure in cargo-fuzz.