### PR TITLE
feat(artifacts): add consumer observability, health fields, and docs

### DIFF
--- a/docs/getting-started/mcp-clients.md
+++ b/docs/getting-started/mcp-clients.md
@@ -27,15 +27,20 @@ use that exact same `DBT_NOVA_EMBEDDINGS_CACHE_DIR` path in your MCP client env.
 If you consume prebuilt Nova storage artifacts (built by the reusable producer
 workflow), set these env vars in your MCP client:
 
-- `DBT_NOVA_STORAGE_DIR` (path to extracted storage artifact root)
+- `DBT_NOVA_STORAGE_DIR` (local Nova storage root)
 - `DBT_NOVA_STORAGE_INSTANCE_ID` (must match producer workflow input)
 - `DBT_NOVA_STORAGE_READ_ONLY=true`
+- `DBT_NOVA_STORAGE_ARTIFACT_URI`
+- `DBT_NOVA_METADATA_ARTIFACT_URI`
+- `DBT_NOVA_MODELS_ARTIFACT_URI` (optional)
+- `DBT_NOVA_ARTIFACT_FETCH_POLICY` (recommended: `if_missing`)
 
 Recommended with prebuilt artifacts:
 
 - Keep `DBT_MANIFEST_PATH` or `DBT_NOVA_MANIFEST_URI` pointed at the same
   manifest content used by the producer build.
 - Use the same Nova release on producer and consumer.
+- Keep artifact URIs stable and allow Nova to cache them locally.
 
 Codex TOML example:
 
@@ -46,9 +51,13 @@ startup_timeout_sec = 60
 
 [mcp_servers.dbt-nova.env]
 DBT_MANIFEST_PATH = "/path/to/manifest.json"
-DBT_NOVA_STORAGE_DIR = "/path/to/dbt-nova-storage"
+DBT_NOVA_STORAGE_DIR = "/path/to/.dbt-nova"
 DBT_NOVA_STORAGE_INSTANCE_ID = "analytics-prod"
 DBT_NOVA_STORAGE_READ_ONLY = "true"
