### PR TITLE
Issue #83: harden workflow shell boundaries and release tag auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,13 +164,18 @@ jobs:
 
       - name: Assert dry-run publish outputs are populated per target
         shell: bash
+        env:
+          PUBLISHED_TARGETS: ${{ needs.reusable-assets-remote-publish-dryrun.outputs.published_targets }}
+          STORAGE_URIS: ${{ needs.reusable-assets-remote-publish-dryrun.outputs.published_storage_uris }}
+          METADATA_URIS: ${{ needs.reusable-assets-remote-publish-dryrun.outputs.published_metadata_uris }}
+          MODELS_URIS: ${{ needs.reusable-assets-remote-publish-dryrun.outputs.published_models_uris }}
         run: |
           set -euo pipefail
 
-          published_targets='${{ needs.reusable-assets-remote-publish-dryrun.outputs.published_targets }}'
-          storage_uris='${{ needs.reusable-assets-remote-publish-dryrun.outputs.published_storage_uris }}'
-          metadata_uris='${{ needs.reusable-assets-remote-publish-dryrun.outputs.published_metadata_uris }}'
-          models_uris='${{ needs.reusable-assets-remote-publish-dryrun.outputs.published_models_uris }}'
+          published_targets="${PUBLISHED_TARGETS}"
+          storage_uris="${STORAGE_URIS}"
+          metadata_uris="${METADATA_URIS}"
+          models_uris="${MODELS_URIS}"
 
           echo "published_targets=${published_targets}"
           echo "published_storage_uris=${storage_uris}"
@@ -223,12 +228,17 @@ jobs:
 
       - name: Validate default remote publish outputs
         shell: bash
+        env:
+          PUBLISHED_TARGETS: ${{ needs.reusable-assets-producer.outputs.published_targets }}
+          PUBLISHED_STORAGE_URIS: ${{ needs.reusable-assets-producer.outputs.published_storage_uris }}
+          PUBLISHED_METADATA_URIS: ${{ needs.reusable-assets-producer.outputs.published_metadata_uris }}
+          PUBLISHED_MODELS_URIS: ${{ needs.reusable-assets-producer.outputs.published_models_uris }}
         run: |
           set -euo pipefail
-          test -z "${{ needs.reusable-assets-producer.outputs.published_targets }}"
-          test '${{ needs.reusable-assets-producer.outputs.published_storage_uris }}' = '{}'
-          test '${{ needs.reusable-assets-producer.outputs.published_metadata_uris }}' = '{}'
-          test '${{ needs.reusable-assets-producer.outputs.published_models_uris }}' = '{}'
+          test -z "${PUBLISHED_TARGETS}"
+          test "${PUBLISHED_STORAGE_URIS}" = '{}'
+          test "${PUBLISHED_METADATA_URIS}" = '{}'
+          test "${PUBLISHED_MODELS_URIS}" = '{}'
 
       - name: Download storage artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16

--- a/.github/workflows/nova-build-assets.yml
+++ b/.github/workflows/nova-build-assets.yml
@@ -23,7 +23,7 @@ on:
         type: boolean
         default: false
       dbt_command:
-        description: "dbt command to generate the manifest when enabled"
+        description: "Trusted shell command executed via bash -lc when dbt_generate_manifest=true"
         required: false
         type: string
         default: ""
@@ -120,7 +120,7 @@ on:
         type: boolean
         default: false
       dbt_command:
-        description: "dbt command to generate the manifest when enabled"
+        description: "Trusted shell command executed via bash -lc when dbt_generate_manifest=true"
         required: false
         type: string
         default: ""
@@ -444,9 +444,12 @@ jobs:
       - name: Optionally generate manifest via dbt
         if: ${{ inputs.dbt_generate_manifest }}
         shell: bash
+        env:
+          INPUT_DBT_COMMAND: ${{ inputs.dbt_command }}
         run: |
           set -euo pipefail
-          bash -lc "${{ inputs.dbt_command }}"
+          # Trust boundary: callers control INPUT_DBT_COMMAND in their own repository.
+          bash -lc "${INPUT_DBT_COMMAND}"
 
       - name: Run manifest load + smoke validations
         id: collect

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -17,11 +17,6 @@ jobs:
       contents: write
       actions: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-        with:
-          fetch-depth: 0
-
       - name: Verify release tag token
         env:
           RELEASE_TAG_TOKEN: ${{ secrets.RELEASE_TAG_TOKEN }}
@@ -31,6 +26,12 @@ jobs:
             echo "Set it to a PAT/GitHub App token with repo contents:write and actions:write."
             exit 1
           fi
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TAG_TOKEN }}
 
       - name: Configure git identity
         run: |
@@ -64,7 +65,7 @@ jobs:
           fi
 
           git tag -a "${tag}" "${MERGE_SHA}" -m "Release ${tag}"
