### PR TITLE
feat(artifacts): integrate file artifact resolver into manifest lifecycle (P3)

### DIFF
--- a/src/manifest/loader.rs
+++ b/src/manifest/loader.rs
@@ -17,6 +17,7 @@ use crate::config::DbtNovaConfig;
 use crate::error::{DbtNovaError, Result};
 use crate::manifest::entity::Entity;
 use crate::manifest::lineage_sql::{extract_ref_calls, find_sql_aliases, sql_for_matching};
+use crate::manifest::prebuilt_assets_resolver::materialize_file_artifacts;
 use crate::manifest::rkyv_indexes;
 use crate::manifest::rkyv_types::{PersistedIndexes, RKYV_SCHEMA_VERSION};
 use crate::manifest::search::{EntityCache, InUseLocks, ManifestSearch, compile_layer_rules};
@@ -449,6 +450,17 @@ impl ManifestSearch {
             &instance_root,
             config.storage_build_lock_wait_secs,
         )?);
+
+        if config.remote_artifact_mode_enabled() {
+            let materialization = materialize_file_artifacts(&config, &signature.content_hash)?;
+            if let Some(outcome) = materialization {
+                info!(
+                    storage_materialized = outcome.storage_materialized,
+                    models_materialized = outcome.models_materialized,
+                    "evaluated remote artifact materialization"
+                );
+            }
+        }
 
         let mut entities: Option<EntityStore> = None;
         let mut reuse_store = false;

--- a/src/manifest/prebuilt_assets_resolver.rs
+++ b/src/manifest/prebuilt_assets_resolver.rs
@@ -73,6 +73,7 @@ pub fn materialize_file_artifacts(
         config.artifact_fetch_policy,
         storage_present,
     )?;
+    ensure_materialization_allowed(config, should_materialize_storage, "storage artifacts")?;
     let storage_materialized = if should_materialize_storage {
         extract_archive_atomically(&storage_archive_path, &storage_target)?;
         true
@@ -89,6 +90,7 @@ pub fn materialize_file_artifacts(
             config.artifact_fetch_policy,
             models_present,
         )?;
+        ensure_materialization_allowed(config, should_materialize_models, "models artifacts")?;
         if should_materialize_models {
             extract_archive_atomically(&models_archive_path, &models_target)?;
             models_materialized = true;
@@ -109,6 +111,19 @@ pub fn materialize_file_artifacts(
         storage_materialized,
         models_materialized,
     }))
