### PR TITLE
docs: sync install guides with installer behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,33 +134,34 @@ Minimal MCP client config:
 ## Quick Start
 
 ```bash
-# Install (defaults to slim artifact; models download on first run)
+# Install (recommended: slim + non-interactive)
 # Public repo (unauthenticated)
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
+  bash -s -- --slim --non-interactive
 
 # Private repo (authenticated)
 GH_TOKEN="$(gh auth token)"
 curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
   https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
-  DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash
+  DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
 
-# Optional: pre-warm model files during install
+# Optional: pre-warm model files during install (recommended for first-time setup)
 curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
-  DBT_NOVA_INSTALL_WARM_MODELS=1 \
   DBT_NOVA_EMBEDDINGS_CACHE_DIR="$HOME/.dbt-nova/models" \
-  bash
+  DBT_NOVA_WARMUP_REQUIRED_MODELS=3 \
+  bash -s -- --slim --warm-models --non-interactive
 
-# Optional: install bundled persona skills to ~/.agents/skills
+# Optional: install built-in persona skills to ~/.agents/skills
 curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
-  DBT_NOVA_INSTALL_SKILLS=1 \
-  bash
+  bash -s -- --slim --install-skills --non-interactive
 
 export DBT_MANIFEST_PATH=/path/to/manifest.json
-./dbt-nova
+export PATH="$HOME/.local/bin:$PATH"
+dbt-nova
 
 # Remote manifest (optional)
 export DBT_NOVA_MANIFEST_URI=dbfs:///mnt/analytics/manifest.json
-./dbt-nova
+dbt-nova
 ```
 
 See installation options in the docs:

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -128,9 +128,17 @@ the binary in `~/.local/bin` by default.
 Useful overrides:
 
 - `DBT_NOVA_INSTALL_FLAVOR=bundled|slim`
+- `DBT_NOVA_INSTALL_WARM_MODELS=1`
+- `DBT_NOVA_EMBEDDINGS_CACHE_DIR=/path/to/models`
+- `DBT_NOVA_WARMUP_REQUIRED_MODELS=3`
+- `DBT_NOVA_INSTALL_SKILLS=1`
+- `DBT_NOVA_SKILLS_DIR=/custom/skills/path`
 - `DBT_NOVA_INSTALL_NONINTERACTIVE=1`
 - `DBT_NOVA_INSTALL_DIR=/custom/path`
-- `--bundled`, `--slim`, `--non-interactive`, `--install-dir <path>`
+- `DBT_NOVA_VERIFY_CHECKSUM=1|0`
+- `DBT_NOVA_VERIFY_SIGNATURE=1|0`
+- `DBT_NOVA_COSIGN_BINARY=cosign`
+- `--bundled`, `--slim`, `--warm-models`, `--install-skills`, `--skills-dir <path>`, `--non-interactive`, `--install-dir <path>`
 
 ## Packaging Notes
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -21,13 +21,14 @@ Use the installer script (defaults to **slim**):
 
 ```bash
 # Public repo (unauthenticated)
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
+  bash -s -- --slim --non-interactive
 
 # Private repo (authenticated)
 GH_TOKEN="$(gh auth token)"
 curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
   https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
-  DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash
+  DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
 ```
 
 Non-interactive examples:
@@ -35,23 +36,23 @@ Non-interactive examples:
 ```bash
 # Public repo: default slim in non-interactive mode
 curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
-  DBT_NOVA_INSTALL_NONINTERACTIVE=1 bash
+  bash -s -- --non-interactive
 
 # Public repo: force slim
 curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
-  DBT_NOVA_INSTALL_NONINTERACTIVE=1 DBT_NOVA_INSTALL_FLAVOR=slim bash
+  bash -s -- --slim --non-interactive
 
 # Private repo: default slim in non-interactive mode
 GH_TOKEN="$(gh auth token)"
 curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
   https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
-  DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" DBT_NOVA_INSTALL_NONINTERACTIVE=1 bash
+  DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --non-interactive
 
 # Private repo: force slim
 GH_TOKEN="$(gh auth token)"
 curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
   https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
-  DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" DBT_NOVA_INSTALL_NONINTERACTIVE=1 DBT_NOVA_INSTALL_FLAVOR=slim bash
+  DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
 ```
 
 The installer places `dbt-nova` in `~/.local/bin`. For bundled installs, it also
@@ -63,9 +64,9 @@ If you want users to avoid first-run model downloads, pre-warm during install:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
-  DBT_NOVA_INSTALL_WARM_MODELS=1 \
   DBT_NOVA_EMBEDDINGS_CACHE_DIR="$HOME/.dbt-nova/models" \
