### PR TITLE
docs: add prebuilt asset producer/consumer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,34 @@ For recurring analysis topics, start with:
 - **[Analysis Recipes](docs/features/recipes.md)** to design deterministic workflows.
 - `search_recipes` -> `get_recipe` -> `run_recipe` in your MCP client.
 
+## Build Once, Reuse Many
+
+For CI/distributed consumers, build Nova assets once and run consumers in
+read-only mode from prebuilt artifacts.
+
+Producer (reusable workflow):
+
+```yaml
+jobs:
+  build_nova_assets:
+    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@v0.0.2
+    with:
+      manifest_path: target/manifest.json
+      storage_instance_id: analytics-prod
+      artifact_name_prefix: analytics-prod
+```
+
+Consumer env (required):
+
+```bash
+export DBT_NOVA_STORAGE_DIR=/path/to/dbt-nova-storage
+export DBT_NOVA_STORAGE_INSTANCE_ID=analytics-prod
+export DBT_NOVA_STORAGE_READ_ONLY=true
+```
+
+Full guide:
+**[Prebuilt Asset Workflow](docs/operations/prebuilt-assets.md)**.
+
 ## CLI Command Mode
 
 `dbt-nova` supports one-shot CLI commands in addition to server mode.
@@ -238,6 +266,7 @@ via build locks and in‑use locks; pruning removes only inactive instances.
 - [Architecture](docs/development/architecture.md)
 - [Operations & Troubleshooting](docs/operations/ops.md)
 - [Performance](docs/operations/performance.md)
+- [Prebuilt Asset Workflow](docs/operations/prebuilt-assets.md)
 - [Security & Limits](docs/operations/security.md)
 - [Testing](docs/operations/testing.md)
 - [Release & Distribution](docs/development/release.md)

--- a/docs/getting-started/mcp-clients.md
+++ b/docs/getting-started/mcp-clients.md
@@ -22,6 +22,39 @@ curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scrip
 
 use that exact same `DBT_NOVA_EMBEDDINGS_CACHE_DIR` path in your MCP client env.
 
