### PR TITLE
recipe: deprecate parameter_types aliases with migration hints

### DIFF
--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -317,7 +317,7 @@ Optional:
 - `include_queries` (bool)
 - `parameters` (optional placeholder values for SQL rendering and missing checks)
 - `placeholder_types` (optional placeholder coercion hints)
-- `parameter_types` (deprecated alias for `placeholder_types`)
+- `parameter_types` (deprecated alias; use `placeholder_types`)
 
 ```json
 {"name":"get_recipe","arguments":{"recipe_id":"marketing/weekly_country_kpi_report","include_queries":true,"include_sql":true}}
@@ -349,7 +349,7 @@ Optional:
 - `stop_on_failure` (bool, default: `true`)
 - `include_sql` (bool)
 - SQL execution controls: `row_limit`, `byte_limit`, `wait_timeout_s`, `poll_interval_ms`, `max_poll_seconds`, `parameters`, `placeholder_types`, `sql_parameter_types`, `fetch_all_chunks`, `max_chunks`
-- `parameter_types` (deprecated fallback alias for both `placeholder_types` and `sql_parameter_types`)
+- `parameter_types` (deprecated fallback alias; use `placeholder_types` and `sql_parameter_types`)
 
 ```json
 {"name":"run_recipe","arguments":{"recipe_id":"marketing/weekly_country_kpi_report","query_indexes":[1,2],"stop_on_failure":true}}

--- a/src/params.rs
+++ b/src/params.rs
@@ -161,7 +161,12 @@ pub struct GetRecipeParams {
     /// Optional placeholder type hints (e.g. {"country_code":"string","target_table":"identifier"}).
     #[serde(default)]
     pub placeholder_types: Option<HashMap<String, String>>,
-    /// Deprecated alias for placeholder type hints.
+    /// Deprecated alias for `placeholder_types`.
+    /// Use `placeholder_types` instead.
+    #[deprecated(
+        since = "0.0.2",
+        note = "Use placeholder_types instead of parameter_types."
+    )]
     #[serde(default)]
     pub parameter_types: Option<HashMap<String, String>>,
 }
@@ -209,8 +214,14 @@ pub struct RunRecipeParams {
     /// (e.g., {"as_of_date":"DATE"}).
     #[serde(default)]
     pub sql_parameter_types: Option<HashMap<String, String>>,
-    /// Deprecated alias for type hints. When provided, it is used as a fallback for both
-    /// `placeholder_types` and `sql_parameter_types`.
+    /// Deprecated alias fallback for both `placeholder_types` and
+    /// `sql_parameter_types`.
+    /// Use `placeholder_types` for placeholder coercion and
+    /// `sql_parameter_types` for warehouse bind parameter hints.
+    #[deprecated(
+        since = "0.0.2",
+        note = "Use placeholder_types and sql_parameter_types instead of parameter_types."
+    )]
     #[serde(default)]
     pub parameter_types: Option<HashMap<String, String>>,
     /// Fetch all result chunks for each query (default true in client)

--- a/src/tests/recipes.rs
+++ b/src/tests/recipes.rs
@@ -1,4 +1,6 @@
 //! Tests for recipe discovery and retrieval tools.
+#![allow(deprecated)]
+
 use super::common::*;
 use std::collections::HashMap;
 

--- a/src/tools/recipes.rs
+++ b/src/tools/recipes.rs
@@ -195,6 +195,7 @@ impl ManifestSearch {
     ///
     /// # Errors
     /// Returns an error if the recipe is not found or SQL files cannot be read.
+    #[allow(deprecated)]
     #[instrument(skip(self, params), fields(tool = "get_recipe", recipe_id = %params.recipe_id))]
     pub async fn get_recipe(&self, params: &GetRecipeParams) -> Result<JsonValue> {
         if params.recipe_id.trim().is_empty() {
@@ -250,6 +251,7 @@ impl ManifestSearch {
     /// # Errors
     /// Returns an error if the recipe cannot be resolved, query execution fails, or query selection is invalid.
     #[allow(clippy::too_many_lines)]
+    #[allow(deprecated)]
     #[instrument(
         skip(self, params),
         fields(
@@ -1932,6 +1934,7 @@ fn select_recipe_queries<'a>(
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
 

--- a/tests/duckdb_provider.rs
+++ b/tests/duckdb_provider.rs
@@ -436,6 +436,7 @@ fn execute_sql_tool_path_blocks_dangerous_statements_before_provider_access() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn run_recipe_executes_with_duckdb_provider_without_special_handling() {
     let _env_lock = lock_env();
     let (_temp_dir, db_path) = create_fixture_database();


### PR DESCRIPTION
## Summary
- added Rust deprecation metadata for recipe alias fields:
  - `GetRecipeParams::parameter_types`
  - `RunRecipeParams::parameter_types`
- strengthened inline migration messaging to canonical fields:
  - `placeholder_types`
  - `sql_parameter_types`
- updated API docs wording to make canonical replacements explicit
- scoped `#[allow(deprecated)]` only where alias compatibility is intentionally exercised (recipe handlers/tests)

## Validation
- `cargo fmt --all`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked`

Closes #25