### PR TITLE
docs: align README/MkDocs and Unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Dedicated CLI command docs covering command tree, one-shot usage patterns,
-  `tool call` parameter input modes, and server-compatibility behavior when no
-  subcommand is passed.
+- Full one-shot CLI command surface:
+  `config show|validate`, `storage inspect|prune|cleanup`, `health check`,
+  `manifest load|reload`, and `tool call` parity with MCP tools.
+- `tool call reload_manifest` support in CLI mode with one-shot reload output.
+- Reusable asset producer workflow (`.github/workflows/nova-build-assets.yml`)
+  to build and publish storage artifacts + metadata contract from
+  `manifest_path`, `manifest_uri`, or an optional dbt command.
+- CI coverage for reusable producer/consumer contracts, including read-only
+  consumer smoke tests and negative-path contract checks.
+- Optional remote publish targets (`s3`, `gcs`, `dbfs`) for reusable assets,
+  including `publish_dry_run` contract coverage.
 
 ### Changed
 
-- README and Quick Start now explicitly document CLI command mode alongside MCP
-  server mode, including examples for `health check` and `tool call`.
-- API response format docs now include CLI JSON envelope structure and CLI exit
-  code mapping.
+- Read-only index reuse now keys on manifest content hash (path-independent),
+  so prebuilt assets can be reused when manifest content matches even if file
+  paths differ.
+- README and MkDocs now document the prebuilt asset producer/consumer workflow,
+  CLI command mode, and MCP read-only consumer env setup.
+- CI now validates reusable-asset dry-run publish outputs and metadata contract
+  outputs as part of the main PR/push pipeline.
+
+### Fixed
+
+- CLI error handling now emits structured JSON envelopes for command failures
+  and validates/sanitizes manifest source inputs more strictly.
+- CLI safety checks now enforce storage instance-id override semantics and
+  read-only final instance-id validation.
+- CLI manifest-load path now preserves URI refresh/cache semantics.
+- Reusable asset CI checks now ignore transient Tantivy lock/managed files and
+  hash only persisted contract artifacts.
+- Reusable remote publish workflow now emits stable non-null URI outputs and
+  fixes DBFS publish heredoc execution parsing in CI.
 
 ## [0.0.2] - 2026-02-28
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Producer (reusable workflow):
 ```yaml
 jobs:
   build_nova_assets:
-    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@v0.0.2
+    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@master
     with:
       manifest_path: target/manifest.json
       storage_instance_id: analytics-prod
@@ -234,7 +234,14 @@ dbt-nova tool call search \
 - `--params-file`
 - `--params-stdin`
 
-`reload_manifest` is intentionally unavailable in CLI mode; call it through an MCP client against a running server.
+`reload_manifest` is available in CLI mode through `tool call`:
+
+```bash
+dbt-nova tool call reload_manifest \
+  --params-json '{"refresh_secs":300}' \
+  --manifest-path /path/to/manifest.json \
+  --json
+```
 
 ## Release Size
 

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -15,7 +15,22 @@ This repository uses GitHub Actions for CI, releases, and documentation.
   `mkdocs build --strict` (with `docs/requirements.txt`), `scripts/check_advisory_ignores.sh`,
   `scripts/check_dependency_watchlist.sh`,
   `scripts/check_config_reference.sh`, and `cargo deny check advisories licenses sources`
+- **Reusable asset contract checks:** calls the reusable producer workflow in
+  standard mode and dry-run remote publish mode, then validates:
+  - metadata contract artifact correctness
+  - read-only consumer behavior from extracted artifacts
+  - negative-path behavior (missing/mismatched storage + invalid metadata)
 - **Note:** sets `DBT_NOVA_STRICT_SCHEMA=1` so schema parsing failures break the build
+
+### Reusable Nova Asset Workflow
+
+- **File:** `.github/workflows/nova-build-assets.yml`
+- **Use:** reusable workflow invoked by CI and downstream repos
+- **Inputs:** `manifest_path` or `manifest_uri`, `storage_instance_id`,
+  optional dbt manifest generation, optional models artifact, optional remote
+  publish targets (`s3`, `gcs`, `dbfs`) and `publish_dry_run`
+- **Outputs:** manifest metadata (`manifest_hash`, `manifest_version`,
+  `entity_count`), artifact names, and optional published URI JSON objects
 
 ### Prepare Release
 

--- a/docs/operations/prebuilt-assets.md
+++ b/docs/operations/prebuilt-assets.md
@@ -29,7 +29,7 @@ on:
 
 jobs:
   build_nova_assets:
-    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@v0.0.2
+    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@master
     with:
       manifest_path: target/manifest.json
       storage_instance_id: analytics-prod


### PR DESCRIPTION
## Summary
- update CHANGELOG Unreleased section with all major post-v0.0.2 work
- align README CLI guidance with current behavior (tool call reload_manifest supported)
- document reusable asset contract checks in CI docs
- refresh prebuilt-asset workflow examples to current reusable workflow ref

## Validation
- mkdocs build --strict

## Notes
- excludes unrelated local Cargo.lock changes