### PR TITLE
fix: make manifest JSON fallbacks observable

### DIFF
--- a/src/manifest/entity.rs
+++ b/src/manifest/entity.rs
@@ -2,6 +2,7 @@ use rkyv::option::ArchivedOption;
 use rkyv::string::ArchivedString;
 use rkyv_derive::{Archive, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
+use tracing::warn;
 
 macro_rules! archived_str_accessor {
     ($( $name:ident => $field:ident ),+ $(,)?) => {
@@ -114,7 +115,17 @@ pub struct Entity {
 impl Entity {
     #[must_use]
     pub fn from_json(unique_id: &str, payload: &JsonValue) -> Self {
-        let payload_json = serde_json::to_string(payload).unwrap_or_else(|_| "null".to_string());
+        let payload_json = match serde_json::to_string(payload) {
+            Ok(payload_json) => payload_json,
+            Err(err) => {
+                warn!(
+                    unique_id = unique_id,
+                    error = %err,
+                    "failed to serialize entity payload; falling back to null"
+                );
+                "null".to_string()
+            }
+        };
         let column_names = get_column_names(payload);
         let column_meta = get_column_meta(payload, &column_names);
         Self {
@@ -143,7 +154,17 @@ impl Entity {
 
     #[must_use]
     pub fn to_json_value(&self) -> serde_json::Value {
-        serde_json::from_str(&self.payload_json).unwrap_or(JsonValue::Null)
+        match serde_json::from_str(&self.payload_json) {
+            Ok(payload) => payload,
+            Err(err) => {
+                warn!(
+                    unique_id = %self.unique_id,
+                    error = %err,
+                    "failed to parse entity payload_json; returning null payload"
+                );
+                JsonValue::Null
+            }
+        }
     }
 
     #[must_use]
@@ -164,7 +185,17 @@ impl ArchivedEntity {
 
     #[must_use]
     pub fn to_json_value(&self) -> serde_json::Value {
-        serde_json::from_str(self.payload_json()).unwrap_or(JsonValue::Null)
+        match serde_json::from_str(self.payload_json()) {
+            Ok(payload) => payload,
+            Err(err) => {
+                warn!(
+                    payload_len = self.payload_json().len(),
+                    error = %err,
+                    "failed to parse archived entity payload_json; returning null payload"
+                );
+                JsonValue::Null
+            }
+        }
     }
 
     #[must_use]
@@ -579,4 +610,22 @@ fn parse_metric(value: &JsonValue) -> Option<NovaMetric> {
         grain,
         recommended_filters,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_json_value_invalid_payload_returns_null() {
+        let mut entity = Entity::from_json(
+            "model.pkg.invalid",
+            &serde_json::json!({
+                "name": "invalid"
+            }),
+        );
+        entity.payload_json = "{not-json".to_string();
+
+        assert_eq!(entity.to_json_value(), JsonValue::Null);
+    }
 }

--- a/src/manifest/loader.rs
+++ b/src/manifest/loader.rs
@@ -25,7 +25,7 @@ use crate::manifest::store::{EntityStore, EntityStoreBuilder};
 use crate::manifest::tantivy_search::TantivySearcher;
 use crate::manifest::vector_search::{Reranker, SparseSearcher, VectorSearcher};
 use crate::utils::{CircuitBreaker, IN_USE_LOCK_FILENAME, prune_dirs, unique_suffix};
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 struct ManifestAccumulator {
     store_builder: Option<EntityStoreBuilder>,
@@ -915,8 +915,17 @@ fn build_column_lineage_aliases(
         let Some(entity) = entities.get_blocking(&unique_id)? else {
             continue;
         };
-        let payload: JsonValue =
-            serde_json::from_str(&entity.payload_json).unwrap_or(JsonValue::Null);
+        let payload: JsonValue = match serde_json::from_str(&entity.payload_json) {
+            Ok(payload) => payload,
+            Err(err) => {
+                warn!(
+                    unique_id = %unique_id,
+                    error = %err,
+                    "failed to parse entity payload_json during column lineage alias precompute; skipping entity"
+                );
+                continue;
+            }
+        };
         if let Some(sql) = sql_for_matching(&payload) {
             let map = find_sql_aliases(sql);
             if !map.is_empty() {
@@ -1259,5 +1268,52 @@ mod tests {
             .unwrap_or_default();
         assert_eq!(sample.len(), 1);
         assert_eq!(sample[0].as_str(), Some("model.pkg.metric__bad"));
+    }
+
+    #[test]
+    fn build_column_lineage_aliases_skips_invalid_payload_json() {
+        let temp = tempdir().unwrap_or_else(|err| panic!("tempdir failed: {err}"));
+        let mut builder = EntityStoreBuilder::new(temp.path())
+            .unwrap_or_else(|err| panic!("builder init failed: {err}"));
+
+        let valid_payload = serde_json::json!({
+            "name": "metric__valid",
+            "resource_type": "model",
+            "raw_code": "select revenue as revenue_alias from {{ ref('orders') }}"
+        });
+        let valid = Entity::from_json("model.pkg.metric__valid", &valid_payload);
+        builder
+            .add("model.pkg.metric__valid", &valid)
+            .unwrap_or_else(|err| panic!("failed to add valid entity: {err}"));
+
+        let mut invalid = Entity::from_json(
+            "model.pkg.metric__invalid",
+            &serde_json::json!({
+                "name": "metric__invalid",
+                "resource_type": "model",
+                "raw_code": "select 1"
+            }),
+        );
+        invalid.payload_json = "{not-json".to_string();
+        builder
+            .add("model.pkg.metric__invalid", &invalid)
+            .unwrap_or_else(|err| panic!("failed to add invalid entity: {err}"));
+
+        let store = builder
+            .finish()
+            .unwrap_or_else(|err| panic!("failed to finalize store: {err}"));
+        let config = DbtNovaConfig::default();
+
+        let aliases = build_column_lineage_aliases(&store, &config)
+            .unwrap_or_else(|err| panic!("failed to build aliases: {err}"));
+
+        assert!(
+            aliases.contains_key("model.pkg.metric__valid"),
+            "expected valid entity to produce aliases"
+        );
+        assert!(
+            !aliases.contains_key("model.pkg.metric__invalid"),
+            "invalid payload_json should be skipped"
+        );
     }
 }

--- a/src/manifest/source/mod.rs
+++ b/src/manifest/source/mod.rs
@@ -602,14 +602,11 @@ fn fetch_dbfs_manifest(
         let body: JsonValue = resp
             .json()
             .map_err(|e| DbtNovaError::ServerError(format!("DBFS read parse failed: {e}")))?;
-        let bytes_str = body.get("data").and_then(JsonValue::as_str).unwrap_or("");
+        let bytes_str = dbfs_read_data_field(&body, offset);
         let chunk = BASE64
             .decode(bytes_str.as_bytes())
             .map_err(|e| DbtNovaError::ServerError(format!("DBFS decode failed: {e}")))?;
-        let bytes_read = body
-            .get("bytes_read")
-            .and_then(JsonValue::as_u64)
-            .unwrap_or(0);
+        let bytes_read = dbfs_read_bytes_read_field(&body, offset);
         buffer.extend_from_slice(&chunk);
         if max_bytes > 0 && buffer.len() as u64 > max_bytes {
             if cache_path.exists() {
@@ -645,6 +642,30 @@ fn fetch_dbfs_manifest(
         source_uri: uri.to_string(),
         cached: false,
     })
+}
+
+fn dbfs_read_data_field(body: &JsonValue, offset: u64) -> &str {
+    if let Some(data) = body.get("data").and_then(JsonValue::as_str) {
+        data
+    } else {
+        warn!(
+            offset = offset,
+            "DBFS read response missing string 'data' field; treating chunk as empty"
+        );
+        ""
+    }
+}
+
+fn dbfs_read_bytes_read_field(body: &JsonValue, offset: u64) -> u64 {
+    if let Some(bytes_read) = body.get("bytes_read").and_then(JsonValue::as_u64) {
+        bytes_read
+    } else {
+        warn!(
+            offset = offset,
+            "DBFS read response missing numeric 'bytes_read' field; treating as zero"
+        );
+        0
+    }
 }
 
 fn fetch_s3_manifest(rest: &str, uri: &str, config: &DbtNovaConfig) -> Result<ManifestResolution> {
@@ -1088,4 +1109,26 @@ fn fetch_gcs_manifest_sdk(
         source_uri: uri.to_string(),
         cached: false,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dbfs_read_field_helpers_default_missing_values() {
+        let body = serde_json::json!({});
+        assert_eq!(dbfs_read_data_field(&body, 7), "");
+        assert_eq!(dbfs_read_bytes_read_field(&body, 7), 0);
+    }
+
+    #[test]
+    fn dbfs_read_field_helpers_use_present_values() {
+        let body = serde_json::json!({
+            "data": "YWJj",
+            "bytes_read": 3
+        });
+        assert_eq!(dbfs_read_data_field(&body, 0), "YWJj");
+        assert_eq!(dbfs_read_bytes_read_field(&body, 0), 3);
+    }
 }


### PR DESCRIPTION
## Summary
- replace silent JSON fallback paths with `tracing::warn!` in entity serialization/parsing paths
- avoid silent alias precompute fallback in loader by warning and skipping invalid payloads
- make DBFS chunk field fallbacks observable via warning helpers
- add unit tests for the new fallback behavior in entity, loader, and manifest source modules

## Validation
- cargo fmt --all
- cargo clippy --locked --all-targets -- -D warnings
- cargo test --locked

Closes #23