+## Prebuilt Read-Only Consumer Setup
+
+If you consume prebuilt Nova storage artifacts (built by the reusable producer
+workflow), set these env vars in your MCP client:
+
+- `DBT_NOVA_STORAGE_DIR` (path to extracted storage artifact root)
+- `DBT_NOVA_STORAGE_INSTANCE_ID` (must match producer workflow input)
+- `DBT_NOVA_STORAGE_READ_ONLY=true`
+
+Recommended with prebuilt artifacts:
+
+- Keep `DBT_MANIFEST_PATH` or `DBT_NOVA_MANIFEST_URI` pointed at the same
+  manifest content used by the producer build.
+- Use the same Nova release on producer and consumer.
+
+Codex TOML example:
+
+```toml
+[mcp_servers.dbt-nova]
+command = "/path/to/dbt-nova"
+startup_timeout_sec = 60
+
+[mcp_servers.dbt-nova.env]
+DBT_MANIFEST_PATH = "/path/to/manifest.json"
+DBT_NOVA_STORAGE_DIR = "/path/to/dbt-nova-storage"
+DBT_NOVA_STORAGE_INSTANCE_ID = "analytics-prod"
+DBT_NOVA_STORAGE_READ_ONLY = "true"
+DBT_NOVA_EMBEDDINGS_CACHE_DIR = "/Users/<you>/.dbt-nova/models"
+```
+
+For producer/consumer workflow details, see:
+- [Prebuilt Asset Workflow](../operations/prebuilt-assets.md)
+
 ## Claude Desktop (`claude_desktop_config.json`)
 
 ```json

--- a/docs/operations/prebuilt-assets.md
+++ b/docs/operations/prebuilt-assets.md
@@ -1,0 +1,119 @@
+# Prebuilt Asset Workflow
+
+Use this workflow when you want to build Nova storage assets once in CI and
+reuse them across jobs/repos in read-only mode.
+
+## What this solves
+
+- Removes repeated index builds on consumer jobs.
+- Makes consumer startup deterministic.
+- Enforces a strict contract (`storage_instance_id` + manifest content hash).
+
+## v1 boundaries
+
+- Producer workflow + GitHub Artifacts are supported.
+- Optional models cache artifact is supported via `include_models_cache`.
+- Consumers are read-only (`DBT_NOVA_STORAGE_READ_ONLY=true`) and do **not**
+  fall back to rebuilding.
+- Optional S3/GCS/DBFS publish targets are out of scope for this version.
+
+## Producer (build once)
+
+Create a workflow in the downstream repo that calls Nova's reusable producer.
+
+```yaml
+name: Build Nova Assets
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_nova_assets:
+    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@v0.0.2
+    with:
+      manifest_path: target/manifest.json
+      storage_instance_id: analytics-prod
+      artifact_name_prefix: analytics-prod
+      retention_days: 14
+      include_models_cache: false
+```
+
+Alternative producer inputs:
+
+- `manifest_uri` (instead of `manifest_path`)
+- `dbt_generate_manifest: true` + `dbt_command` (build manifest in workflow)
+
+The producer emits:
+
+- storage artifact (required)
+- metadata contract artifact (`nova-build-metadata.json`, required)
+- models artifact (optional when `include_models_cache=true`)
+
+## Consumer (reuse in read-only mode)
+
+1. Download and extract the storage artifact.
+2. Use the **same** `storage_instance_id` used by the producer.
+3. Set read-only env vars before starting Nova.
+
+Required env vars:
+
+- `DBT_NOVA_STORAGE_DIR`
+- `DBT_NOVA_STORAGE_INSTANCE_ID`
+- `DBT_NOVA_STORAGE_READ_ONLY=true`
+
+Example (CI shell step):
+
+```bash
+export DBT_NOVA_STORAGE_DIR="$PWD/dbt-nova-storage"
+export DBT_NOVA_STORAGE_INSTANCE_ID="analytics-prod"
+export DBT_NOVA_STORAGE_READ_ONLY="true"
+
+# If your consumer uses a local manifest copy:
+export DBT_MANIFEST_PATH="$PWD/manifest.json"
+
+dbt-nova health check --manifest-path "$DBT_MANIFEST_PATH" --json
+```
+
+If you publish/download the optional models artifact, also set:
+
+- `DBT_NOVA_EMBEDDINGS_CACHE_DIR` to the extracted models directory.
+
+## MCP client env example (read-only consumer)
+
+```json
+{
+  "mcpServers": {
+    "dbt-nova": {
+      "command": "/path/to/dbt-nova",
+      "env": {
+        "DBT_MANIFEST_PATH": "/path/to/manifest.json",
+        "DBT_NOVA_STORAGE_DIR": "/path/to/dbt-nova-storage",
+        "DBT_NOVA_STORAGE_INSTANCE_ID": "analytics-prod",
+        "DBT_NOVA_STORAGE_READ_ONLY": "true"
+      }
+    }
+  }
+}
+```
+
+## Compatibility guidance
+
+- Keep producer and consumer on the same released Nova version when possible.
+- `storage_instance_id` must match between producer and consumer.
+- Consumer manifest content must match the producer-built manifest hash.
+  Path differences are allowed; content differences are not.
+- Metadata contract version must be compatible (`v1` currently).
+
+## Failure modes and fixes
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `Storage is read-only and no reusable index is available` | Missing storage files, mismatched `storage_instance_id`, or manifest content mismatch | Re-download artifacts, verify instance id, verify manifest is identical to producer input |
+| Metadata contract validation fails | Missing/corrupt `nova-build-metadata.json` or unsupported contract version | Re-run producer and consume both storage + metadata artifacts together |
+| Health passes but embeddings are missing | Models artifact was not downloaded in slim/read-only flow | Download models artifact (if produced) and set `DBT_NOVA_EMBEDDINGS_CACHE_DIR` |
+
+## Related docs
+
+- [MCP Client Configs](../getting-started/mcp-clients.md)
+- [Troubleshooting](troubleshooting.md)
+- [CI & Automation](../development/ci.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
     - Nova Meta (Metrics): features/nova-meta-metrics.md
   - Operations:
     - Ops & Troubleshooting: operations/ops.md
+    - Prebuilt Asset Workflow: operations/prebuilt-assets.md
     - Performance: operations/performance.md
     - Limitations: operations/limitations.md
     - Troubleshooting: operations/troubleshooting.md


### PR DESCRIPTION
## Summary\n- add a new operations guide for prebuilt Nova assets (producer + read-only consumer)\n- add a README section for build-once/reuse-many with copy/paste snippets\n- add MCP client setup docs for read-only consumers and link to the operations guide\n- wire the new page into the MkDocs navigation\n\n## Why\nIssue #62 asks for end-to-end docs covering required consumer env vars, compatibility expectations, and troubleshooting for prebuilt asset reuse.\n\n## Validation\n- mkdocs build --strict\n\nRefs #62