### PR TITLE
Test hardening: consolidate fixtures and add MCP protocol smoke test

### DIFF
--- a/src/tests/context.rs
+++ b/src/tests/context.rs
@@ -34,9 +34,10 @@ async fn test_get_context_basic() {
         .get("data")
         .and_then(|d| d.as_array())
         .expect("search response missing 'data' array");
-    if results.is_empty() {
-        return;
-    }
+    assert!(
+        !results.is_empty(),
+        "expected at least one model search result"
+    );
     let model_id = results[0]
         .get("unique_id")
         .and_then(|v| v.as_str())

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -1,13 +1,12 @@
 //! Integration tests for get_context tool behavior.
 use dbt_nova::params::ContextLimits;
 use dbt_nova::params::{ContextMode, GetContextParams};
-use dbt_nova::{DbtNovaConfig, ManifestSearch};
 use serde_json::json;
 use std::io::Write;
-use std::ops::Deref;
-
 #[path = "support/config.rs"]
 mod support_config;
+#[path = "support/fixtures.rs"]
+mod support_fixtures;
 
 fn create_test_manifest() -> tempfile::NamedTempFile {
     let manifest = json!({
@@ -117,32 +116,9 @@ fn create_test_manifest() -> tempfile::NamedTempFile {
     file
 }
 
-struct TestSearchEnv {
-    searcher: ManifestSearch,
-    _guard: support_config::TestStorageGuard,
-}
-
-impl Deref for TestSearchEnv {
-    type Target = ManifestSearch;
-
-    fn deref(&self) -> &Self::Target {
-        &self.searcher
-    }
-}
-
-fn create_searcher(manifest_file: &tempfile::NamedTempFile) -> TestSearchEnv {
-    let guard = support_config::TestStorageGuard::new();
-    let mut cfg = DbtNovaConfig {
-        manifest_path: manifest_file.path().to_string_lossy().to_string(),
-        search: support_config::test_search_config(),
-        ..Default::default()
-    };
-    support_config::apply_test_storage(&mut cfg, &guard);
-    let searcher = ManifestSearch::new(cfg).unwrap().search;
-    TestSearchEnv {
-        searcher,
-        _guard: guard,
-    }
+fn create_searcher(manifest_file: &tempfile::NamedTempFile) -> support_fixtures::FixtureSearchEnv {
+    support_fixtures::load_manifest_path(manifest_file.path())
+        .expect("failed to build searcher from test manifest")
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/databricks_client.rs
+++ b/tests/databricks_client.rs
@@ -6,19 +6,6 @@ use serde_json::json;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-fn wiremock_enabled() -> bool {
-    // Gate wiremock integration tests to avoid hitting network in default runs.
-    std::env::var("DBT_NOVA_TEST_HTTPMOCK")
-        .ok()
-        .map(|v| {
-            matches!(
-                v.trim().to_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
-            )
-        })
-        .unwrap_or(false)
-}
-
 fn test_config(host: String) -> DatabricksSqlConfig {
     DatabricksSqlConfig {
         host,
@@ -33,13 +20,8 @@ fn test_config(host: String) -> DatabricksSqlConfig {
 }
 
 #[tokio::test]
+#[ignore = "requires local socket bind for wiremock; run explicitly in environments that allow loopback bind"]
 async fn databricks_query_succeeds_inline() {
-    if !wiremock_enabled() {
-        eprintln!(
-            "Skipping databricks_query_succeeds_inline (set DBT_NOVA_TEST_HTTPMOCK=1 to run)"
-        );
-        return;
-    }
     // Mock a one-shot SQL response where results are embedded inline.
     let server = MockServer::start().await;
     Mock::given(method("POST"))
@@ -72,13 +54,8 @@ async fn databricks_query_succeeds_inline() {
 }
 
 #[tokio::test]
+#[ignore = "requires local socket bind for wiremock; run explicitly in environments that allow loopback bind"]
 async fn databricks_query_polls_and_fetches_chunks() {
-    if !wiremock_enabled() {
-        eprintln!(
-            "Skipping databricks_query_polls_and_fetches_chunks (set DBT_NOVA_TEST_HTTPMOCK=1 to run)"
-        );
-        return;
-    }
     // Mock a multi-step query that transitions from RUNNING to SUCCEEDED and fetches chunks.
     let server = MockServer::start().await;
 
@@ -137,13 +114,8 @@ async fn databricks_query_polls_and_fetches_chunks() {
 }
 
 #[tokio::test]
+#[ignore = "requires local socket bind for wiremock; run explicitly in environments that allow loopback bind"]
 async fn databricks_query_failed_returns_error() {
-    if !wiremock_enabled() {
-        eprintln!(
-            "Skipping databricks_query_failed_returns_error (set DBT_NOVA_TEST_HTTPMOCK=1 to run)"
-        );
-        return;
-    }
     // Mock a FAILED status to ensure error surfaces with message context.
     let server = MockServer::start().await;
     Mock::given(method("POST"))

--- a/tests/manifest_source.rs
+++ b/tests/manifest_source.rs
@@ -169,15 +169,9 @@ fn dbfs_manifest_rejects_legacy_token_env() {
 }
 
 #[test]
+#[ignore = "requires local socket bind timing behavior; run explicitly in environments that allow loopback bind"]
 fn http_manifest_times_out_without_cache() {
-    let listener = match TcpListener::bind("127.0.0.1:0") {
-        Ok(listener) => listener,
-        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
-            eprintln!("skipping http timeout test: bind permission denied");
-            return;
-        }
-        Err(err) => panic!("bind: {err}"),
-    };
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral localhost port");
     let addr = listener.local_addr().expect("local addr");
     let handle = thread::spawn(move || {
         if let Ok((stream, _)) = listener.accept() {

--- a/tests/mcp_protocol.rs
+++ b/tests/mcp_protocol.rs
@@ -1,0 +1,152 @@
+//! Protocol-level MCP smoke test over stdio transport.
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{ChildStdout, Command};
+use tokio::time::timeout;
+
+async fn write_json_line(
+    stdin: &mut tokio::process::ChildStdin,
+    payload: &Value,
+) -> Result<(), std::io::Error> {
+    stdin.write_all(payload.to_string().as_bytes()).await?;
+    stdin.write_all(b"\n").await?;
+    stdin.flush().await
+}
+
+async fn read_message(stdout: &mut BufReader<ChildStdout>, max_wait: Duration) -> Value {
+    loop {
+        let mut line = String::new();
+        let read = timeout(max_wait, stdout.read_line(&mut line))
+            .await
+            .expect("timed out waiting for MCP message")
+            .expect("failed reading MCP message");
+        assert!(read > 0, "MCP server closed stdio unexpectedly");
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        return serde_json::from_str(line).expect("MCP server emitted non-JSON output on stdout");
+    }
+}
+
+fn id_matches(message: &Value, expected: i64) -> bool {
+    message
+        .get("id")
+        .and_then(Value::as_i64)
+        .is_some_and(|id| id == expected)
+        || message
+            .get("id")
+            .and_then(Value::as_str)
+            .is_some_and(|id| id == expected.to_string())
+}
+
+async fn read_response(stdout: &mut BufReader<ChildStdout>, request_id: i64) -> Value {
+    loop {
+        let message = read_message(stdout, Duration::from_secs(20)).await;
+        if id_matches(&message, request_id) {
+            return message;
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_round_trip_supports_initialize_and_tools_list() {
+    let binary = PathBuf::from(env!("CARGO_BIN_EXE_dbt-nova"));
+    assert!(
+        binary.exists(),
+        "dbt-nova binary not found at {}",
+        binary.display()
+    );
+    let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("nova_manifest.json");
+    let storage_dir = tempfile::tempdir().expect("tempdir for protocol smoke storage");
+
+    let mut child = Command::new(&binary)
+        .arg("server")
+        .arg("start")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .env("DBT_MANIFEST_PATH", &manifest_path)
+        .env("DBT_NOVA_STORAGE_DIR", storage_dir.path())
+        .env("DBT_NOVA_STORAGE_INSTANCE_ID", "tests-mcp-protocol")
+        .env("DBT_NOVA_SEARCH_ENABLE_VECTOR", "false")
+        .env("DBT_NOVA_SEARCH_ENABLE_SPARSE", "false")
+        .env("DBT_NOVA_SEARCH_ENABLE_RERANKER", "false")
+        .spawn()
+        .expect("failed to spawn dbt-nova MCP server");
+
+    let mut stdin = child.stdin.take().expect("child stdin unavailable");
+    let stdout = child.stdout.take().expect("child stdout unavailable");
+    let mut stdout = BufReader::new(stdout);
+
+    write_json_line(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "dbt-nova-test", "version": "1.0.0"}
+            }
+        }),
+    )
+    .await
+    .expect("failed to write initialize request");
+
+    let initialize_response = read_response(&mut stdout, 1).await;
+    assert!(
+        initialize_response.get("result").is_some(),
+        "initialize response should include result, got: {initialize_response}"
+    );
+
+    write_json_line(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+            "params": {}
+        }),
+    )
+    .await
+    .expect("failed to write initialized notification");
+
+    write_json_line(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }),
+    )
+    .await
+    .expect("failed to write tools/list request");
+
+    let tools_response = read_response(&mut stdout, 2).await;
+    let tools = tools_response
+        .get("result")
+        .and_then(|result| result.get("tools"))
+        .and_then(Value::as_array)
+        .expect("tools/list response missing result.tools");
+    assert!(
+        tools.len() >= 20,
+        "expected >=20 MCP tools, got {}",
+        tools.len()
+    );
+    let has_search = tools
+        .iter()
+        .any(|tool| tool.get("name").and_then(Value::as_str) == Some("search"));
+    assert!(has_search, "tools/list should include search tool");
+
+    child.start_kill().expect("failed to terminate MCP child");
+    let _ = child.wait().await;
+}

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -29,8 +29,9 @@ async fn concurrent_searches() {
     let searcher = Arc::new(searcher);
 
     let mut tasks = JoinSet::new();
+    let total_requests = 50usize;
     // Fire a burst of concurrent searches to catch contention or locking issues.
-    for i in 0..50 {
+    for i in 0..total_requests {
         let searcher = Arc::clone(&searcher);
         tasks.spawn(async move {
             let params = SearchParams {
@@ -53,11 +54,9 @@ async fn concurrent_searches() {
         }
     }
 
-    // Allow a small amount of flakiness under load but require a high success rate.
     assert!(
-        successes >= 45,
-        "At least 90% should succeed under load, got {}",
-        successes
+        successes == total_requests,
+        "expected all concurrent searches to succeed ({total_requests}), got {successes}"
     );
 }
 

--- a/tests/support/fixtures.rs
+++ b/tests/support/fixtures.rs
@@ -1,5 +1,5 @@
 use std::ops::Deref;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use dbt_nova::error::Result;
 use dbt_nova::{DbtNovaConfig, ManifestSearch};
@@ -19,16 +19,23 @@ impl Deref for FixtureSearchEnv {
     }
 }
 
+#[allow(dead_code)]
 pub fn fixture_path(name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures")
         .join(name)
 }
 
+#[allow(dead_code)]
 pub fn load_fixture(name: &str) -> Result<FixtureSearchEnv> {
+    let manifest_path = fixture_path(name);
+    load_manifest_path(&manifest_path)
+}
+
+pub fn load_manifest_path(manifest_path: &Path) -> Result<FixtureSearchEnv> {
     let guard = TestStorageGuard::new();
     let mut cfg = DbtNovaConfig {
-        manifest_path: fixture_path(name).to_string_lossy().to_string(),
+        manifest_path: manifest_path.to_string_lossy().to_string(),
         search: test_search_config(),
         ..Default::default()
     };

--- a/tests/tantivy_search.rs
+++ b/tests/tantivy_search.rs
@@ -4,10 +4,10 @@ use dbt_nova::params::{DetailLevel, SearchParams};
 use dbt_nova::{DbtNovaConfig, ManifestSearch};
 use serde_json::json;
 use std::io::Write;
-use std::ops::Deref;
-
 #[path = "support/config.rs"]
 mod support_config;
+#[path = "support/fixtures.rs"]
+mod support_fixtures;
 
 fn create_test_manifest() -> tempfile::NamedTempFile {
     // Minimal manifest fixture that exercises name/alias/description/tags/SQL/doc searches.
@@ -99,33 +99,10 @@ fn create_test_manifest() -> tempfile::NamedTempFile {
     file
 }
 
-struct TestSearchEnv {
-    searcher: ManifestSearch,
-    _guard: support_config::TestStorageGuard,
-}
-
-impl Deref for TestSearchEnv {
-    type Target = ManifestSearch;
-
-    fn deref(&self) -> &Self::Target {
-        &self.searcher
-    }
-}
-
-fn create_searcher(manifest_file: &tempfile::NamedTempFile) -> TestSearchEnv {
+fn create_searcher(manifest_file: &tempfile::NamedTempFile) -> support_fixtures::FixtureSearchEnv {
     // Use a temporary storage root to avoid polluting local state during tests.
-    let guard = support_config::TestStorageGuard::new();
-    let mut cfg = DbtNovaConfig {
-        manifest_path: manifest_file.path().to_string_lossy().to_string(),
-        search: support_config::test_search_config(),
-        ..Default::default()
-    };
-    support_config::apply_test_storage(&mut cfg, &guard);
-    let searcher = ManifestSearch::new(cfg).unwrap().search;
-    TestSearchEnv {
-        searcher,
-        _guard: guard,
-    }
+    support_fixtures::load_manifest_path(manifest_file.path())
+        .expect("failed to build searcher from test manifest")
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -596,10 +573,6 @@ async fn tantivy_search_with_min_score() {
     support_config::apply_test_storage(&mut cfg, &guard);
     cfg.search.enable_rrf = false;
     let searcher = ManifestSearch::new(cfg).unwrap().search;
-    let searcher = TestSearchEnv {
-        searcher,
-        _guard: guard,
-    };
 
     let params = SearchParams {
         query: "customers".to_string(),
@@ -767,10 +740,6 @@ async fn tantivy_search_suggestions() {
     support_config::apply_test_storage(&mut cfg, &guard);
     cfg.search.enable_ngram = false;
     let searcher = ManifestSearch::new(cfg).unwrap().search;
-    let searcher = TestSearchEnv {
-        searcher,
-        _guard: guard,
-    };
 
     let params = SearchParams {
         query: "custmoers".to_string(),


### PR DESCRIPTION
## Summary
- consolidate duplicated integration-test manifest/search setup into shared tests/support/fixtures.rs helpers
- remove skip-style silent passes in context/stress tests and replace socket-dependent cases with explicit #[ignore] reasons
- add a protocol-level stdio MCP smoke test (initialize + tools/list) to validate end-to-end server wiring

## Validation
- cargo fmt --check
- cargo clippy --locked --all-targets -- -D warnings
- cargo test --locked --test mcp_protocol --test context --test tantivy_search --test stress --test manifest_source --test databricks_client
- cargo test --locked --lib test_get_context_basic

Closes #85
