### PR TITLE
feat(artifacts): support remote prebuilt artifact providers (P4)

### DIFF
--- a/src/manifest/prebuilt_assets_resolver.rs
+++ b/src/manifest/prebuilt_assets_resolver.rs
@@ -46,30 +46,12 @@ pub fn materialize_file_artifacts(
     let metadata = PrebuiltAssetsMetadata::from_json_str(&metadata_raw)?;
     validate_metadata_against_runtime(&metadata, config, expected_manifest_hash)?;
 
-    let storage_archive_path = resolve_artifact_uri_to_local(
-        config,
-        "DBT_NOVA_STORAGE_ARTIFACT_URI",
-        &config.storage_artifact_uri,
-    )?;
-    ensure_regular_file("DBT_NOVA_STORAGE_ARTIFACT_URI", &storage_archive_path)?;
-
-    let models_archive_path = if config.models_artifact_uri.trim().is_empty() {
-        None
-    } else {
-        let path = resolve_artifact_uri_to_local(
-            config,
-            "DBT_NOVA_MODELS_ARTIFACT_URI",
-            &config.models_artifact_uri,
-        )?;
-        ensure_regular_file("DBT_NOVA_MODELS_ARTIFACT_URI", &path)?;
-        if !metadata.has_models_artifact() {
-            return Err(DbtNovaError::InvalidParams(
-                "DBT_NOVA_MODELS_ARTIFACT_URI is set but metadata contract has no artifact_name_models"
-                    .to_string(),
-            ));
-        }
-        Some(path)
-    };
+    if !config.models_artifact_uri.trim().is_empty() && !metadata.has_models_artifact() {
+        return Err(DbtNovaError::InvalidParams(
+            "DBT_NOVA_MODELS_ARTIFACT_URI is set but metadata contract has no artifact_name_models"
+                .to_string(),
+        ));
+    }
 
     let storage_target = config.storage_root_dir()?;
     let storage_present = storage_instance_present(config)?;
@@ -80,6 +62,12 @@ pub fn materialize_file_artifacts(
     )?;
     ensure_materialization_allowed(config, should_materialize_storage, "storage artifacts")?;
     let storage_materialized = if should_materialize_storage {
+        let storage_archive_path = resolve_artifact_uri_to_local(
+            config,
+            "DBT_NOVA_STORAGE_ARTIFACT_URI",
+            &config.storage_artifact_uri,
+        )?;
+        ensure_regular_file("DBT_NOVA_STORAGE_ARTIFACT_URI", &storage_archive_path)?;
         extract_archive_atomically(&storage_archive_path, &storage_target)?;
         true
     } else {
@@ -87,7 +75,7 @@ pub fn materialize_file_artifacts(
     };
 
     let mut models_materialized = false;
-    if let Some(models_archive_path) = models_archive_path {
+    if !config.models_artifact_uri.trim().is_empty() {
         let models_target = PathBuf::from(&config.search.embedding_cache_dir);
         let models_present = directory_has_files(&models_target)?;
         let should_materialize_models = should_materialize(
@@ -97,6 +85,12 @@ pub fn materialize_file_artifacts(
         )?;
         ensure_materialization_allowed(config, should_materialize_models, "models artifacts")?;
         if should_materialize_models {
+            let models_archive_path = resolve_artifact_uri_to_local(
+                config,
+                "DBT_NOVA_MODELS_ARTIFACT_URI",
+                &config.models_artifact_uri,
+            )?;
+            ensure_regular_file("DBT_NOVA_MODELS_ARTIFACT_URI", &models_archive_path)?;
             extract_archive_atomically(&models_archive_path, &models_target)?;
             models_materialized = true;
         }

--- a/tests/prebuilt_assets_resolver.rs
+++ b/tests/prebuilt_assets_resolver.rs
@@ -299,6 +299,97 @@ fn materialize_file_artifacts_if_missing_skips_existing_storage() {
 }
 
 #[test]
+fn materialize_file_artifacts_if_missing_skips_remote_storage_fetch_when_local_present() {
+    let workspace = TempDir::new().expect("tempdir");
+    let mut config = setup_config(&workspace);
+
+    let existing_version_dir = PathBuf::from(&config.storage_dir)
+        .join("instances")
+        .join("analytics-prod")
+        .join("versions")
+        .join("existing");
+    write_file(&existing_version_dir.join("entities.bin"), b"entities");
+
+    let metadata_path = workspace.path().join("nova-build-metadata.json");
+    write_file(
+        &metadata_path,
+        br#"{
+  "contract_version":"v1",
+  "manifest_hash":"manifest-hash",
+  "manifest_version":"v12",
+  "entity_count":42,
+  "storage_instance_id":"analytics-prod",
+  "dbt_nova_version":"0.0.2",
+  "build_timestamp":"2026-03-02T00:00:00Z",
+  "artifact_name_storage":"storage-asset",
+  "artifact_name_models":""
+}"#,
+    );
+
+    config.storage_artifact_uri = "s3://bucket/storage.tar.gz".to_string();
+    config.metadata_artifact_uri = to_file_uri(&metadata_path);
+    config.artifact_fetch_policy = ArtifactFetchPolicy::IfMissing;
+
+    let outcome = materialize_file_artifacts(&config, "manifest-hash")
+        .expect("existing local storage should avoid remote storage fetch")
+        .expect("artifact mode enabled");
+    assert!(!outcome.storage_materialized);
+}
+
+#[test]
+fn materialize_file_artifacts_if_missing_skips_remote_models_fetch_when_local_present() {
+    let workspace = TempDir::new().expect("tempdir");
+    let mut config = setup_config(&workspace);
+    config.search.embedding_cache_dir = workspace
+        .path()
+        .join("embedding-cache")
+        .to_string_lossy()
+        .to_string();
+
+    let existing_version_dir = PathBuf::from(&config.storage_dir)
+        .join("instances")
+        .join("analytics-prod")
+        .join("versions")
+        .join("existing");
+    write_file(&existing_version_dir.join("entities.bin"), b"entities");
+
+    let existing_model = PathBuf::from(&config.search.embedding_cache_dir)
+        .join("models--intfloat--multilingual-e5-base")
+        .join("snapshots")
+        .join("main")
+        .join("onnx")
+        .join("model.onnx");
+    write_file(&existing_model, b"model");
+
+    let metadata_path = workspace.path().join("nova-build-metadata.json");
+    write_file(
+        &metadata_path,
+        br#"{
+  "contract_version":"v1",
+  "manifest_hash":"manifest-hash",
+  "manifest_version":"v12",
+  "entity_count":42,
+  "storage_instance_id":"analytics-prod",
+  "dbt_nova_version":"0.0.2",
+  "build_timestamp":"2026-03-02T00:00:00Z",
+  "artifact_name_storage":"storage-asset",
+  "artifact_name_models":"models-asset"
+}"#,
+    );
+
+    config.storage_artifact_uri = "s3://bucket/storage.tar.gz".to_string();
+    config.metadata_artifact_uri = to_file_uri(&metadata_path);
+    config.models_artifact_uri = "gs://bucket/models.tar.gz".to_string();
+    config.artifact_fetch_policy = ArtifactFetchPolicy::IfMissing;
+
+    let outcome = materialize_file_artifacts(&config, "manifest-hash")
+        .expect("existing local models should avoid remote models fetch")
+        .expect("artifact mode enabled");
+    assert!(!outcome.storage_materialized);
+    assert!(!outcome.models_materialized);
+}
+
+#[test]
 fn materialize_file_artifacts_supports_remote_cached_uris_when_policy_never() {
     let workspace = TempDir::new().expect("tempdir");
     let mut config = setup_config(&workspace);


### PR DESCRIPTION
## Summary
Implements P4 of issue #74 by extending prebuilt artifact materialization from file-only to provider-backed URI resolution.

## What changed
- Extended `materialize_file_artifacts` to resolve artifact URIs via existing manifest source providers (`file`, `http(s)`, `s3`, `gs`, `dbfs`).
- Added remote artifact cache resolution in `DBT_NOVA_ARTIFACTS_CACHE_DIR` keyed by URI hash.
- Enforced fetch policy behavior in resolver:
  - `never`: require cached artifact, do not fetch
  - `if_missing`: use cached artifact when present, fetch only when missing
  - `always`: clear cached artifact + metadata and refetch
- Kept metadata contract validation and storage/models materialization lifecycle unchanged.

## Tests
- Updated and expanded `tests/prebuilt_assets_resolver.rs`:
  - replaced old P2 non-file rejection expectation
  - added cached remote URI path under `never`
  - added cached DBFS path under `if_missing` without Databricks auth
  - added DBFS auth-required failure when cache is missing
- Verified lifecycle tests still pass (`tests/prebuilt_artifact_lifecycle.rs`).

## Validation run
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --test prebuilt_assets_resolver --test prebuilt_artifact_lifecycle`
- `cargo test --test manifest_source`
- `cargo test --no-default-features --test prebuilt_assets_resolver`

Part of #74
