### PR TITLE
Refactor manifest loader flow and MCP permit handling

### DIFF
--- a/src/manifest/loader.rs
+++ b/src/manifest/loader.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::fs::{self, File};
 use std::io::{BufReader, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::time::{Duration, Instant};
@@ -20,7 +20,9 @@ use crate::manifest::lineage_sql::{extract_ref_calls, find_sql_aliases, sql_for_
 use crate::manifest::prebuilt_assets_resolver::materialize_file_artifacts;
 use crate::manifest::rkyv_indexes;
 use crate::manifest::rkyv_types::{PersistedIndexes, RKYV_SCHEMA_VERSION};
-use crate::manifest::search::{EntityCache, InUseLocks, ManifestSearch, compile_layer_rules};
+use crate::manifest::search::{
+    CompiledLayerRule, EntityCache, InUseLocks, ManifestSearch, compile_layer_rules,
+};
 use crate::manifest::source::{ManifestSignature, manifest_signature, resolve_manifest};
 use crate::manifest::store::{EntityStore, EntityStoreBuilder};
 use crate::manifest::tantivy_search::TantivySearcher;
@@ -392,6 +394,91 @@ pub struct ManifestLoadResult {
     pub elapsed_ms: u128,
 }
 
+struct StoragePreparation {
+    instance_root: PathBuf,
+    versions_root: PathBuf,
+    signature: ManifestSignature,
+    version_id: String,
+    storage_dir: PathBuf,
+    signature_path: PathBuf,
+    build_lock: Option<File>,
+    artifact_consumer_status: JsonValue,
+}
+
+struct ReuseArtifacts {
+    current_version: Option<String>,
+    storage_dir: PathBuf,
+    signature_path: PathBuf,
+    entities: Option<EntityStore>,
+    reuse_store: bool,
+    tantivy_opened: Option<TantivySearcher>,
+}
+
+struct CachedIndexData {
+    by_path_prefix: HashMap<String, Vec<String>>,
+    tests_by_entity: HashMap<String, Vec<String>>,
+    tests_by_column: HashMap<String, Vec<String>>,
+    used_cached_indexes: bool,
+}
+
+struct PathAndTestIndexes {
+    by_path_prefix: HashMap<String, Vec<String>>,
+    tests_by_entity: HashMap<String, Vec<String>>,
+    tests_by_column: HashMap<String, Vec<String>>,
+}
+
+struct SearchBackends {
+    tantivy: TantivySearcher,
+    vector_search: Option<Arc<VectorSearcher>>,
+    sparse_search: Option<Arc<SparseSearcher>>,
+}
+
+struct RuntimeComponents {
+    entity_cache: Option<EntityCache>,
+    lineage_cache: Option<MokaCache<String, Arc<JsonValue>>>,
+    column_lineage_aliases: HashMap<String, HashMap<String, String>>,
+    vector_breaker: CircuitBreaker,
+    sparse_breaker: CircuitBreaker,
+    reranker_breaker: CircuitBreaker,
+    reranker: Option<Arc<Reranker>>,
+    compiled_layer_rules: Vec<CompiledLayerRule>,
+    manifest_health: JsonValue,
+    parent_map: HashMap<String, Vec<String>>,
+    child_map: HashMap<String, Vec<String>>,
+    resource_type_by_id: HashMap<String, String>,
+}
+
+struct PreparedManifestData {
+    accumulator: ManifestAccumulator,
+    entities: EntityStore,
+    cached_indexes: CachedIndexData,
+    indexes_reused: bool,
+}
+
+struct PersistContext<'a> {
+    signature_path: &'a Path,
+    storage_dir: &'a Path,
+    config: &'a DbtNovaConfig,
+    needs_build: bool,
+    indexes_reused: bool,
+    parent_map: &'a HashMap<String, Vec<String>>,
+    child_map: &'a HashMap<String, Vec<String>>,
+    accumulator: &'a ManifestAccumulator,
+    cached_indexes: &'a CachedIndexData,
+}
+
+struct AssembleContext {
+    config: DbtNovaConfig,
+    entities: EntityStore,
+    storage: StoragePreparation,
+    runtime: RuntimeComponents,
+    accumulator: ManifestAccumulator,
+    cached_indexes: CachedIndexData,
+    search_backends: SearchBackends,
+    in_use_locks: InUseLocks,
+    manifest_source_uri: String,
+}
+
 impl ManifestSearch {
     /// Build in-memory search indexes from a dbt manifest file.
     #[instrument(level = "info", skip(config), fields(manifest_path = %config.manifest_path))]
@@ -399,7 +486,6 @@ impl ManifestSearch {
     ///
     /// # Errors
     /// Returns an error if the manifest cannot be loaded, parsed, or indexed.
-    #[allow(clippy::too_many_lines)]
     #[allow(clippy::new_ret_no_self)]
     pub fn new(mut config: DbtNovaConfig) -> Result<ManifestLoadResult> {
         config.ensure_storage_instance_id();
@@ -407,97 +493,191 @@ impl ManifestSearch {
         let load_start = Instant::now();
 
         let manifest_resolution = resolve_manifest(&config)?;
-        let manifest_path = manifest_resolution.local_path;
+        let manifest_path = manifest_resolution.local_path.clone();
         info!(
             source_uri = %manifest_resolution.source_uri,
             cached = manifest_resolution.cached,
             "resolved manifest source"
         );
+        let mut storage = prepare_storage(&config, &manifest_resolution)?;
+        let reused = prepare_reuse_state(&config, &storage)?;
+        fs::create_dir_all(&reused.storage_dir)?;
+        let in_use_locks = acquire_in_use_locks(&storage.instance_root, &reused.storage_dir)?;
+        let needs_build = !reused.reuse_store || reused.tantivy_opened.is_none();
+        let entity_store_reused = reused.reuse_store;
+        ensure_build_reuse_state(&mut storage, &reused, &config, needs_build)?;
+        let tantivy_reused = reused.tantivy_opened.is_some();
+        let prepared_manifest_data = prepare_manifest_data(
+            &reused.storage_dir,
+            &storage.signature,
+            reused.reuse_store,
+            reused.entities,
+            &manifest_path,
+            &manifest_resolution.source_uri,
+            load_start,
+        )?;
+        let PreparedManifestData {
+            accumulator,
+            entities,
+            cached_indexes,
+            indexes_reused,
+        } = prepared_manifest_data;
+        let signature_path = reused.signature_path.clone();
+        let storage_dir = reused.storage_dir.clone();
+        let search_backends = build_search_backends_for_manifest(
+            &mut config,
+            &reused.storage_dir,
+            &storage.signature.content_hash,
+            &accumulator,
+            &entities,
+            reused.tantivy_opened,
+        )?;
+        info!(
+            elapsed_ms = load_start.elapsed().as_millis(),
+            "tantivy index built"
+        );
+        let runtime = build_runtime_components(
+            &config,
+            load_start,
+            &entities,
+            &accumulator,
+            search_backends.vector_search.as_ref(),
+            search_backends.sparse_search.as_ref(),
+        )?;
+        let persist_context = PersistContext {
+            signature_path: &signature_path,
+            storage_dir: &storage_dir,
+            config: &config,
+            needs_build,
+            indexes_reused,
+            parent_map: &runtime.parent_map,
+            child_map: &runtime.child_map,
+            accumulator: &accumulator,
+            cached_indexes: &cached_indexes,
+        };
+        persist_storage_outputs(&mut storage, &persist_context)?;
+        Ok(ManifestLoadResult {
+            search: assemble_manifest_search(AssembleContext {
+                config,
+                entities,
+                storage,
+                runtime,
+                accumulator,
+                cached_indexes,
+                search_backends,
+                in_use_locks,
+                manifest_source_uri: manifest_resolution.source_uri.clone(),
+            }),
+            entity_store_reused,
+            tantivy_reused,
+            indexes_reused,
+            elapsed_ms: load_start.elapsed().as_millis(),
+        })
+    }
+}
 
-        let storage_root = config.storage_instances_dir()?;
-        if config.storage_max_instances > 0 {
-            let exclude = [config.storage_instance_id.as_str()];
-            prune_dirs(
-                &storage_root,
-                config.storage_max_instances,
-                0,
-                config.storage_max_bytes,
-                &exclude,
-            )?;
+fn prepare_storage(
+    config: &DbtNovaConfig,
+    manifest_resolution: &crate::manifest::source::ManifestResolution,
+) -> Result<StoragePreparation> {
+    let storage_root = config.storage_instances_dir()?;
+    if config.storage_max_instances > 0 {
+        let exclude = [config.storage_instance_id.as_str()];
+        prune_dirs(
+            &storage_root,
+            config.storage_max_instances,
+            0,
+            config.storage_max_bytes,
+            &exclude,
+        )?;
+    }
+
+    let instance_root = config.storage_instance_root_dir()?;
+    fs::create_dir_all(&instance_root)?;
+    let versions_root = instance_root.join("versions");
+    fs::create_dir_all(&versions_root)?;
+
+    let signature = manifest_signature(
+        &manifest_resolution.local_path,
+        &manifest_resolution.source_uri,
+    )
+    .map_err(|err| {
+        DbtNovaError::ManifestError(format!(
+            "Failed to read manifest file {}: {err}",
+            manifest_resolution.source_uri
+        ))
+    })?;
+    let mut version_id = signature.content_hash.chars().take(12).collect::<String>();
+    if version_id.is_empty() {
+        version_id = "unknown".to_string();
+    }
+
+    let storage_dir = versions_root.join(&version_id);
+    let signature_path = storage_dir.join(MANIFEST_SIGNATURE_FILENAME);
+    let build_lock = Some(acquire_build_lock(
+        &instance_root,
+        config.storage_build_lock_wait_secs,
+    )?);
+
+    let mut artifact_consumer_status = build_artifact_consumer_status(config, None, None);
+    if config.remote_artifact_mode_enabled() {
+        let evaluated_at_ms = current_time_ms();
+        let materialization = materialize_file_artifacts(config, &signature.content_hash)?;
+        if let Some(outcome) = materialization {
+            let last_materialized_at_ms =
+                if outcome.storage_materialized || outcome.models_materialized {
+                    Some(evaluated_at_ms)
+                } else {
+                    None
+                };
+            artifact_consumer_status = build_artifact_consumer_status(
+                config,
+                Some(&outcome),
+                Some((evaluated_at_ms, last_materialized_at_ms)),
+            );
+            info!(
+                storage_materialized = outcome.storage_materialized,
+                models_materialized = outcome.models_materialized,
+                "evaluated remote artifact materialization"
+            );
         }
+    }
 
-        let instance_root = config.storage_instance_root_dir()?;
-        fs::create_dir_all(&instance_root)?;
-        let versions_root = instance_root.join("versions");
-        fs::create_dir_all(&versions_root)?;
+    Ok(StoragePreparation {
+        instance_root,
+        versions_root,
+        signature,
+        version_id,
+        storage_dir,
+        signature_path,
+        build_lock,
+        artifact_consumer_status,
+    })
+}
 
-        let signature = manifest_signature(&manifest_path, &manifest_resolution.source_uri)
-            .map_err(|err| {
-                DbtNovaError::ManifestError(format!(
-                    "Failed to read manifest file {}: {err}",
-                    manifest_resolution.source_uri
-                ))
-            })?;
-        let mut version_id = signature.content_hash.chars().take(12).collect::<String>();
-        if version_id.is_empty() {
-            version_id = "unknown".to_string();
-        }
+fn load_reusable_artifacts(
+    config: &DbtNovaConfig,
+    instance_root: &Path,
+    versions_root: &Path,
+    signature: &ManifestSignature,
+    initial_storage_dir: &Path,
+    initial_signature_path: &Path,
+) -> Result<ReuseArtifacts> {
+    let current_version = read_current_version(instance_root)?;
+    let mut storage_dir = initial_storage_dir.to_path_buf();
+    let mut signature_path = initial_signature_path.to_path_buf();
+    let mut entities: Option<EntityStore> = None;
+    let mut reuse_store = false;
+    let mut tantivy_opened: Option<TantivySearcher> = None;
 
-        let mut storage_dir = versions_root.join(&version_id);
-        let mut signature_path = storage_dir.join(MANIFEST_SIGNATURE_FILENAME);
-
-        let mut build_lock = Some(acquire_build_lock(
-            &instance_root,
-            config.storage_build_lock_wait_secs,
-        )?);
-
-        let mut artifact_consumer_status = build_artifact_consumer_status(&config, None, None);
-        if config.remote_artifact_mode_enabled() {
-            let evaluated_at_ms = current_time_ms();
-            let materialization = materialize_file_artifacts(&config, &signature.content_hash)?;
-            if let Some(outcome) = materialization {
-                let last_materialized_at_ms =
-                    if outcome.storage_materialized || outcome.models_materialized {
-                        Some(evaluated_at_ms)
-                    } else {
-                        None
-                    };
-                artifact_consumer_status = build_artifact_consumer_status(
-                    &config,
-                    Some(&outcome),
-                    Some((evaluated_at_ms, last_materialized_at_ms)),
-                );
-                info!(
-                    storage_materialized = outcome.storage_materialized,
-                    models_materialized = outcome.models_materialized,
-                    "evaluated remote artifact materialization"
-                );
-            }
-        }
-
-        let mut entities: Option<EntityStore> = None;
-        let mut reuse_store = false;
-        let mut tantivy_opened: Option<TantivySearcher> = None;
-        let current_version = read_current_version(&instance_root)?;
-        if let Some(current) = &current_version {
-            let current_dir = versions_root.join(current);
-            let current_sig_path = current_dir.join(MANIFEST_SIGNATURE_FILENAME);
-            if let Some(existing) = read_manifest_signature(&current_sig_path)?
-                && manifest_signature_matches_for_reuse(&existing, &signature)
-            {
-                storage_dir = current_dir;
-                signature_path = current_sig_path;
-                if let Ok(store) = EntityStore::open(&storage_dir) {
-                    entities = Some(store);
-                    reuse_store = true;
-                }
-                if let Ok(opened) = TantivySearcher::open(&storage_dir, &config.search) {
-                    tantivy_opened = opened;
-                }
-            }
-        } else if let Some(existing) = read_manifest_signature(&signature_path)?
-            && manifest_signature_matches_for_reuse(&existing, &signature)
+    if let Some(current) = &current_version {
+        let current_dir = versions_root.join(current);
+        let current_sig_path = current_dir.join(MANIFEST_SIGNATURE_FILENAME);
+        if let Some(existing) = read_manifest_signature(&current_sig_path)?
+            && manifest_signature_matches_for_reuse(&existing, signature)
         {
+            storage_dir = current_dir;
+            signature_path = current_sig_path;
             if let Ok(store) = EntityStore::open(&storage_dir) {
                 entities = Some(store);
                 reuse_store = true;
@@ -506,390 +686,546 @@ impl ManifestSearch {
                 tantivy_opened = opened;
             }
         }
-
-        let mut exclude_versions = Vec::new();
-        if let Some(current) = &current_version {
-            exclude_versions.push(current.as_str());
+    } else if let Some(existing) = read_manifest_signature(&signature_path)?
+        && manifest_signature_matches_for_reuse(&existing, signature)
+    {
+        if let Ok(store) = EntityStore::open(&storage_dir) {
+            entities = Some(store);
+            reuse_store = true;
         }
-        exclude_versions.push(version_id.as_str());
-        let min_versions = if config.storage_max_instances == 0 {
-            config.storage_min_versions
-        } else {
-            config
-                .storage_min_versions
-                .min(config.storage_max_instances)
-        };
-        prune_dirs(
-            &versions_root,
-            config.storage_max_instances,
-            min_versions,
-            config.storage_max_bytes,
-            &exclude_versions,
-        )?;
-
-        fs::create_dir_all(&storage_dir)?;
-        let in_use_locks = acquire_in_use_locks(&instance_root, &storage_dir)?;
-
-        let needs_build = !reuse_store || tantivy_opened.is_none();
-        if reuse_store {
-            info!("reusing entity store from existing storage");
+        if let Ok(opened) = TantivySearcher::open(&storage_dir, &config.search) {
+            tantivy_opened = opened;
         }
-        if tantivy_opened.is_some() {
-            info!("reusing tantivy index from existing storage");
-        }
-        if config.storage_read_only && needs_build {
-            build_lock.take();
-            return Err(DbtNovaError::ServerError(
-                "Storage is read-only and no reusable index is available".to_string(),
-            ));
-        }
-        let mut accumulator = ManifestAccumulator::new(&storage_dir, !reuse_store)?;
-        let tantivy_reused = tantivy_opened.is_some();
+    }
 
-        let mut by_path_prefix: HashMap<String, Vec<String>> = HashMap::new();
-        let mut tests_by_entity: HashMap<String, Vec<String>> = HashMap::new();
-        let mut tests_by_column: HashMap<String, Vec<String>> = HashMap::new();
-        let mut used_cached_indexes = false;
+    Ok(ReuseArtifacts {
+        current_version,
+        storage_dir,
+        signature_path,
+        entities,
+        reuse_store,
+        tantivy_opened,
+    })
+}
 
-        if let Some(cached) = reuse_store
-            .then(|| rkyv_indexes::try_load_indexes(&storage_dir, &signature.content_hash))
-            .flatten()
-        {
-            info!("loaded indexes from cache");
-            accumulator.parent_map = map_vec_to_set(cached.parent_map);
-            accumulator.child_map = map_vec_to_set(cached.child_map);
-            accumulator.by_resource_type = cached.by_resource_type;
-            accumulator.by_package = cached.by_package;
-            accumulator.by_tag = cached.by_tag;
-            accumulator.by_database_schema = cached.by_database_schema;
-            accumulator.name_to_keys = cached.name_to_keys;
-            accumulator.unique_id_to_resource_type = cached.unique_id_to_resource_type;
-            accumulator.unique_id_to_path = cached.unique_id_to_path;
-            accumulator.unique_id_to_tag_strings = cached.unique_id_to_tag_strings;
-            accumulator.entity_counts = cached.entity_counts;
-            accumulator.manifest_metadata = serde_json::from_str(&cached.manifest_metadata_json)
-                .unwrap_or_else(|err| {
-                    tracing::warn!(
-                        error = %err,
-                        "failed to decode cached manifest metadata; using null"
-                    );
-                    JsonValue::Null
-                });
-            accumulator.seen_unique_ids = accumulator
-                .unique_id_to_resource_type
-                .keys()
-                .cloned()
-                .collect();
-            by_path_prefix = cached.by_path_prefix;
-            tests_by_entity = cached.tests_by_entity;
-            tests_by_column = cached.tests_by_column;
-            used_cached_indexes = true;
-        }
+fn prepare_reuse_state(
+    config: &DbtNovaConfig,
+    storage: &StoragePreparation,
+) -> Result<ReuseArtifacts> {
+    let reused = load_reusable_artifacts(
+        config,
+        &storage.instance_root,
+        &storage.versions_root,
+        &storage.signature,
+        &storage.storage_dir,
+        &storage.signature_path,
+    )?;
+    prune_storage_versions(
+        config,
+        &storage.versions_root,
+        reused.current_version.as_deref(),
+        &storage.version_id,
+    )?;
+    Ok(reused)
+}
 
-        let parse_manifest = !reuse_store || !used_cached_indexes;
-        if parse_manifest {
-            let file = File::open(&manifest_path).map_err(|err| {
-                DbtNovaError::ManifestError(format!(
-                    "Failed to read manifest file {}: {err}",
-                    manifest_resolution.source_uri
-                ))
-            })?;
-            let reader = BufReader::new(file);
+fn prune_storage_versions(
+    config: &DbtNovaConfig,
+    versions_root: &Path,
+    current_version: Option<&str>,
+    version_id: &str,
+) -> Result<()> {
+    let mut exclude_versions = Vec::new();
+    if let Some(current) = current_version {
+        exclude_versions.push(current);
+    }
+    exclude_versions.push(version_id);
+    let min_versions = if config.storage_max_instances == 0 {
+        config.storage_min_versions
+    } else {
+        config
+            .storage_min_versions
+            .min(config.storage_max_instances)
+    };
+    prune_dirs(
+        versions_root,
+        config.storage_max_instances,
+        min_versions,
+        config.storage_max_bytes,
+        &exclude_versions,
+    )?;
+    Ok(())
+}
 
-            let mut deserializer = serde_json::Deserializer::from_reader(reader);
-            ManifestSeed {
-                accumulator: &mut accumulator,
-            }
-            .deserialize(&mut deserializer)
-            .map_err(|err| {
-                DbtNovaError::ManifestError(format!("Failed to parse manifest JSON: {err}"))
-            })?;
-            info!(
-                elapsed_ms = load_start.elapsed().as_millis(),
-                "manifest parsed"
-            );
-        } else {
-            info!("reused entity/index caches; skipped manifest parse");
-        }
+fn load_cached_indexes(
+    storage_dir: &Path,
+    signature: &ManifestSignature,
+    reuse_store: bool,
+    accumulator: &mut ManifestAccumulator,
+) -> CachedIndexData {
+    let mut cached_index_data = CachedIndexData {
+        by_path_prefix: HashMap::new(),
+        tests_by_entity: HashMap::new(),
+        tests_by_column: HashMap::new(),
+        used_cached_indexes: false,
+    };
 
-        let entities = match entities {
-            Some(store) => store,
-            None => accumulator.finish_store()?,
-        };
-        let entity_count = entities.len();
-        info!(
-            elapsed_ms = load_start.elapsed().as_millis(),
-            entity_count, "entity store built"
-        );
+    if let Some(cached) = reuse_store
+        .then(|| rkyv_indexes::try_load_indexes(storage_dir, &signature.content_hash))
+        .flatten()
+    {
+        info!("loaded indexes from cache");
+        accumulator.parent_map = map_vec_to_set(cached.parent_map);
+        accumulator.child_map = map_vec_to_set(cached.child_map);
+        accumulator.by_resource_type = cached.by_resource_type;
+        accumulator.by_package = cached.by_package;
+        accumulator.by_tag = cached.by_tag;
+        accumulator.by_database_schema = cached.by_database_schema;
+        accumulator.name_to_keys = cached.name_to_keys;
+        accumulator.unique_id_to_resource_type = cached.unique_id_to_resource_type;
+        accumulator.unique_id_to_path = cached.unique_id_to_path;
+        accumulator.unique_id_to_tag_strings = cached.unique_id_to_tag_strings;
+        accumulator.entity_counts = cached.entity_counts;
+        accumulator.manifest_metadata = serde_json::from_str(&cached.manifest_metadata_json)
+            .unwrap_or_else(|err| {
+                tracing::warn!(
+                    error = %err,
+                    "failed to decode cached manifest metadata; using null"
+                );
+                JsonValue::Null
+            });
+        accumulator.seen_unique_ids = accumulator
+            .unique_id_to_resource_type
+            .keys()
+            .cloned()
+            .collect();
+        cached_index_data.by_path_prefix = cached.by_path_prefix;
+        cached_index_data.tests_by_entity = cached.tests_by_entity;
+        cached_index_data.tests_by_column = cached.tests_by_column;
+        cached_index_data.used_cached_indexes = true;
+    }
 
-        if !used_cached_indexes {
-            for (unique_id, path) in &accumulator.unique_id_to_path {
-                let parts: Vec<&str> = path.split('/').collect();
-                let mut prefix = String::new();
-                for (i, part) in parts.iter().enumerate() {
-                    if i > 0 {
-                        prefix.push('/');
-                    }
-                    prefix.push_str(part);
-                    by_path_prefix
-                        .entry(prefix.clone())
-                        .or_default()
-                        .push(unique_id.clone());
-                }
-            }
+    cached_index_data
+}
 
-            if let Some(tests) = accumulator.by_resource_type.get("test") {
-                for test_id in tests {
-                    if let Some(test) = entities.get_blocking(test_id)? {
-                        let test_json = test.to_json_value();
-                        if let Some(attached) =
-                            test_json.get("attached_node").and_then(|a| a.as_str())
-                        {
-                            tests_by_entity
-                                .entry(attached.to_string())
-                                .or_default()
-                                .push(test_id.clone());
+fn ensure_build_reuse_state(
+    storage: &mut StoragePreparation,
+    reused: &ReuseArtifacts,
+    config: &DbtNovaConfig,
+    needs_build: bool,
+) -> Result<()> {
+    if reused.reuse_store {
+        info!("reusing entity store from existing storage");
+    }
+    if reused.tantivy_opened.is_some() {
+        info!("reusing tantivy index from existing storage");
+    }
+    if config.storage_read_only && needs_build {
+        storage.build_lock.take();
+        return Err(DbtNovaError::ServerError(
+            "Storage is read-only and no reusable index is available".to_string(),
+        ));
+    }
+    Ok(())
+}
 
-                            if let Some(col) = test_json.get("column_name").and_then(|c| c.as_str())
-                            {
-                                let key = format!("{attached}:{col}");
-                                tests_by_column
-                                    .entry(key)
-                                    .or_default()
-                                    .push(test_id.clone());
-                            }
-                        } else if let Some(attached) = test_json
-                            .get("depends_on")
-                            .and_then(|d| d.get("nodes"))
-                            .and_then(|n| n.as_array())
-                            .and_then(|nodes| nodes.iter().find_map(|n| n.as_str()))
-                        {
-                            tests_by_entity
-                                .entry(attached.to_string())
-                                .or_default()
-                                .push(test_id.clone());
-                        }
+fn prepare_manifest_data(
+    storage_dir: &Path,
+    signature: &ManifestSignature,
+    reuse_store: bool,
+    existing_entities: Option<EntityStore>,
+    manifest_path: &Path,
+    source_uri: &str,
+    load_start: Instant,
+) -> Result<PreparedManifestData> {
+    let mut accumulator = ManifestAccumulator::new(storage_dir, !reuse_store)?;
+    let mut cached_indexes =
+        load_cached_indexes(storage_dir, signature, reuse_store, &mut accumulator);
+    let indexes_reused = cached_indexes.used_cached_indexes;
 
-                        if let Some(deps) = test_json
-                            .get("depends_on")
-                            .and_then(|d| d.get("nodes"))
-                            .and_then(|n| n.as_array())
-                        {
-                            for dep in deps {
-                                if let Some(dep_id) = dep.as_str() {
-                                    let entry =
-                                        tests_by_entity.entry(dep_id.to_string()).or_default();
-                                    if !entry.contains(test_id) {
-                                        entry.push(test_id.clone());
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+    let parse_manifest = !reuse_store || !cached_indexes.used_cached_indexes;
+    if parse_manifest {
+        parse_manifest_file(manifest_path, source_uri, &mut accumulator, load_start)?;
+    } else {
+        info!("reused entity/index caches; skipped manifest parse");
+    }
 
-        config.search.manifest_hash = Some(signature.content_hash.clone());
+    let entities = match existing_entities {
+        Some(store) => store,
+        None => accumulator.finish_store()?,
+    };
+    let entity_count = entities.len();
+    info!(
+        elapsed_ms = load_start.elapsed().as_millis(),
+        entity_count, "entity store built"
+    );
 
-        let (tantivy, vector_search, sparse_search) = std::thread::scope(|scope| -> Result<_> {
-            let mut opened = tantivy_opened;
-            let tantivy_handle = if opened.is_none() {
-                Some(scope.spawn(|| {
-                    TantivySearcher::build(
-                        &storage_dir,
-                        &accumulator.unique_id_to_resource_type,
-                        &accumulator.unique_id_to_path,
-                        &accumulator.unique_id_to_tag_strings,
-                        &config.search,
-                    )
-                }))
-            } else {
-                None
-            };
+    if !cached_indexes.used_cached_indexes {
+        let path_and_test_indexes = build_path_and_test_indexes(&accumulator, &entities)?;
+        cached_indexes.by_path_prefix = path_and_test_indexes.by_path_prefix;
+        cached_indexes.tests_by_entity = path_and_test_indexes.tests_by_entity;
+        cached_indexes.tests_by_column = path_and_test_indexes.tests_by_column;
+    }
 
-            let vector_handle = scope.spawn(|| VectorSearcher::build(&entities, &config.search));
-            let sparse_handle = scope.spawn(|| SparseSearcher::build(&entities, &config.search));
+    Ok(PreparedManifestData {
+        accumulator,
+        entities,
+        cached_indexes,
+        indexes_reused,
+    })
+}
 
-            let tantivy_result = if let Some(opened) = opened.take() {
-                Ok(opened)
-            } else {
-                match tantivy_handle {
-                    Some(handle) => match handle.join() {
-                        Ok(result) => result,
-                        Err(err) => Err(DbtNovaError::ServerError(format!(
-                            "Tantivy index build thread panicked: {}",
-                            panic_message(&err)
-                        ))),
-                    },
-                    None => Err(DbtNovaError::ServerError(
-                        "Tantivy build handle missing".to_string(),
-                    )),
-                }
-            };
+fn parse_manifest_file(
+    manifest_path: &Path,
+    source_uri: &str,
+    accumulator: &mut ManifestAccumulator,
+    load_start: Instant,
+) -> Result<()> {
+    let file = File::open(manifest_path).map_err(|err| {
+        DbtNovaError::ManifestError(format!("Failed to read manifest file {source_uri}: {err}"))
+    })?;
+    let reader = BufReader::new(file);
 
-            let vector_result = match vector_handle.join() {
-                Ok(result) => result,
-                Err(err) => Err(DbtNovaError::ServerError(format!(
-                    "Vector index build thread panicked: {}",
-                    panic_message(&err)
-                ))),
-            };
-
-            let sparse_result = match sparse_handle.join() {
-                Ok(result) => result,
-                Err(err) => Err(DbtNovaError::ServerError(format!(
-                    "Sparse index build thread panicked: {}",
-                    panic_message(&err)
-                ))),
-            };
-
-            let (tantivy, vector_search, sparse_search) =
-                combine_index_build_results(tantivy_result, vector_result, sparse_result)?;
-
-            Ok((
-                tantivy,
-                vector_search.map(Arc::new),
-                sparse_search.map(Arc::new),
-            ))
+    let mut deserializer = serde_json::Deserializer::from_reader(reader);
+    ManifestSeed { accumulator }
+        .deserialize(&mut deserializer)
+        .map_err(|err| {
+            DbtNovaError::ManifestError(format!("Failed to parse manifest JSON: {err}"))
         })?;
+    info!(
+        elapsed_ms = load_start.elapsed().as_millis(),
+        "manifest parsed"
+    );
+    Ok(())
+}
 
-        info!(
-            elapsed_ms = load_start.elapsed().as_millis(),
-            "tantivy index built"
-        );
+fn build_path_and_test_indexes(
+    accumulator: &ManifestAccumulator,
+    entities: &EntityStore,
+) -> Result<PathAndTestIndexes> {
+    let mut by_path_prefix: HashMap<String, Vec<String>> = HashMap::new();
+    for (unique_id, path) in &accumulator.unique_id_to_path {
+        let parts: Vec<&str> = path.split('/').collect();
+        let mut prefix = String::new();
+        for (i, part) in parts.iter().enumerate() {
+            if i > 0 {
+                prefix.push('/');
+            }
+            prefix.push_str(part);
+            by_path_prefix
+                .entry(prefix.clone())
+                .or_default()
+                .push(unique_id.clone());
+        }
+    }
 
-        let entity_cache = EntityCache::build(config.entity_cache_size);
-        let lineage_cache = if config.search.lineage_cache_size > 0 {
-            Some(
-                MokaCache::builder()
-                    .max_capacity(config.search.lineage_cache_size as u64)
-                    .build(),
-            )
+    let mut tests_by_entity: HashMap<String, Vec<String>> = HashMap::new();
+    let mut tests_by_column: HashMap<String, Vec<String>> = HashMap::new();
+    if let Some(tests) = accumulator.by_resource_type.get("test") {
+        for test_id in tests {
+            if let Some(test) = entities.get_blocking(test_id)? {
+                let test_json = test.to_json_value();
+                if let Some(attached) = test_json.get("attached_node").and_then(|a| a.as_str()) {
+                    tests_by_entity
+                        .entry(attached.to_string())
+                        .or_default()
+                        .push(test_id.clone());
+
+                    if let Some(col) = test_json.get("column_name").and_then(|c| c.as_str()) {
+                        let key = format!("{attached}:{col}");
+                        tests_by_column
+                            .entry(key)
+                            .or_default()
+                            .push(test_id.clone());
+                    }
+                } else if let Some(attached) = test_json
+                    .get("depends_on")
+                    .and_then(|d| d.get("nodes"))
+                    .and_then(|n| n.as_array())
+                    .and_then(|nodes| nodes.iter().find_map(|n| n.as_str()))
+                {
+                    tests_by_entity
+                        .entry(attached.to_string())
+                        .or_default()
+                        .push(test_id.clone());
+                }
+
+                if let Some(deps) = test_json
+                    .get("depends_on")
+                    .and_then(|d| d.get("nodes"))
+                    .and_then(|n| n.as_array())
+                {
+                    for dep in deps {
+                        if let Some(dep_id) = dep.as_str() {
+                            let entry = tests_by_entity.entry(dep_id.to_string()).or_default();
+                            if !entry.contains(test_id) {
+                                entry.push(test_id.clone());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(PathAndTestIndexes {
+        by_path_prefix,
+        tests_by_entity,
+        tests_by_column,
+    })
+}
+
+fn build_search_indexes(
+    storage_dir: &Path,
+    accumulator: &ManifestAccumulator,
+    entities: &EntityStore,
+    search_config: &crate::config::SearchConfig,
+    tantivy_opened: Option<TantivySearcher>,
+) -> Result<SearchBackends> {
+    std::thread::scope(|scope| -> Result<_> {
+        let mut opened = tantivy_opened;
+        let tantivy_handle = if opened.is_none() {
+            Some(scope.spawn(|| {
+                TantivySearcher::build(
+                    storage_dir,
+                    &accumulator.unique_id_to_resource_type,
+                    &accumulator.unique_id_to_path,
+                    &accumulator.unique_id_to_tag_strings,
+                    search_config,
+                )
+            }))
         } else {
             None
         };
-        let column_lineage_aliases = build_column_lineage_aliases(&entities, &config)?;
 
-        let breaker_threshold = config.search.search_circuit_failure_threshold;
-        let breaker_duration = Duration::from_secs(config.search.search_circuit_open_seconds);
-        let vector_breaker = CircuitBreaker::new(breaker_threshold, breaker_duration);
-        let sparse_breaker = CircuitBreaker::new(breaker_threshold, breaker_duration);
-        let reranker_breaker = CircuitBreaker::new(breaker_threshold, breaker_duration);
+        let vector_handle = scope.spawn(|| VectorSearcher::build(entities, search_config));
+        let sparse_handle = scope.spawn(|| SparseSearcher::build(entities, search_config));
 
-        if vector_search.is_some() {
-            info!(
-                elapsed_ms = load_start.elapsed().as_millis(),
-                "vector index built"
-            );
-        }
-
-        if sparse_search.is_some() {
-            info!(
-                elapsed_ms = load_start.elapsed().as_millis(),
-                "sparse index built"
-            );
-        }
-
-        let reranker = Reranker::build(&config.search)?.map(Arc::new);
-        let compiled_layer_rules = compile_layer_rules(&config.layer_rules);
-
-        let manifest_health = build_manifest_health(
-            &entities,
-            &accumulator.parent_map,
-            &accumulator.unique_id_to_resource_type,
-        )?;
-        let parent_map = map_set_to_vec(accumulator.parent_map);
-        let child_map = map_set_to_vec(accumulator.child_map);
-        let resource_type_by_id = accumulator.unique_id_to_resource_type.clone();
-
-        let persist_indexes = !used_cached_indexes && !config.storage_read_only;
-
-        if needs_build {
-            write_manifest_signature(&signature_path, &signature)?;
-            write_current_version(&instance_root, &version_id)?;
-        }
-        if persist_indexes {
-            let manifest_metadata_json = serde_json::to_string(&accumulator.manifest_metadata)
-                .unwrap_or_else(|err| {
-                    tracing::warn!(
-                        error = %err,
-                        "failed to encode manifest metadata for cache; using null"
-                    );
-                    "null".to_string()
-                });
-            let indexes = PersistedIndexes {
-                schema_version: RKYV_SCHEMA_VERSION,
-                manifest_hash: signature.content_hash.clone(),
-                parent_map: parent_map.clone(),
-                child_map: child_map.clone(),
-                by_resource_type: accumulator.by_resource_type.clone(),
-                by_package: accumulator.by_package.clone(),
-                by_tag: accumulator.by_tag.clone(),
-                by_database_schema: accumulator.by_database_schema.clone(),
-                name_to_keys: accumulator.name_to_keys.clone(),
-                by_path_prefix: by_path_prefix.clone(),
-                tests_by_entity: tests_by_entity.clone(),
-                tests_by_column: tests_by_column.clone(),
-                unique_id_to_resource_type: accumulator.unique_id_to_resource_type.clone(),
-                unique_id_to_path: accumulator.unique_id_to_path.clone(),
-                unique_id_to_tag_strings: accumulator.unique_id_to_tag_strings.clone(),
-                entity_counts: accumulator.entity_counts.clone(),
-                manifest_metadata_json,
-            };
-            if let Err(err) = rkyv_indexes::save_indexes(&indexes, &storage_dir) {
-                tracing::warn!(error = %err, "failed to save index cache");
+        let tantivy_result = if let Some(opened) = opened.take() {
+            Ok(opened)
+        } else {
+            match tantivy_handle {
+                Some(handle) => match handle.join() {
+                    Ok(result) => result,
+                    Err(err) => Err(DbtNovaError::ServerError(format!(
+                        "Tantivy index build thread panicked: {}",
+                        panic_message(&err)
+                    ))),
+                },
+                None => Err(DbtNovaError::ServerError(
+                    "Tantivy build handle missing".to_string(),
+                )),
             }
-        }
-        build_lock.take();
+        };
 
-        Ok(ManifestLoadResult {
-            search: Self {
-                config,
-                entities: Arc::new(entities),
-                parent_map,
-                child_map,
-                by_resource_type: accumulator.by_resource_type,
-                by_package: accumulator.by_package,
-                by_tag: accumulator.by_tag,
-                by_database_schema: accumulator.by_database_schema,
-                name_to_keys: accumulator.name_to_keys,
-                resource_type_by_id,
-                tantivy,
-                vector_search,
-                sparse_search,
-                reranker,
-                compiled_layer_rules,
-                tests_by_entity,
-                tests_by_column,
-                by_path_prefix,
-                column_lineage_aliases,
-                manifest_metadata: accumulator.manifest_metadata,
-                manifest_health,
-                artifact_consumer: artifact_consumer_status,
-                entity_counts: accumulator.entity_counts,
-                entity_cache,
-                lineage_cache,
-                entity_cache_hits: AtomicU64::new(0),
-                entity_cache_misses: AtomicU64::new(0),
-                lineage_cache_hits: AtomicU64::new(0),
-                lineage_cache_misses: AtomicU64::new(0),
-                manifest_source_uri: manifest_resolution.source_uri.clone(),
-                manifest_hash: signature.content_hash.clone(),
-                manifest_len: signature.len,
-                manifest_modified_ms: signature.modified_ms,
-                manifest_version: version_id.clone(),
-                loaded_at_ms: current_time_ms(),
-                vector_breaker,
-                sparse_breaker,
-                reranker_breaker,
-                _in_use_locks: Some(in_use_locks),
-            },
-            entity_store_reused: reuse_store,
-            tantivy_reused,
-            indexes_reused: used_cached_indexes,
-            elapsed_ms: load_start.elapsed().as_millis(),
+        let vector_result = match vector_handle.join() {
+            Ok(result) => result,
+            Err(err) => Err(DbtNovaError::ServerError(format!(
+                "Vector index build thread panicked: {}",
+                panic_message(&err)
+            ))),
+        };
+
+        let sparse_result = match sparse_handle.join() {
+            Ok(result) => result,
+            Err(err) => Err(DbtNovaError::ServerError(format!(
+                "Sparse index build thread panicked: {}",
+                panic_message(&err)
+            ))),
+        };
+
+        let (tantivy, vector_search, sparse_search) =
+            combine_index_build_results(tantivy_result, vector_result, sparse_result)?;
+
+        Ok(SearchBackends {
+            tantivy,
+            vector_search: vector_search.map(Arc::new),
+            sparse_search: sparse_search.map(Arc::new),
         })
+    })
+}
+
+fn build_search_backends_for_manifest(
+    config: &mut DbtNovaConfig,
+    storage_dir: &Path,
+    signature_hash: &str,
+    accumulator: &ManifestAccumulator,
+    entities: &EntityStore,
+    tantivy_opened: Option<TantivySearcher>,
+) -> Result<SearchBackends> {
+    config.search.manifest_hash = Some(signature_hash.to_string());
+    build_search_indexes(
+        storage_dir,
+        accumulator,
+        entities,
+        &config.search,
+        tantivy_opened,
+    )
+}
+
+fn build_runtime_components(
+    config: &DbtNovaConfig,
+    load_start: Instant,
+    entities: &EntityStore,
+    accumulator: &ManifestAccumulator,
+    vector_search: Option<&Arc<VectorSearcher>>,
+    sparse_search: Option<&Arc<SparseSearcher>>,
+) -> Result<RuntimeComponents> {
+    let entity_cache = EntityCache::build(config.entity_cache_size);
+    let lineage_cache = if config.search.lineage_cache_size > 0 {
+        Some(
+            MokaCache::builder()
+                .max_capacity(config.search.lineage_cache_size as u64)
+                .build(),
+        )
+    } else {
+        None
+    };
+    let column_lineage_aliases = build_column_lineage_aliases(entities, config)?;
+
+    let breaker_threshold = config.search.search_circuit_failure_threshold;
+    let breaker_duration = Duration::from_secs(config.search.search_circuit_open_seconds);
+    let vector_breaker = CircuitBreaker::new(breaker_threshold, breaker_duration);
+    let sparse_breaker = CircuitBreaker::new(breaker_threshold, breaker_duration);
+    let reranker_breaker = CircuitBreaker::new(breaker_threshold, breaker_duration);
+
+    if vector_search.is_some() {
+        info!(
+            elapsed_ms = load_start.elapsed().as_millis(),
+            "vector index built"
+        );
+    }
+
+    if sparse_search.is_some() {
+        info!(
+            elapsed_ms = load_start.elapsed().as_millis(),
+            "sparse index built"
+        );
+    }
+
+    let reranker = Reranker::build(&config.search)?.map(Arc::new);
+    let compiled_layer_rules = compile_layer_rules(&config.layer_rules);
+    let manifest_health = build_manifest_health(
+        entities,
+        &accumulator.parent_map,
+        &accumulator.unique_id_to_resource_type,
+    )?;
+
+    Ok(RuntimeComponents {
+        entity_cache,
+        lineage_cache,
+        column_lineage_aliases,
+        vector_breaker,
+        sparse_breaker,
+        reranker_breaker,
+        reranker,
+        compiled_layer_rules,
+        manifest_health,
+        parent_map: map_set_to_vec(accumulator.parent_map.clone()),
+        child_map: map_set_to_vec(accumulator.child_map.clone()),
+        resource_type_by_id: accumulator.unique_id_to_resource_type.clone(),
+    })
+}
+
+fn persist_storage_outputs(
+    storage: &mut StoragePreparation,
+    context: &PersistContext<'_>,
+) -> Result<()> {
+    if context.needs_build {
+        write_manifest_signature(context.signature_path, &storage.signature)?;
+        write_current_version(&storage.instance_root, &storage.version_id)?;
+    }
+
+    let persist_indexes = !context.indexes_reused && !context.config.storage_read_only;
+    if persist_indexes {
+        let manifest_metadata_json = serde_json::to_string(&context.accumulator.manifest_metadata)
+            .unwrap_or_else(|err| {
+                tracing::warn!(
+                    error = %err,
+                    "failed to encode manifest metadata for cache; using null"
+                );
+                "null".to_string()
+            });
+        let indexes = PersistedIndexes {
+            schema_version: RKYV_SCHEMA_VERSION,
+            manifest_hash: storage.signature.content_hash.clone(),
+            parent_map: context.parent_map.clone(),
+            child_map: context.child_map.clone(),
+            by_resource_type: context.accumulator.by_resource_type.clone(),
+            by_package: context.accumulator.by_package.clone(),
+            by_tag: context.accumulator.by_tag.clone(),
+            by_database_schema: context.accumulator.by_database_schema.clone(),
+            name_to_keys: context.accumulator.name_to_keys.clone(),
+            by_path_prefix: context.cached_indexes.by_path_prefix.clone(),
+            tests_by_entity: context.cached_indexes.tests_by_entity.clone(),
+            tests_by_column: context.cached_indexes.tests_by_column.clone(),
+            unique_id_to_resource_type: context.accumulator.unique_id_to_resource_type.clone(),
+            unique_id_to_path: context.accumulator.unique_id_to_path.clone(),
+            unique_id_to_tag_strings: context.accumulator.unique_id_to_tag_strings.clone(),
+            entity_counts: context.accumulator.entity_counts.clone(),
+            manifest_metadata_json,
+        };
+        if let Err(err) = rkyv_indexes::save_indexes(&indexes, context.storage_dir) {
+            tracing::warn!(error = %err, "failed to save index cache");
+        }
+    }
+
+    storage.build_lock.take();
+    Ok(())
+}
+
+fn assemble_manifest_search(context: AssembleContext) -> ManifestSearch {
+    let AssembleContext {
+        config,
+        entities,
+        storage,
+        runtime,
+        accumulator,
+        cached_indexes,
+        search_backends,
+        in_use_locks,
+        manifest_source_uri,
+    } = context;
+    ManifestSearch {
+        config,
+        entities: Arc::new(entities),
+        parent_map: runtime.parent_map,
+        child_map: runtime.child_map,
+        by_resource_type: accumulator.by_resource_type,
+        by_package: accumulator.by_package,
+        by_tag: accumulator.by_tag,
+        by_database_schema: accumulator.by_database_schema,
+        name_to_keys: accumulator.name_to_keys,
+        resource_type_by_id: runtime.resource_type_by_id,
+        tantivy: search_backends.tantivy,
+        vector_search: search_backends.vector_search,
+        sparse_search: search_backends.sparse_search,
+        reranker: runtime.reranker,
+        compiled_layer_rules: runtime.compiled_layer_rules,
+        tests_by_entity: cached_indexes.tests_by_entity,
+        tests_by_column: cached_indexes.tests_by_column,
+        by_path_prefix: cached_indexes.by_path_prefix,
+        column_lineage_aliases: runtime.column_lineage_aliases,
+        manifest_metadata: accumulator.manifest_metadata,
+        manifest_health: runtime.manifest_health,
+        artifact_consumer: storage.artifact_consumer_status,
+        entity_counts: accumulator.entity_counts,
+        entity_cache: runtime.entity_cache,
+        lineage_cache: runtime.lineage_cache,
+        entity_cache_hits: AtomicU64::new(0),
+        entity_cache_misses: AtomicU64::new(0),
+        lineage_cache_hits: AtomicU64::new(0),
+        lineage_cache_misses: AtomicU64::new(0),
+        manifest_source_uri,
+        manifest_hash: storage.signature.content_hash,
+        manifest_len: storage.signature.len,
+        manifest_modified_ms: storage.signature.modified_ms,
+        manifest_version: storage.version_id,
+        loaded_at_ms: current_time_ms(),
+        vector_breaker: runtime.vector_breaker,
+        sparse_breaker: runtime.sparse_breaker,
+        reranker_breaker: runtime.reranker_breaker,
+        _in_use_locks: Some(in_use_locks),
     }
 }
 

--- a/src/manifest/search/mod.rs
+++ b/src/manifest/search/mod.rs
@@ -3,7 +3,7 @@ mod core;
 mod summary;
 
 pub(crate) use cache::EntityCache;
-pub(crate) use core::{InUseLocks, compile_layer_rules};
+pub(crate) use core::{CompiledLayerRule, InUseLocks, compile_layer_rules};
 
 pub use core::{ManifestSearch, ManifestSearchHandle, ManifestStatus};
 

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -75,6 +75,34 @@ impl DbtNovaServer {
         }
     }
 
+    fn serialization_error_response(err: &impl std::fmt::Display) -> String {
+        serde_json::json!({
+            "success": false,
+            "error": format!("Serialization error: {err}"),
+            "error_code": "SERVER_ERROR"
+        })
+        .to_string()
+    }
+
+    fn error_response(err: &DbtNovaError) -> String {
+        serde_json::to_string(&err.to_response())
+            .unwrap_or_else(|ser_err| Self::serialization_error_response(&ser_err))
+    }
+
+    fn permit_from_result(
+        permit_result: Result<Option<ConcurrencyPermit>, DbtNovaError>,
+    ) -> std::result::Result<Option<ConcurrencyPermit>, String> {
+        permit_result.map_err(|err| Self::error_response(&err))
+    }
+
+    async fn acquire_sql_permit_for_tool(&self) -> Result<Option<ConcurrencyPermit>, DbtNovaError> {
+        let Ok(searcher) = self.searcher.get().await else {
+            return Ok(None);
+        };
+        let timeout = sql_queue_timeout(searcher.config());
+        self.acquire_sql_permit(searcher.config(), timeout).await
+    }
+
     async fn handle_async<F, Fut>(&self, tool: &'static str, persona: Option<&str>, f: F) -> String
     where
         F: FnOnce(Arc<ManifestSearch>) -> Fut,
@@ -85,15 +113,7 @@ impl DbtNovaServer {
         let searcher = match self.searcher.get().await {
             Ok(searcher) => searcher,
             Err(err) => {
-                let out = match serde_json::to_string(&err.to_response()) {
-                    Ok(out) => out,
-                    Err(ser_err) => serde_json::json!({
-                        "success": false,
-                        "error": format!("Serialization error: {}", ser_err),
-                        "error_code": "SERVER_ERROR"
-                    })
-                    .to_string(),
-                };
+                let out = Self::error_response(&err);
                 self.record_metrics(tool, persona, elapsed_ms_to_u64(start.elapsed()), success);
                 return out;
             }
@@ -116,22 +136,9 @@ impl DbtNovaServer {
                     success = true;
                     out
                 }
-                Err(e) => serde_json::json!({
-                    "success": false,
-                    "error": format!("Serialization error: {}", e),
-                    "error_code": "SERVER_ERROR"
-                })
-                .to_string(),
+                Err(e) => Self::serialization_error_response(&e),
             },
-            Err(e) => match serde_json::to_string(&e.to_response()) {
-                Ok(out) => out,
-                Err(err) => serde_json::json!({
-                    "success": false,
-                    "error": format!("Serialization error: {}", err),
-                    "error_code": "SERVER_ERROR"
-                })
-                .to_string(),
-            },
+            Err(e) => Self::error_response(&e),
         };
         self.record_metrics(tool, persona, elapsed_ms_to_u64(start.elapsed()), success);
         out
@@ -390,18 +397,9 @@ impl DbtNovaServer {
         } else {
             Ok(None)
         };
-        let permit = match permit_result {
+        let permit = match Self::permit_from_result(permit_result) {
             Ok(permit) => permit,
-            Err(err) => {
-                return serde_json::to_string(&err.to_response()).unwrap_or_else(|ser_err| {
-                    serde_json::json!({
-                        "success": false,
-                        "error": format!("Serialization error: {}", ser_err),
-                        "error_code": "SERVER_ERROR"
-                    })
-                    .to_string()
-                });
-            }
+            Err(response) => return response,
         };
         let result = self
             .handle_async("search", persona.as_deref(), |searcher| async move {
@@ -816,28 +814,9 @@ impl DbtNovaServer {
     )]
     #[instrument(level = "info", skip(self, params))]
     async fn run_recipe(&self, params: Parameters<RunRecipeParams>) -> String {
-        let permit_timeout = match self.searcher.get().await {
-            Ok(searcher) => sql_queue_timeout(searcher.config()),
-            Err(_) => None,
-        };
-        let permit_result = if let Ok(searcher) = self.searcher.get().await {
-            self.acquire_sql_permit(searcher.config(), permit_timeout)
-                .await
-        } else {
-            Ok(None)
-        };
-        let permit = match permit_result {
+        let permit = match Self::permit_from_result(self.acquire_sql_permit_for_tool().await) {
             Ok(permit) => permit,
-            Err(err) => {
-                return serde_json::to_string(&err.to_response()).unwrap_or_else(|ser_err| {
-                    serde_json::json!({
-                        "success": false,
-                        "error": format!("Serialization error: {}", ser_err),
-                        "error_code": "SERVER_ERROR"
-                    })
-                    .to_string()
-                });
-            }
+            Err(response) => return response,
         };
         let result = self
             .handle_async("run_recipe", None, |searcher| async move {
@@ -881,28 +860,9 @@ impl DbtNovaServer {
     )]
     #[instrument(level = "info", skip(self, params))]
     async fn execute_sql(&self, params: Parameters<ExecuteSqlParams>) -> String {
-        let permit_timeout = match self.searcher.get().await {
-            Ok(searcher) => sql_queue_timeout(searcher.config()),
-            Err(_) => None,
-        };
-        let permit_result = if let Ok(searcher) = self.searcher.get().await {
-            self.acquire_sql_permit(searcher.config(), permit_timeout)
-                .await
-        } else {
-            Ok(None)
-        };
-        let permit = match permit_result {
+        let permit = match Self::permit_from_result(self.acquire_sql_permit_for_tool().await) {
             Ok(permit) => permit,
-            Err(err) => {
-                return serde_json::to_string(&err.to_response()).unwrap_or_else(|ser_err| {
-                    serde_json::json!({
-                        "success": false,
-                        "error": format!("Serialization error: {}", ser_err),
-                        "error_code": "SERVER_ERROR"
-                    })
-                    .to_string()
-                });
-            }
+            Err(response) => return response,
         };
         let result = self
             .handle_async("execute_sql", None, |searcher| async move {


### PR DESCRIPTION
## Summary
- extract shared MCP error/permit helpers so `search`, `execute_sql`, and `run_recipe` no longer duplicate concurrency-permit error mapping logic
- decompose `ManifestSearch::new` into focused helper stages (`prepare_storage`, `prepare_reuse_state`, `prepare_manifest_data`, runtime assembly, persistence)
- remove the high-impact `#[allow(clippy::too_many_lines)]` suppression from `src/manifest/loader.rs` by shrinking `ManifestSearch::new` below clippy threshold
- replace tuple-heavy helper return types with named structs for clarity and clippy cleanliness

## Validation
- `cargo fmt --all`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked`

Closes #86
