### PR TITLE
ci: add read-only reusable-asset consumer regression job (#63)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,12 @@ jobs:
           # Force strict read-only semantics: any attempted rebuild write should fail.
           chmod -R a-w "${storage_dir}"
           cp tests/fixtures/nova_manifest.json "${consumer_workspace}/manifest.json"
-          storage_snapshot_before="$(tar -C "${storage_dir}" -cf - . | sha256sum | awk '{print $1}')"
+          storage_snapshot_before="$(
+            (
+              cd "${storage_dir}"
+              find . -type f -print0 | sort -z | xargs -0 sha256sum
+            ) | sha256sum | awk '{print $1}'
+          )"
 
           echo "workspace_dir=${consumer_workspace}" >> "$GITHUB_OUTPUT"
           echo "storage_dir=${storage_dir}" >> "$GITHUB_OUTPUT"
@@ -262,7 +267,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          storage_snapshot_after="$(tar -C "${{ steps.workspace.outputs.storage_dir }}" -cf - . | sha256sum | awk '{print $1}')"
+          storage_snapshot_after="$(
+            (
+              cd "${{ steps.workspace.outputs.storage_dir }}"
+              find . -type f -print0 | sort -z | xargs -0 sha256sum
+            ) | sha256sum | awk '{print $1}'
+          )"
           test "${storage_snapshot_after}" = "${{ steps.workspace.outputs.storage_snapshot_before }}" || {
             echo "storage content changed during read-only consumer execution"
             exit 1


### PR DESCRIPTION
Implements #63 against the reusable-assets feature branch.

## What changed
- Added `reusable-assets-producer` CI job that invokes the reusable workflow (`.github/workflows/nova-build-assets.yml`) using fixture manifest `tests/fixtures/nova_manifest.json`.
- Added `reusable-assets-readonly-consumer` CI job that:
  - downloads produced storage + metadata artifacts,
  - extracts into a fresh temp workspace,
  - enforces strict read-only storage permissions (`chmod -R a-w`),
  - validates metadata contract fields,
  - runs `dbt-nova health check --json` successfully in read-only mode,
  - runs `dbt-nova tool call show_metadata --json` successfully in read-only mode,
  - asserts storage bytes are unchanged before/after consumer calls.

## Why
This creates a concrete CI regression guard for reusable artifact re-consumption and fails if read-only consumer behavior regresses (rebuild attempts / write side effects / unusable artifacts).

## Scope notes
- Target branch: `feature/reusable-nova-assets-epic-57`
- Existing local `Cargo.lock` change was intentionally left out of this PR.