+DBT_NOVA_STORAGE_ARTIFACT_URI = "s3://my-bucket/nova-assets/prod/storage-asset.tar.gz"
+DBT_NOVA_METADATA_ARTIFACT_URI = "s3://my-bucket/nova-assets/prod/nova-build-metadata.json"
+DBT_NOVA_MODELS_ARTIFACT_URI = "s3://my-bucket/nova-assets/prod/models-asset.tar.gz"
+DBT_NOVA_ARTIFACT_FETCH_POLICY = "if_missing"
 DBT_NOVA_EMBEDDINGS_CACHE_DIR = "/Users/<you>/.dbt-nova/models"
 ```
 

--- a/docs/operations/ops.md
+++ b/docs/operations/ops.md
@@ -59,6 +59,17 @@ Cache stats:
 
 - `manifest_cache.hits`: number of times a cached manifest was used
 - `manifest_cache.misses`: number of times a remote fetch was attempted
+
+Artifact consumer stats (when prebuilt artifact mode is configured):
+
+- `artifact_consumer.enabled`: whether remote artifact mode is active
+- `artifact_consumer.fetch_policy`: `if_missing` | `always` | `never`
+- `artifact_consumer.metadata_validated`: metadata contract was parsed and validated
+- `artifact_consumer.storage_materialized`: storage archive was materialized in this load cycle
+- `artifact_consumer.models_materialized`: models archive was materialized in this load cycle
+- `artifact_consumer.last_evaluated_at_ms`: timestamp for last artifact-consumer decision
+- `artifact_consumer.last_materialized_at_ms`: timestamp for last successful materialization (if any)
+
 ## Rate limiting
 
 Nova applies tool rate limits by default (`search=60,execute_sql=20,default=120` per

--- a/docs/operations/prebuilt-assets.md
+++ b/docs/operations/prebuilt-assets.md
@@ -87,34 +87,100 @@ Producer outputs include:
 
 ## Consumer (reuse in read-only mode)
 
-1. Download and extract the storage artifact.
-2. Use the **same** `storage_instance_id` used by the producer.
-3. Set read-only env vars before starting Nova.
+Nova now supports **native remote artifact consumption**. Manual download/extract is optional.
 
-Required env vars:
+### Option A (recommended): native remote artifact mode
+
+Set these env vars:
+
+- `DBT_NOVA_STORAGE_READ_ONLY=true`
+- `DBT_NOVA_STORAGE_INSTANCE_ID` (must match producer)
+- `DBT_NOVA_STORAGE_ARTIFACT_URI`
+- `DBT_NOVA_METADATA_ARTIFACT_URI`
+- `DBT_NOVA_MODELS_ARTIFACT_URI` (optional)
+- `DBT_NOVA_ARTIFACT_FETCH_POLICY=if_missing|always|never` (default `if_missing`)
+
+Optional:
+
+- `DBT_NOVA_ARTIFACTS_CACHE_DIR` (defaults to `<storage_root>/artifacts`)
+- `DBT_NOVA_ARTIFACT_TIMEOUT_SECS` (default `300`)
+- `DBT_NOVA_ARTIFACT_ALLOW_HTTP=true` (only for non-TLS artifact URIs; not recommended)
+
+Local shell example:
+
+```bash
+export DBT_MANIFEST_PATH="$PWD/manifest.json"
+export DBT_NOVA_STORAGE_DIR="$PWD/.dbt-nova"
+export DBT_NOVA_STORAGE_INSTANCE_ID="analytics-prod"
+export DBT_NOVA_STORAGE_READ_ONLY="true"
+export DBT_NOVA_STORAGE_ARTIFACT_URI="s3://my-bucket/nova-assets/prod/storage-asset.tar.gz"
+export DBT_NOVA_METADATA_ARTIFACT_URI="s3://my-bucket/nova-assets/prod/nova-build-metadata.json"
+export DBT_NOVA_MODELS_ARTIFACT_URI="s3://my-bucket/nova-assets/prod/models-asset.tar.gz"
+export DBT_NOVA_ARTIFACT_FETCH_POLICY="if_missing"
+
+dbt-nova health check --manifest-path "$DBT_MANIFEST_PATH" --json
+```
+
+CI shell example:
+
+```bash
+export DBT_MANIFEST_PATH="$GITHUB_WORKSPACE/target/manifest.json"
+export DBT_NOVA_STORAGE_DIR="$RUNNER_TEMP/.dbt-nova"
+export DBT_NOVA_STORAGE_INSTANCE_ID="analytics-prod"
+export DBT_NOVA_STORAGE_READ_ONLY="true"
+export DBT_NOVA_STORAGE_ARTIFACT_URI="$STORAGE_URI"
+export DBT_NOVA_METADATA_ARTIFACT_URI="$METADATA_URI"
+export DBT_NOVA_MODELS_ARTIFACT_URI="$MODELS_URI" # optional
+export DBT_NOVA_ARTIFACT_FETCH_POLICY="if_missing"
+
+dbt-nova health check --manifest-path "$DBT_MANIFEST_PATH" --json
+```
+
+MCP client env example:
+
+```json
+{
+  "mcpServers": {
+    "dbt-nova": {
+      "command": "/path/to/dbt-nova",
+      "env": {
+        "DBT_MANIFEST_PATH": "/path/to/manifest.json",
+        "DBT_NOVA_STORAGE_DIR": "/path/to/.dbt-nova",
+        "DBT_NOVA_STORAGE_INSTANCE_ID": "analytics-prod",
+        "DBT_NOVA_STORAGE_READ_ONLY": "true",
+        "DBT_NOVA_STORAGE_ARTIFACT_URI": "s3://my-bucket/nova-assets/prod/storage-asset.tar.gz",
+        "DBT_NOVA_METADATA_ARTIFACT_URI": "s3://my-bucket/nova-assets/prod/nova-build-metadata.json",
+        "DBT_NOVA_MODELS_ARTIFACT_URI": "s3://my-bucket/nova-assets/prod/models-asset.tar.gz",
+        "DBT_NOVA_ARTIFACT_FETCH_POLICY": "if_missing"
+      }
+    }
+  }
+}
+```
+
+Use `health` to verify runtime decisions:
+
+- `artifact_consumer.enabled`
+- `artifact_consumer.fetch_policy`
+- `artifact_consumer.metadata_validated`
+- `artifact_consumer.storage_materialized`
+- `artifact_consumer.models_materialized`
+- `artifact_consumer.last_evaluated_at_ms`
+- `artifact_consumer.last_materialized_at_ms`
+
+### Option B: manual extraction fallback
+
+If you prefer manual extraction, keep using pre-extracted artifacts with:
 
 - `DBT_NOVA_STORAGE_DIR`
 - `DBT_NOVA_STORAGE_INSTANCE_ID`
 - `DBT_NOVA_STORAGE_READ_ONLY=true`
 
-Example (CI shell step):
-
-```bash
-export DBT_NOVA_STORAGE_DIR="$PWD/dbt-nova-storage"
-export DBT_NOVA_STORAGE_INSTANCE_ID="analytics-prod"
-export DBT_NOVA_STORAGE_READ_ONLY="true"
-
-# If your consumer uses a local manifest copy:
-export DBT_MANIFEST_PATH="$PWD/manifest.json"
-
-dbt-nova health check --manifest-path "$DBT_MANIFEST_PATH" --json
-```
-
-If you publish/download the optional models artifact, also set:
+If you extracted models separately, set:
 
 - `DBT_NOVA_EMBEDDINGS_CACHE_DIR` to the extracted models directory.
 
-### Consumer retrieval examples
+### Manual retrieval examples
 
 S3:
 
@@ -135,24 +201,6 @@ DBFS (Databricks CLI):
 ```bash
 databricks fs cp dbfs:/mnt/nova-assets/prod/<artifact_name_storage>.tar.gz .
 tar -xzf <artifact_name_storage>.tar.gz
