### PR TITLE
docs(cli): document command mode, envelopes, and exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Dedicated CLI command docs covering command tree, one-shot usage patterns,
+  `tool call` parameter input modes, and server-compatibility behavior when no
+  subcommand is passed.
+
+### Changed
+
+- README and Quick Start now explicitly document CLI command mode alongside MCP
+  server mode, including examples for `health check` and `tool call`.
+- API response format docs now include CLI JSON envelope structure and CLI exit
+  code mapping.
+
 ## [0.0.2] - 2026-02-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -171,6 +171,39 @@ For recurring analysis topics, start with:
 - **[Analysis Recipes](docs/features/recipes.md)** to design deterministic workflows.
 - `search_recipes` -> `get_recipe` -> `run_recipe` in your MCP client.
 
+## CLI Command Mode
+
+`dbt-nova` supports one-shot CLI commands in addition to server mode.
+
+- No subcommand: starts MCP server (backward compatible)
+- Subcommand: executes command and exits
+
+Examples:
+
+```bash
+# Start MCP server (default behavior)
+dbt-nova
+
+# Equivalent explicit server command
+dbt-nova server start
+
+# One-shot health diagnostics with JSON envelope output
+dbt-nova health check --manifest-path /path/to/manifest.json --json
+
+# One-shot tool invocation
+dbt-nova tool call search \
+  --params-json '{"query":"orders","limit":5}' \
+  --manifest-path /path/to/manifest.json
+```
+
+`tool call` parameter input modes:
+
+- `--params-json`
+- `--params-file`
+- `--params-stdin`
+
+`reload_manifest` is intentionally unavailable in CLI mode; call it through an MCP client against a running server.
+
 ## Release Size
 
 Default builds include embeddings + S3/GCS SDK support. For a minimal binary, build
@@ -189,6 +222,7 @@ via build locks and in‑use locks; pruning removes only inactive instances.
 - [Docs Index](docs/index.md)
 - [Installation](docs/getting-started/installation.md)
 - [Quick Start](docs/getting-started/quickstart.md)
+- [CLI Commands](docs/getting-started/cli.md)
 - [MCP Client Configs](docs/getting-started/mcp-clients.md)
 - [Configuration Reference](docs/configuration/reference.md)
 - [Manifest Sources](docs/configuration/manifest-sources.md)