-          git push "https://x-access-token:${RELEASE_TAG_TOKEN}@github.com/${REPOSITORY}.git" "${tag}"
+          git push origin "${tag}"
 
           api="https://api.github.com/repos/${REPOSITORY}/actions/workflows"
           auth_header="Authorization: Bearer ${RELEASE_TAG_TOKEN}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,13 @@ jobs:
       - name: Resolve tag
         id: resolve_tag
         shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
           release_tag="${GITHUB_REF_NAME}"
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            release_tag="${{ inputs.tag }}"
+            release_tag="${INPUT_TAG}"
           fi
           if ! [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid release tag: ${release_tag}"
@@ -51,8 +53,10 @@ jobs:
           git fetch --tags origin
 
       - name: Ensure tag is on master
+        env:
+          RELEASE_TAG: ${{ steps.resolve_tag.outputs.release_tag }}
         run: |
-          TAG_COMMIT="$(git rev-list -n1 "${{ steps.resolve_tag.outputs.release_tag }}")"
+          TAG_COMMIT="$(git rev-list -n1 "${RELEASE_TAG}")"
           if ! git merge-base --is-ancestor "$TAG_COMMIT" origin/master; then
             echo "Release tags must point to a commit on master."
             exit 1
@@ -98,21 +102,27 @@ jobs:
           cosign-release: "v2.4.1"
 
       - name: Build (release, all features)
-        run: cargo build --locked --release --all-features --target ${{ matrix.target }}
+        env:
+          TARGET_TRIPLE: ${{ matrix.target }}
+        run: cargo build --locked --release --all-features --target "${TARGET_TRIPLE}"
 
       - name: Package
         shell: bash
+        env:
+          TARGET_TRIPLE: ${{ matrix.target }}
+          ASSET_NAME: ${{ matrix.asset }}
+          BIN_EXT: ${{ matrix.ext }}
         run: |
           set -euo pipefail
-          BIN="target/${{ matrix.target }}/release/dbt-nova${{ matrix.ext }}"
+          BIN="target/${TARGET_TRIPLE}/release/dbt-nova${BIN_EXT}"
           mkdir -p dist/slim
           cp "$BIN" dist/slim/
 
-          tar -C dist/slim -czf "dbt-nova-${{ matrix.asset }}.tar.gz" "dbt-nova${{ matrix.ext }}"
-          shasum -a 256 "dbt-nova-${{ matrix.asset }}.tar.gz" > "dbt-nova-${{ matrix.asset }}.sha256"
+          tar -C dist/slim -czf "dbt-nova-${ASSET_NAME}.tar.gz" "dbt-nova${BIN_EXT}"
+          shasum -a 256 "dbt-nova-${ASSET_NAME}.tar.gz" > "dbt-nova-${ASSET_NAME}.sha256"
           for artifact in \
-            "dbt-nova-${{ matrix.asset }}.tar.gz" \
-            "dbt-nova-${{ matrix.asset }}.sha256"
+            "dbt-nova-${ASSET_NAME}.tar.gz" \
+            "dbt-nova-${ASSET_NAME}.sha256"
           do
             COSIGN_EXPERIMENTAL=1 COSIGN_YES=1 cosign sign-blob \
               --output-signature "${artifact}.sig" \

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -30,6 +30,9 @@ This repository uses GitHub Actions for CI, releases, and documentation.
 - **Inputs:** `manifest_path` or `manifest_uri`, `storage_instance_id`,
   optional dbt manifest generation, optional models artifact, optional remote
   publish targets (`s3`, `gcs`, `dbfs`) and `publish_dry_run`
+- **Trust boundary:** when `dbt_generate_manifest=true`, `dbt_command` is
+  executed via `bash -lc` in the caller repository context and must be treated
+  as trusted caller input
 - **Outputs:** manifest metadata (`manifest_hash`, `manifest_version`,
   `entity_count`), artifact names, and optional published URI JSON objects
 

--- a/docs/operations/prebuilt-assets.md
+++ b/docs/operations/prebuilt-assets.md
@@ -44,6 +44,10 @@ Alternative producer inputs:
 - `manifest_uri` (instead of `manifest_path`)
 - `dbt_generate_manifest: true` + `dbt_command` (build manifest in workflow)
 
+`dbt_command` is executed as `bash -lc "<command>"` inside the caller
+repository checkout. Treat it as a trusted command surface and only use this
+mode in repositories/branches where workflow callers are trusted.
+
 The producer emits:
 
 - storage artifact (required)


### PR DESCRIPTION
## Summary
- remove token-in-URL push from `release-tag.yml` and push tags via authenticated `origin`
- route shell-sensitive GitHub expressions through `env:` in `release.yml` and CI assertion steps
- keep manual release tag validation behavior while avoiding direct expression interpolation in shell scripts
- document the reusable workflow trust boundary for `dbt_command` and execute it via env-backed variable

## Validation
- parsed all workflow YAML files with `python + yaml.safe_load`
- verified no remaining `x-access-token:` push pattern
- verified no direct `${{ inputs.tag }}` or `${{ ...published_*... }}` interpolations remain in affected `run:` shells
- `git diff --check` clean

Closes #83