+}
+
+fn ensure_materialization_allowed(
+    config: &DbtNovaConfig,
+    should_materialize: bool,
+    label: &str,
+) -> Result<()> {
+    if config.storage_read_only && should_materialize {
+        return Err(DbtNovaError::ServerError(format!(
+            "Storage is read-only; cannot materialize {label} (set DBT_NOVA_ARTIFACT_FETCH_POLICY=never and pre-materialize assets)"
+        )));
+    }
+    Ok(())
 }
 
 fn should_materialize(label: &str, policy: ArtifactFetchPolicy, is_present: bool) -> Result<bool> {

--- a/tests/prebuilt_artifact_lifecycle.rs
+++ b/tests/prebuilt_artifact_lifecycle.rs
@@ -1,0 +1,252 @@
+//! Integration tests for remote prebuilt artifact lifecycle wiring.
+use std::fs::{self, File};
+use std::io::ErrorKind;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex};
+
+use dbt_nova::ManifestSearch;
+use dbt_nova::config::{ArtifactFetchPolicy, DbtNovaConfig, SearchConfig};
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use tar::Builder;
+use tempfile::TempDir;
+
+static LIFECYCLE_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+fn fixture_manifest_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("nova_manifest.json")
+}
+
+fn build_config(storage_dir: &Path) -> DbtNovaConfig {
+    let search = SearchConfig {
+        enable_vector_search: false,
+        enable_sparse_search: false,
+        enable_reranker: false,
+        embedding_cache_dir: storage_dir
+            .join("models-cache")
+            .to_string_lossy()
+            .to_string(),
+        ..SearchConfig::default()
+    };
+
+    DbtNovaConfig {
+        manifest_path: fixture_manifest_path().to_string_lossy().to_string(),
+        storage_dir: storage_dir.to_string_lossy().to_string(),
+        storage_instance_id: "analytics-prod".to_string(),
+        search,
+        ..DbtNovaConfig::default()
+    }
+}
+
+fn write_file(path: &Path, content: &[u8]) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent dirs");
+    }
+    let mut file = File::create(path).expect("create file");
+    file.write_all(content).expect("write file");
+}
+
+fn create_archive_from_dir(source_dir: &Path, archive_path: &Path) {
+    let file = File::create(archive_path).expect("create archive file");
+    let encoder = GzEncoder::new(file, Compression::default());
+    let mut tar = Builder::new(encoder);
+    let root_name = source_dir
+        .file_name()
+        .expect("source root name")
+        .to_string_lossy()
+        .to_string();
+    tar.append_dir(&root_name, source_dir)
+        .expect("append root dir to archive");
+
+    let mut stack = vec![(source_dir.to_path_buf(), PathBuf::from(&root_name))];
+    while let Some((current_abs, current_rel)) = stack.pop() {
+        let entries = match fs::read_dir(&current_abs) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == ErrorKind::NotFound => continue,
+            Err(error) => panic!("read archive source dir {}: {error}", current_abs.display()),
+        };
+
+        for entry_result in entries {
+            let entry = match entry_result {
+                Ok(entry) => entry,
+                Err(error) if error.kind() == ErrorKind::NotFound => continue,
+                Err(error) => panic!("read archive entry in {}: {error}", current_abs.display()),
+            };
+
+            let file_name = entry.file_name();
+            if file_name.to_string_lossy().starts_with(".tmp") {
+                continue;
+            }
+
+            let entry_abs = entry.path();
+            let entry_rel = current_rel.join(file_name);
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(error) if error.kind() == ErrorKind::NotFound => continue,
+                Err(error) => panic!("read entry type {}: {error}", entry_abs.display()),
+            };
+
+            if file_type.is_dir() {
+                tar.append_dir(&entry_rel, &entry_abs)
+                    .unwrap_or_else(|error| panic!("append dir {}: {error}", entry_abs.display()));
+                stack.push((entry_abs, entry_rel));
+                continue;
+            }
+
+            if file_type.is_file() {
+                let mut input = match File::open(&entry_abs) {
+                    Ok(file) => file,
+                    Err(error) if error.kind() == ErrorKind::NotFound => continue,
+                    Err(error) => panic!("open entry file {}: {error}", entry_abs.display()),
+                };
+                tar.append_file(&entry_rel, &mut input)
+                    .unwrap_or_else(|error| panic!("append file {}: {error}", entry_abs.display()));
+            }
+        }
+    }
+    let encoder = tar.into_inner().expect("finish tar stream");
+    encoder.finish().expect("finish gzip stream");
+}
+
+fn to_file_uri(path: &Path) -> String {
+    format!("file://{}", path.display())
+}
+
+fn manifest_content_hash() -> String {
+    let raw = fs::read(fixture_manifest_path()).expect("read fixture manifest");
+    blake3::hash(&raw).to_hex().to_string()
+}
+
+fn build_source_storage(workspace: &TempDir) -> PathBuf {
+    let source_storage_dir = workspace.path().join("source-storage");
+    let source_config = build_config(&source_storage_dir);
+    let source_storage_root = source_config
+        .storage_root_dir()
+        .expect("source storage root should resolve");
+    let load = ManifestSearch::new(source_config).expect("source manifest build should succeed");
+    assert!(load.search.entity_count() > 0);
+    assert!(
+        source_storage_root.is_dir(),
+        "source storage root should exist"
+    );
+    source_storage_root
+}
+
+fn write_metadata(path: &Path, manifest_hash: &str, include_models_artifact: bool) {
+    let artifact_name_models = if include_models_artifact {
+        "models-asset"
+    } else {
+        ""
+    };
+    let payload = serde_json::json!({
+        "contract_version": "v1",
+        "manifest_hash": manifest_hash,
+        "manifest_version": "v12",
+        "entity_count": 1,
+        "storage_instance_id": "analytics-prod",
+        "dbt_nova_version": "0.0.2",
+        "build_timestamp": "2026-03-02T00:00:00Z",
+        "artifact_name_storage": "storage-asset",
+        "artifact_name_models": artifact_name_models
+    });
+    write_file(
+        path,
+        serde_json::to_string(&payload)
+            .expect("serialize metadata")
+            .as_bytes(),
+    );
+}
+
+#[test]
+fn manifest_load_materializes_file_artifacts_before_reuse() {
+    let _guard = LIFECYCLE_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let workspace = TempDir::new().expect("tempdir");
+    let source_storage_dir = build_source_storage(&workspace);
+
+    let storage_archive_path = workspace.path().join("storage.tar.gz");
+    create_archive_from_dir(&source_storage_dir, &storage_archive_path);
+
+    let metadata_path = workspace.path().join("nova-build-metadata.json");
+    write_metadata(&metadata_path, &manifest_content_hash(), false);
+
+    let destination_storage_dir = workspace.path().join("destination-storage");
+    let mut destination_config = build_config(&destination_storage_dir);
+    destination_config.storage_artifact_uri = to_file_uri(&storage_archive_path);
+    destination_config.metadata_artifact_uri = to_file_uri(&metadata_path);
+    destination_config.artifact_fetch_policy = ArtifactFetchPolicy::Always;
+
+    let load =
+        ManifestSearch::new(destination_config).expect("artifact-backed load should succeed");
+    assert!(
+        load.entity_store_reused,
+        "storage artifact should be reused"
+    );
+    assert!(load.tantivy_reused, "tantivy index should be reused");
+    assert!(load.indexes_reused, "indexes cache should be reused");
+    assert!(load.search.entity_count() > 0);
+}
+
+#[test]
+fn manifest_load_rejects_artifact_metadata_hash_mismatch() {
+    let _guard = LIFECYCLE_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let workspace = TempDir::new().expect("tempdir");
+    let source_storage_dir = build_source_storage(&workspace);
+
+    let storage_archive_path = workspace.path().join("storage.tar.gz");
+    create_archive_from_dir(&source_storage_dir, &storage_archive_path);
+
+    let metadata_path = workspace.path().join("nova-build-metadata.json");
+    write_metadata(&metadata_path, "mismatched-hash", false);
+
+    let destination_storage_dir = workspace.path().join("destination-storage");
+    let mut destination_config = build_config(&destination_storage_dir);
+    destination_config.storage_artifact_uri = to_file_uri(&storage_archive_path);
+    destination_config.metadata_artifact_uri = to_file_uri(&metadata_path);
+    destination_config.artifact_fetch_policy = ArtifactFetchPolicy::Always;
+
+    let error = match ManifestSearch::new(destination_config) {
+        Ok(_) => panic!("hash mismatch should fail"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("manifest hash mismatch"));
+}
+
+#[test]
+fn manifest_load_read_only_rejects_artifact_materialization_when_missing() {
+    let _guard = LIFECYCLE_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let workspace = TempDir::new().expect("tempdir");
+    let source_storage_dir = build_source_storage(&workspace);
+
+    let storage_archive_path = workspace.path().join("storage.tar.gz");
+    create_archive_from_dir(&source_storage_dir, &storage_archive_path);
+
+    let metadata_path = workspace.path().join("nova-build-metadata.json");
+    write_metadata(&metadata_path, &manifest_content_hash(), false);
+
+    let destination_storage_dir = workspace.path().join("destination-storage");
+    let mut destination_config = build_config(&destination_storage_dir);
+    destination_config.storage_artifact_uri = to_file_uri(&storage_archive_path);
+    destination_config.metadata_artifact_uri = to_file_uri(&metadata_path);
+    destination_config.artifact_fetch_policy = ArtifactFetchPolicy::IfMissing;
+    destination_config.storage_read_only = true;
+
+    let error = match ManifestSearch::new(destination_config) {
+        Ok(_) => panic!("read-only mode should reject required materialization"),
+        Err(error) => error,
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("Storage is read-only; cannot materialize storage artifacts")
+    );
+}


### PR DESCRIPTION
## Summary
- wire prebuilt artifact materialization into `ManifestSearch::new` before store/index reuse decisions
- enforce read-only safety in resolver: when materialization is required and `storage_read_only=true`, fail with actionable error
- add integration lifecycle coverage for remote artifact mode:
  - happy path: file-backed artifacts materialize and are reused
  - mismatch: metadata manifest hash mismatch fails fast
  - read-only: required materialization is rejected

## Validation
- `cargo fmt`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked`

Part of #74 (P3).