-```
-
-## MCP client env example (read-only consumer)
-
-```json
-{
-  "mcpServers": {
-    "dbt-nova": {
-      "command": "/path/to/dbt-nova",
-      "env": {
-        "DBT_MANIFEST_PATH": "/path/to/manifest.json",
-        "DBT_NOVA_STORAGE_DIR": "/path/to/dbt-nova-storage",
-        "DBT_NOVA_STORAGE_INSTANCE_ID": "analytics-prod",
-        "DBT_NOVA_STORAGE_READ_ONLY": "true"
-      }
-    }
-  }
-}
 ```
 
 ## Compatibility guidance

--- a/src/manifest/loader.rs
+++ b/src/manifest/loader.rs
@@ -25,7 +25,7 @@ use crate::manifest::source::{ManifestSignature, manifest_signature, resolve_man
 use crate::manifest::store::{EntityStore, EntityStoreBuilder};
 use crate::manifest::tantivy_search::TantivySearcher;
 use crate::manifest::vector_search::{Reranker, SparseSearcher, VectorSearcher};
-use crate::utils::{CircuitBreaker, IN_USE_LOCK_FILENAME, prune_dirs, unique_suffix};
+use crate::utils::{CircuitBreaker, IN_USE_LOCK_FILENAME, prune_dirs, sanitize_uri, unique_suffix};
 use tracing::{info, instrument, warn};
 
 struct ManifestAccumulator {
@@ -451,9 +451,22 @@ impl ManifestSearch {
             config.storage_build_lock_wait_secs,
         )?);
 
+        let mut artifact_consumer_status = build_artifact_consumer_status(&config, None, None);
         if config.remote_artifact_mode_enabled() {
+            let evaluated_at_ms = current_time_ms();
             let materialization = materialize_file_artifacts(&config, &signature.content_hash)?;
             if let Some(outcome) = materialization {
+                let last_materialized_at_ms =
+                    if outcome.storage_materialized || outcome.models_materialized {
+                        Some(evaluated_at_ms)
+                    } else {
+                        None
+                    };
+                artifact_consumer_status = build_artifact_consumer_status(
+                    &config,
+                    Some(&outcome),
+                    Some((evaluated_at_ms, last_materialized_at_ms)),
+                );
                 info!(
                     storage_materialized = outcome.storage_materialized,
                     models_materialized = outcome.models_materialized,
@@ -853,6 +866,7 @@ impl ManifestSearch {
                 column_lineage_aliases,
                 manifest_metadata: accumulator.manifest_metadata,
                 manifest_health,
+                artifact_consumer: artifact_consumer_status,
                 entity_counts: accumulator.entity_counts,
                 entity_cache,
                 lineage_cache,
@@ -1030,6 +1044,45 @@ fn build_manifest_health(
         "malformed_ref_candidate_sample": malformed_ref_candidate_sample,
         "ref_calls_without_dependencies_sample": ref_without_dependencies_sample
     }))
+}
+
+fn artifact_fetch_policy_label(policy: crate::config::ArtifactFetchPolicy) -> &'static str {
+    match policy {
+        crate::config::ArtifactFetchPolicy::IfMissing => "if_missing",
+        crate::config::ArtifactFetchPolicy::Always => "always",
+        crate::config::ArtifactFetchPolicy::Never => "never",
+    }
+}
+
+fn build_artifact_consumer_status(
+    config: &DbtNovaConfig,
+    outcome: Option<&crate::manifest::prebuilt_assets_resolver::FileArtifactMaterialization>,
+    timing: Option<(u128, Option<u128>)>,
+) -> JsonValue {
+    let (last_evaluated_at_ms, last_materialized_at_ms) = timing
+        .map_or((None, None), |(evaluated, materialized)| {
+            (Some(evaluated), materialized)
+        });
+
+    serde_json::json!({
+        "enabled": config.remote_artifact_mode_enabled(),
+        "fetch_policy": artifact_fetch_policy_label(config.artifact_fetch_policy),
+        "allow_http": config.artifact_allow_http,
+        "timeout_secs": config.artifact_timeout_secs,
+        "cache_dir": config
+            .artifacts_cache_dir()
+            .ok()
+            .map(|path| path.to_string_lossy().to_string()),
+        "storage_uri": sanitize_uri(&config.storage_artifact_uri),
+        "metadata_uri": sanitize_uri(&config.metadata_artifact_uri),
+        "models_uri": sanitize_uri(&config.models_artifact_uri),
+        "metadata_validated": outcome.is_some(),
+        "metadata_contract_version": outcome.map(|value| value.metadata.contract_version.clone()),
+        "storage_materialized": outcome.is_some_and(|value| value.storage_materialized),
+        "models_materialized": outcome.is_some_and(|value| value.models_materialized),
+        "last_evaluated_at_ms": last_evaluated_at_ms,
+        "last_materialized_at_ms": last_materialized_at_ms,
+    })
 }
 
 fn has_apparent_malformed_ref(sql: &str) -> bool {

--- a/src/manifest/prebuilt_assets_resolver.rs
+++ b/src/manifest/prebuilt_assets_resolver.rs
@@ -6,7 +6,7 @@ use std::path::{Component, Path, PathBuf};
 use blake3;
 use flate2::read::GzDecoder;
 use tar::Archive;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::config::{ArtifactFetchPolicy, DbtNovaConfig};
 use crate::error::{DbtNovaError, Result};
@@ -120,38 +120,168 @@ struct ArtifactLocator {
 
 fn resolve_artifact_uri_to_local(config: &DbtNovaConfig, name: &str, uri: &str) -> Result<PathBuf> {
     let locator = parse_artifact_locator(name, uri)?;
+    let sanitized_uri = sanitize_uri(&locator.raw);
+    let policy = artifact_fetch_policy_label(config.artifact_fetch_policy);
     if locator.scheme == "file" {
+        info!(
+            artifact = name,
+            scheme = %locator.scheme,
+            fetch_policy = policy,
+            uri = %sanitized_uri,
+            "artifact resolver using local file URI"
+        );
         return resolve_file_artifact_uri(name, &locator.raw);
     }
 
+    resolve_remote_artifact_uri(config, name, &locator, &sanitized_uri, policy)
+}
+
+fn resolve_remote_artifact_uri(
+    config: &DbtNovaConfig,
+    name: &str,
+    locator: &ArtifactLocator,
+    sanitized_uri: &str,
+    policy: &'static str,
+) -> Result<PathBuf> {
     let cache_dir = config.artifacts_cache_dir()?;
     fs::create_dir_all(&cache_dir)?;
     let (cache_path, meta_path) = artifact_cache_paths(&cache_dir, &locator.raw);
 
+    if let Some(path) = maybe_reuse_cached_artifact(
+        config,
+        name,
+        locator,
+        sanitized_uri,
+        policy,
+        &cache_path,
+        &meta_path,
+    )? {
+        return Ok(path);
+    }
+
+    fetch_remote_artifact(
+        config,
+        name,
+        locator,
+        sanitized_uri,
+        policy,
+        cache_dir.as_path(),
+    )
+}
+
+fn maybe_reuse_cached_artifact(
+    config: &DbtNovaConfig,
+    name: &str,
+    locator: &ArtifactLocator,
+    sanitized_uri: &str,
+    policy: &'static str,
+    cache_path: &Path,
+    meta_path: &Path,
+) -> Result<Option<PathBuf>> {
     match config.artifact_fetch_policy {
         ArtifactFetchPolicy::Never => {
             if cache_path.exists() {
-                return Ok(cache_path);
+                info!(
+                    artifact = name,
+                    scheme = %locator.scheme,
+                    fetch_policy = policy,
+                    cache_hit = true,
+                    fetched = false,
+                    uri = %sanitized_uri,
+                    cache_path = %cache_path.display(),
+                    "artifact resolver using cached artifact (policy=never)"
+                );
+                return Ok(Some(cache_path.to_path_buf()));
             }
-            return Err(DbtNovaError::ServerError(format!(
-                "artifact fetch policy is 'never' but no cached copy exists for {name}: {}",
-                sanitize_uri(&locator.raw)
-            )));
+            warn!(
+                artifact = name,
+                scheme = %locator.scheme,
+                fetch_policy = policy,
+                cache_hit = false,
+                fetched = false,
+                uri = %sanitized_uri,
+                "artifact resolver missing cached artifact (policy=never)"
+            );
+            Err(DbtNovaError::ServerError(format!(
+                "artifact fetch policy is 'never' but no cached copy exists for {name}: {sanitized_uri}"
+            )))
         }
         ArtifactFetchPolicy::IfMissing => {
             if cache_path.exists() {
-                return Ok(cache_path);
+                info!(
+                    artifact = name,
+                    scheme = %locator.scheme,
+                    fetch_policy = policy,
+                    cache_hit = true,
+                    fetched = false,
+                    uri = %sanitized_uri,
+                    cache_path = %cache_path.display(),
+                    "artifact resolver using cached artifact (policy=if_missing)"
+                );
+                return Ok(Some(cache_path.to_path_buf()));
             }
+            Ok(None)
         }
         ArtifactFetchPolicy::Always => {
-            let _ = fs::remove_file(&cache_path);
-            let _ = fs::remove_file(&meta_path);
+            info!(
+                artifact = name,
+                scheme = %locator.scheme,
+                fetch_policy = policy,
+                cache_hit = cache_path.exists(),
+                fetched = true,
+                uri = %sanitized_uri,
+                "artifact resolver forcing refetch (policy=always)"
+            );
+            let _ = fs::remove_file(cache_path);
+            let _ = fs::remove_file(meta_path);
+            Ok(None)
         }
     }
+}
 
+fn fetch_remote_artifact(
+    config: &DbtNovaConfig,
+    name: &str,
+    locator: &ArtifactLocator,
+    sanitized_uri: &str,
+    policy: &'static str,
+    cache_dir: &Path,
+) -> Result<PathBuf> {
+    let fetch_config = build_remote_artifact_fetch_config(config, &locator.raw, cache_dir);
+
+    info!(
+        artifact = name,
+        scheme = %locator.scheme,
+        fetch_policy = policy,
+        cache_hit = false,
+        fetched = true,
+        allow_http = config.artifact_allow_http,
+        timeout_secs = config.artifact_timeout_secs,
+        uri = %sanitized_uri,
+        "artifact resolver fetching remote artifact"
+    );
+    let resolution = resolve_manifest(&fetch_config)?;
+    info!(
+        artifact = name,
+        scheme = %locator.scheme,
+        fetch_policy = policy,
+        fetched = !resolution.cached,
+        cached_copy_used = resolution.cached,
+        uri = %sanitized_uri,
+        local_path = %resolution.local_path.display(),
+        "artifact resolver completed remote artifact resolution"
+    );
+    Ok(resolution.local_path)
+}
+
+fn build_remote_artifact_fetch_config(
+    config: &DbtNovaConfig,
+    uri: &str,
+    cache_dir: &Path,
+) -> DbtNovaConfig {
     let mut fetch_config = config.clone();
     fetch_config.manifest_path = String::new();
-    fetch_config.manifest_uri = locator.raw;
+    fetch_config.manifest_uri = uri.to_string();
     fetch_config.manifest_cache_dir = cache_dir.to_string_lossy().to_string();
     // Artifacts can exceed manifest limits; metadata size is enforced after fetch.
     fetch_config.manifest_max_bytes = 0;
@@ -160,9 +290,7 @@ fn resolve_artifact_uri_to_local(config: &DbtNovaConfig, name: &str, uri: &str) 
     fetch_config.manifest_fetch_timeout_secs = config.artifact_timeout_secs;
     fetch_config.manifest_http_timeout_secs = config.artifact_timeout_secs;
     fetch_config.manifest_http_connect_timeout_secs = config.artifact_timeout_secs;
-
-    let resolution = resolve_manifest(&fetch_config)?;
-    Ok(resolution.local_path)
+    fetch_config
 }
 
 fn parse_artifact_locator(name: &str, uri: &str) -> Result<ArtifactLocator> {
@@ -201,6 +329,14 @@ fn artifact_cache_paths(cache_dir: &Path, uri: &str) -> (PathBuf, PathBuf) {
     (cache_path, meta_path)
 }
 
+fn artifact_fetch_policy_label(policy: ArtifactFetchPolicy) -> &'static str {
+    match policy {
+        ArtifactFetchPolicy::IfMissing => "if_missing",
+        ArtifactFetchPolicy::Always => "always",
+        ArtifactFetchPolicy::Never => "never",
+    }
+}
+
 fn ensure_materialization_allowed(
     config: &DbtNovaConfig,
     should_materialize: bool,
@@ -236,18 +372,42 @@ fn validate_metadata_against_runtime(
     expected_manifest_hash: &str,
 ) -> Result<()> {
     let instance_id = config.storage_instance_id.trim();
+    info!(
+        contract_version = %metadata.contract_version,
+        metadata_storage_instance_id = %metadata.storage_instance_id,
+        runtime_storage_instance_id = %instance_id,
+        metadata_manifest_hash = %metadata.manifest_hash,
+        runtime_manifest_hash = %expected_manifest_hash,
+        has_models_artifact = metadata.has_models_artifact(),
+        "validating prebuilt artifact metadata contract"
+    );
     if metadata.storage_instance_id.trim() != instance_id {
+        warn!(
+            metadata_storage_instance_id = %metadata.storage_instance_id,
+            runtime_storage_instance_id = %instance_id,
+            "prebuilt artifact metadata contract validation failed: storage_instance_id mismatch"
+        );
         return Err(DbtNovaError::ServerError(format!(
             "storage_instance_id mismatch: metadata='{}' runtime='{}'",
             metadata.storage_instance_id, instance_id
         )));
     }
     if metadata.manifest_hash.trim() != expected_manifest_hash.trim() {
+        warn!(
+            metadata_manifest_hash = %metadata.manifest_hash,
+            runtime_manifest_hash = %expected_manifest_hash,
+            "prebuilt artifact metadata contract validation failed: manifest hash mismatch"
+        );
         return Err(DbtNovaError::ServerError(format!(
             "manifest hash mismatch: metadata='{}' runtime='{}'",
             metadata.manifest_hash, expected_manifest_hash
         )));
     }
+    info!(
+        storage_instance_id = %metadata.storage_instance_id,
+        manifest_hash = %metadata.manifest_hash,
+        "prebuilt artifact metadata contract validated"
+    );
     Ok(())
 }
 

--- a/src/manifest/search/core.rs
+++ b/src/manifest/search/core.rs
@@ -58,6 +58,7 @@ pub struct ManifestSearch {
     // === Metadata ===
     pub(crate) manifest_metadata: JsonValue,
     pub(crate) manifest_health: JsonValue,
+    pub(crate) artifact_consumer: JsonValue,
 
     // === Stats ===
     pub(crate) entity_counts: HashMap<String, usize>,
@@ -471,6 +472,7 @@ impl ManifestSearch {
                 "loaded_age_ms": loaded_age_ms,
             },
             "manifest_health": self.manifest_health,
+            "artifact_consumer": self.artifact_consumer,
             "manifest_cache": {
                 "hits": manifest_cache_hits,
                 "misses": manifest_cache_misses,

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -988,6 +988,11 @@ mod tests {
         assert!(payload["data"]["tool_metrics"].is_object());
         assert!(payload["data"]["search_concurrency"].is_object());
         assert!(payload["data"]["sql_concurrency"].is_object());
+        assert!(payload["data"]["artifact_consumer"].is_object());
+        assert_eq!(
+            payload["data"]["artifact_consumer"]["enabled"],
+            serde_json::json!(false)
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/prebuilt_artifact_lifecycle.rs
+++ b/tests/prebuilt_artifact_lifecycle.rs
@@ -190,6 +190,32 @@ fn manifest_load_materializes_file_artifacts_before_reuse() {
     assert!(load.tantivy_reused, "tantivy index should be reused");
     assert!(load.indexes_reused, "indexes cache should be reused");
     assert!(load.search.entity_count() > 0);
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let health = runtime.block_on(load.search.health_snapshot());
+    let artifact_consumer = &health["artifact_consumer"];
+    assert_eq!(artifact_consumer["enabled"], serde_json::json!(true));
+    assert_eq!(
+        artifact_consumer["fetch_policy"],
+        serde_json::json!("always")
+    );
+    assert_eq!(
+        artifact_consumer["metadata_validated"],
+        serde_json::json!(true)
+    );
+    assert_eq!(
+        artifact_consumer["storage_materialized"],
+        serde_json::json!(true)
+    );
+    assert!(artifact_consumer["last_evaluated_at_ms"].as_u64().is_some());
+    assert!(
+        artifact_consumer["last_materialized_at_ms"]
+            .as_u64()
+            .is_some()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add artifact consumer telemetry to health payload via artifact_consumer
- add structured logs for artifact fetch-policy decisions and metadata contract validation
- update lifecycle and health tests for new artifact-consumer status fields
- document native remote artifact consumer setup and health diagnostics in ops/getting-started docs

## Validation
- cargo test --test prebuilt_assets_resolver --test prebuilt_artifact_lifecycle --test manifest_source
- cargo test health_reports_ready_status_and_metrics_payload
- cargo clippy --all-targets -- -D warnings
- cargo clippy --all-targets --all-features -- -D warnings

Refs #74