### PR TITLE
docs: align prebuilt artifact consumer setup across README and mkdocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,14 +191,23 @@ jobs:
 Consumer env (required):
 
 ```bash
-export DBT_NOVA_STORAGE_DIR=/path/to/dbt-nova-storage
+# Native remote artifact mode (recommended)
+export DBT_NOVA_STORAGE_DIR=/path/to/.dbt-nova
 export DBT_NOVA_STORAGE_INSTANCE_ID=analytics-prod
 export DBT_NOVA_STORAGE_READ_ONLY=true
+export DBT_NOVA_STORAGE_ARTIFACT_URI="$STORAGE_URI"
+export DBT_NOVA_METADATA_ARTIFACT_URI="$METADATA_URI"
+export DBT_NOVA_MODELS_ARTIFACT_URI="$MODELS_URI"   # optional
+export DBT_NOVA_ARTIFACT_FETCH_POLICY=if_missing
 ```
 
 Optional: publish artifacts directly to cloud targets from the reusable
 workflow with `publish_targets` plus per-target prefixes
 (`publish_s3_prefix`, `publish_gcs_prefix`, `publish_dbfs_prefix`).
+
+Legacy fallback: if you manually extract artifacts locally, you can omit
+`DBT_NOVA_*_ARTIFACT_URI` vars and keep only
+`DBT_NOVA_STORAGE_DIR` + `DBT_NOVA_STORAGE_INSTANCE_ID` + `DBT_NOVA_STORAGE_READ_ONLY=true`.
 
 Full guide:
 **[Prebuilt Asset Workflow](docs/operations/prebuilt-assets.md)**.

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -503,6 +503,10 @@ Readiness and status (`loading`/`ready`/`refreshing`/`failed`) plus retriever in
 Includes `manifest_health` diagnostics for lineage metadata quality, including
 models with `ref(...)` calls but no manifest dependencies.
 
+Also includes `artifact_consumer` status when prebuilt artifact consumer mode is
+configured (`enabled`, `fetch_policy`, validation/materialization flags, and
+last evaluation/materialization timestamps).
+
 `status=failed` indicates manifest initialization is not yet available. Keep the source
 valid and allow the configured refresh interval to recover automatically.
 

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -19,6 +19,7 @@ This repository uses GitHub Actions for CI, releases, and documentation.
   standard mode and dry-run remote publish mode, then validates:
   - metadata contract artifact correctness
   - read-only consumer behavior from extracted artifacts
+  - native remote consumer behavior via `file://` artifact URIs
   - negative-path behavior (missing/mismatched storage + invalid metadata)
 - **Note:** sets `DBT_NOVA_STRICT_SCHEMA=1` so schema parsing failures break the build
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -81,6 +81,20 @@ Use the same `DBT_NOVA_EMBEDDINGS_CACHE_DIR` value in your MCP client config.
 !!! tip "Pro Tip"
     Add this to your shell profile (`~/.bashrc`, `~/.zshrc`) to persist across sessions.
 
+### Optional: Consume Prebuilt Artifacts (Read-Only)
+
+If you build assets in CI with the reusable workflow, consumers can start
+without manual extraction by setting:
+
+- `DBT_NOVA_STORAGE_INSTANCE_ID`
+- `DBT_NOVA_STORAGE_READ_ONLY=true`
+- `DBT_NOVA_STORAGE_ARTIFACT_URI`
+- `DBT_NOVA_METADATA_ARTIFACT_URI`
+- optional `DBT_NOVA_MODELS_ARTIFACT_URI`
+- optional `DBT_NOVA_ARTIFACT_FETCH_POLICY` (recommended `if_missing`)
+
+See [Prebuilt Asset Workflow](../operations/prebuilt-assets.md) for full producer/consumer setup.
+
 ### Optional: Remote Manifests
 
 dbt-nova supports loading manifests from remote sources:

--- a/docs/operations/prebuilt-assets.md
+++ b/docs/operations/prebuilt-assets.md
@@ -217,7 +217,7 @@ tar -xzf <artifact_name_storage>.tar.gz
 | --- | --- | --- |
 | `Storage is read-only and no reusable index is available` | Missing storage files, mismatched `storage_instance_id`, or manifest content mismatch | Re-download artifacts, verify instance id, verify manifest is identical to producer input |
 | Metadata contract validation fails | Missing/corrupt `nova-build-metadata.json` or unsupported contract version | Re-run producer and consume both storage + metadata artifacts together |
-| Health passes but embeddings are missing | Models artifact was not downloaded in slim/read-only flow | Download models artifact (if produced) and set `DBT_NOVA_EMBEDDINGS_CACHE_DIR` |
+| Health passes but embeddings are missing | Models artifact not provided in consumer setup | Native mode: set `DBT_NOVA_MODELS_ARTIFACT_URI` to the producer models artifact URI. Manual mode: extract models artifact and set `DBT_NOVA_EMBEDDINGS_CACHE_DIR`. |
 
 ## Related docs
 


### PR DESCRIPTION
## Summary
- update README consumer section to recommend native remote artifact mode (`DBT_NOVA_STORAGE_ARTIFACT_URI` + `DBT_NOVA_METADATA_ARTIFACT_URI`) with manual extraction as fallback
- document `artifact_consumer` fields under `health` in tools reference
- update CI docs to include native remote consumer smoke coverage
- add quickstart note for prebuilt read-only consumer env setup
- clarify troubleshooting for missing embeddings in native vs manual artifact flows

## Validation
- mkdocs build --strict