-  bash
+  DBT_NOVA_WARMUP_REQUIRED_MODELS=3 \
+  bash -s -- --slim --warm-models --non-interactive
 ```
 
 Use the same `DBT_NOVA_EMBEDDINGS_CACHE_DIR` value in your MCP client config so every
@@ -78,24 +79,33 @@ standard Agent Skills user directory:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
-  DBT_NOVA_INSTALL_SKILLS=1 \
-  bash
+  bash -s -- --slim --install-skills --non-interactive
 ```
 
 To choose a different destination:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
-  DBT_NOVA_INSTALL_SKILLS=1 \
   DBT_NOVA_SKILLS_DIR="$HOME/.codex/skills" \
-  bash
+  bash -s -- --slim --install-skills --non-interactive
 ```
 
 ## Verify Installation
 
 ```bash
+export PATH="$HOME/.local/bin:$PATH"
+command -v dbt-nova
+dbt-nova --version
 export DBT_MANIFEST_PATH=/path/to/manifest.json
 echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | dbt-nova
+```
+
+If you pre-warmed models, verify three required model snapshots exist:
+
+```bash
+find "$HOME/.dbt-nova/models" -type f \
+  \( -path "*/snapshots/*/onnx/model.onnx" -o -path "*/snapshots/*/model.onnx" \) \
+  | sed -E 's#/(onnx/)?model\.onnx$##' | sort -u | wc -l
 ```
 
 The installer verifies SHA-256 checksums for downloaded archives by default.

--- a/docs/getting-started/mcp-clients.md
+++ b/docs/getting-started/mcp-clients.md
@@ -10,7 +10,10 @@ For slim installs, set a stable `DBT_NOVA_EMBEDDINGS_CACHE_DIR` (recommended:
 If you installed with:
 
 ```bash
-DBT_NOVA_INSTALL_WARM_MODELS=1 DBT_NOVA_EMBEDDINGS_CACHE_DIR="$HOME/.dbt-nova/models"
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
+  DBT_NOVA_EMBEDDINGS_CACHE_DIR="$HOME/.dbt-nova/models" \
+  DBT_NOVA_WARMUP_REQUIRED_MODELS=3 \
+  bash -s -- --slim --warm-models --non-interactive
 ```
 
 use that exact same `DBT_NOVA_EMBEDDINGS_CACHE_DIR` path in your MCP client env.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -15,19 +15,24 @@ Get dbt-nova running in under 5 minutes.
 
 ```bash
 # Public repo (unauthenticated)
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
+  bash -s -- --slim --non-interactive
 
 # Private repo (authenticated)
 GH_TOKEN="$(gh auth token)"
 curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
   https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
-  DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash
+  DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
 
 # Optional: pre-warm models during install (instead of first semantic query)
 curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
-  DBT_NOVA_INSTALL_WARM_MODELS=1 \
   DBT_NOVA_EMBEDDINGS_CACHE_DIR="$HOME/.dbt-nova/models" \
-  bash
+  DBT_NOVA_WARMUP_REQUIRED_MODELS=3 \
+  bash -s -- --slim --warm-models --non-interactive
+
+# Optional: install Agent Skills into ~/.agents/skills
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
+  bash -s -- --slim --install-skills --non-interactive
 ```
 
 === "macOS (Apple Silicon)"
@@ -66,6 +71,7 @@ curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scrip
 Set your manifest path:
 
 ```bash
+export PATH="$HOME/.local/bin:$PATH"
 export DBT_MANIFEST_PATH=/path/to/your/dbt/project/target/manifest.json
 export DBT_NOVA_EMBEDDINGS_CACHE_DIR="$HOME/.dbt-nova/models"
 ```

--- a/docs/getting-started/skills.md
+++ b/docs/getting-started/skills.md
@@ -27,8 +27,7 @@ the standard Agent Skills user directory in one step:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scripts/install.sh | \
-  DBT_NOVA_INSTALL_SKILLS=1 \
-  bash
+  bash -s -- --slim --install-skills --non-interactive
 ```
 
 Set `DBT_NOVA_SKILLS_DIR` to use a different destination (for example


### PR DESCRIPTION
Summary:
- align install commands with the current install.sh CLI flow (bash -s -- ...)
- standardize recommended install path to slim + non-interactive
- add warm-model and skills install examples using current flags
- add PATH/version verification and warmed-model count check
- update release docs with current installer env vars and flags

Validation:
- mkdocs build --strict