--- a/docs/api/response-format.md
+++ b/docs/api/response-format.md
@@ -132,3 +132,32 @@ structured `details` object on `INVALID_PARAMS` responses:
   }
 }
 ```
+
+## CLI JSON Envelope
+
+CLI subcommands that use `--json` return a command envelope (different from MCP tool envelopes):
+
+```json
+{
+  "command": "manifest load",
+  "status": "success",
+  "data": { "...": "..." },
+  "meta": {
+    "elapsed_ms": 123,
+    "timestamp_ms": 1772304167827,
+    "version": "0.0.2"
+  },
+  "error": null
+}
+```
+
+For errors, `status` is `"error"` and `error` contains the standard Nova error object.
+
+### CLI Exit Codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | Invalid parameters |
+| `2` | Manifest/index lifecycle failures |
+| `3` | Runtime/provider/server failures |

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -1,0 +1,130 @@
+# CLI Commands
+
+Use `dbt-nova` in two modes:
+
+- No subcommand: start MCP server (backward compatible behavior)
+- Subcommand: run one-shot CLI commands and exit
+
+## Command Tree
+
+```text
+dbt-nova
+├── server start
+├── manifest load [--manifest-path|--manifest-uri] [--storage-instance-id] [--cleanup-storage-on-start] [--read-only] [--json]
+├── manifest reload
+├── tool call <tool_name> [--params-json|--params-file|--params-stdin] [--manifest-path|--manifest-uri] [--storage-instance-id] [--cleanup-storage-on-start] [--read-only] [--json]
+├── config show [--defaults] [--json]
+├── config validate [--json]
+├── storage inspect [--storage-instance-id] [--json]
+├── storage prune [--max-keep] [--max-bytes] [--storage-instance-id] [--json]
+├── storage cleanup [--storage-instance-id] [--json]
+└── health check [--manifest-path|--manifest-uri] [--json]
+```
+
+## No-Arg Compatibility
+
+`dbt-nova` with no subcommand still starts the MCP server:
+
+```bash
+dbt-nova
+```
+
+Equivalent explicit form:
+
+```bash
+dbt-nova server start
+```
+
+## Common Examples
+
+### Build and inspect manifest indexes
+
+```bash
+dbt-nova manifest load \
+  --manifest-path /path/to/target/manifest.json
+```
+
+### One-shot tool execution
+
+```bash
+dbt-nova tool call search \
+  --params-json '{"query":"orders","limit":5}' \
+  --manifest-path /path/to/target/manifest.json
+```
+
+### Health diagnostics
+
+```bash
+dbt-nova health check \
+  --manifest-path /path/to/target/manifest.json \
+  --json
+```
+
+## `tool call` Parameter Input Modes
+
+Exactly one of the following may be used at a time:
+
+- `--params-json '{"query":"orders"}'`
+- `--params-file /path/to/params.json`
+- `--params-stdin` (reads full JSON payload from `stdin`)
+
+Examples:
+
+```bash
+dbt-nova tool call get_entity \
+  --params-file ./params/get_entity.json \
+  --manifest-path /path/to/target/manifest.json
+```
+
+```bash
+echo '{"query":"customers","limit":10}' | \
+  dbt-nova tool call search --params-stdin --manifest-path /path/to/target/manifest.json
+```
+
+## CLI-Mode Limitation: `reload_manifest`
+
+`reload_manifest` is server-only today. In CLI mode:
+
+```bash
+dbt-nova tool call reload_manifest --params-json '{}'
+```
+
+returns `INVALID_PARAMS` with:
+
+`tool 'reload_manifest' is not available in CLI mode`
+
+Use `reload_manifest` through an MCP client connected to a running `dbt-nova` server.
+
+## JSON Envelope and Exit Codes
+
+When `--json` is passed, CLI commands return a standard envelope:
+
+```json
+{
+  "command": "health check",
+  "status": "success",
+  "data": { "status": "ready" },
+  "meta": {
+    "elapsed_ms": 42,
+    "timestamp_ms": 1772304167827,
+    "version": "0.0.2"
+  },
+  "error": null
+}
+```
+
+On errors (`status: "error"`), `error` contains the standard Nova error payload.
+
+Exit codes:
+
+| Code | Category |
+|---|---|
+| `0` | Success |
+| `1` | Invalid params / request shape |
+| `2` | Manifest/index lifecycle errors |
+| `3` | Runtime/server/provider errors |
+
+See also:
+
+- [Response Format](../api/response-format.md)
+- [Error Codes](../api/error-codes.md)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -212,6 +212,7 @@ parameter contracts, and execution order rules.
 
 ## Next Steps
 
+- [CLI Commands](cli.md) - One-shot command groups, JSON mode, and exit codes
 - [Configuration Reference](../configuration/reference.md) - All configuration options
 - [Tools Reference](../api/tools.md) - Available tools and parameters
 - [Personas](../personas/overview.md) - Workflow guides by role

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
   - Getting Started:
     - Installation: getting-started/installation.md
     - Quick Start: getting-started/quickstart.md
+    - CLI Commands: getting-started/cli.md
     - MCP Clients: getting-started/mcp-clients.md
     - Agent Skills: getting-started/skills.md
     - Glossary: getting-started/glossary.md


### PR DESCRIPTION
## Summary
- add a dedicated MkDocs page for CLI command mode (`getting-started/cli.md`)
- document command tree, one-shot examples, `tool call` parameter input modes, and CLI limitations
- document CLI JSON envelope and exit code mapping
- update README + Quick Start links and add changelog notes under `Unreleased`

## Details
- Added `docs/getting-started/cli.md` with:
  - command tree for `server`, `manifest`, `tool`, `config`, `storage`, `health`
  - no-arg compatibility note (`dbt-nova` still starts server)
  - `tool call` parameter source modes (`--params-json`, `--params-file`, `--params-stdin`)
  - `reload_manifest` CLI-mode limitation note
  - CLI JSON envelope structure and exit code table
- Updated nav in `mkdocs.yml` to include **Getting Started → CLI Commands**
- Updated `README.md` with a CLI command mode section and examples
- Updated `docs/api/response-format.md` with CLI-specific envelope + exit code docs
- Updated `docs/getting-started/quickstart.md` next steps to link CLI commands
- Updated `CHANGELOG.md` (`Unreleased`) with documentation/changelog notes for CLI surface

## Validation
- `mkdocs build --strict`

Closes #47
