### PR TITLE
workflow: use publish summary artifact for remote URI handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,31 +178,41 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq
 
+      - name: Download dry-run publish summary artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: ${{ needs.reusable-assets-remote-publish-dryrun.outputs.artifact_name_publish_summary }}
+          path: dryrun-publish-summary
+
       - name: Assert dry-run publish outputs are populated per target
         shell: bash
         env:
           PUBLISHED_TARGETS: ${{ needs.reusable-assets-remote-publish-dryrun.outputs.published_targets }}
-          STORAGE_URIS: ${{ needs.reusable-assets-remote-publish-dryrun.outputs.published_storage_uris }}
-          MANIFEST_URIS: ${{ needs.reusable-assets-remote-publish-dryrun.outputs.published_manifest_uris }}
-          METADATA_URIS: ${{ needs.reusable-assets-remote-publish-dryrun.outputs.published_metadata_uris }}
-          BOOTSTRAP_URIS: ${{ needs.reusable-assets-remote-publish-dryrun.outputs.published_bootstrap_uris }}
-          MODELS_URIS: ${{ needs.reusable-assets-remote-publish-dryrun.outputs.published_models_uris }}
         run: |
           set -euo pipefail
 
+          summary_path="$(find dryrun-publish-summary -type f -name '*.json' | head -n 1)"
+          test -f "${summary_path}" || {
+            echo "missing publish summary artifact content"
+            exit 1
+          }
+
           published_targets="${PUBLISHED_TARGETS}"
-          storage_uris="${STORAGE_URIS}"
-          manifest_uris="${MANIFEST_URIS}"
-          metadata_uris="${METADATA_URIS}"
-          bootstrap_uris="${BOOTSTRAP_URIS}"
-          models_uris="${MODELS_URIS}"
+          storage_uris="$(jq -c '.published_storage_uris' "${summary_path}")"
+          manifest_uris="$(jq -c '.published_manifest_uris' "${summary_path}")"
+          metadata_uris="$(jq -c '.published_metadata_uris' "${summary_path}")"
+          bootstrap_uris="$(jq -c '.published_bootstrap_uris' "${summary_path}")"
+          models_uris="$(jq -c '.published_models_uris' "${summary_path}")"
+          summary_targets="$(jq -r '.published_targets' "${summary_path}")"
 
           echo "published_targets=${published_targets}"
+          echo "summary_targets=${summary_targets}"
           echo "published_storage_uris=${storage_uris}"
           echo "published_manifest_uris=${manifest_uris}"
           echo "published_metadata_uris=${metadata_uris}"
           echo "published_bootstrap_uris=${bootstrap_uris}"
           echo "published_models_uris=${models_uris}"
+          test "${summary_targets}" = "${published_targets}"
 
           test -n "${published_targets}"
           normalized_targets="$(
@@ -264,6 +274,28 @@ jobs:
           test "${PUBLISHED_STORAGE_URIS}" = '{}'
           test "${PUBLISHED_METADATA_URIS}" = '{}'
           test "${PUBLISHED_MODELS_URIS}" = '{}'
+
+      - name: Download publish summary artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: ${{ needs.reusable-assets-producer.outputs.artifact_name_publish_summary }}
+          path: consumer-artifacts/publish-summary
+
+      - name: Validate default publish summary artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          summary_path="$(find consumer-artifacts/publish-summary -type f -name '*.json' | head -n 1)"
+          test -f "${summary_path}" || {
+            echo "missing publish summary artifact json"
+            exit 1
+          }
+          jq -e '.published_targets == ""' "${summary_path}" >/dev/null
+          jq -e '.published_storage_uris == {}' "${summary_path}" >/dev/null
+          jq -e '.published_manifest_uris == {}' "${summary_path}" >/dev/null
+          jq -e '.published_metadata_uris == {}' "${summary_path}" >/dev/null
+          jq -e '.published_bootstrap_uris == {}' "${summary_path}" >/dev/null
+          jq -e '.published_models_uris == {}' "${summary_path}" >/dev/null
 
       - name: Download storage artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16

--- a/.github/workflows/nova-build-assets.yml
+++ b/.github/workflows/nova-build-assets.yml
@@ -121,23 +121,26 @@ on:
       artifact_name_bootstrap:
         description: "Bootstrap artifact name"
         value: ${{ jobs.build.outputs.artifact_name_bootstrap }}
+      artifact_name_publish_summary:
+        description: "Remote publish summary artifact name"
+        value: ${{ jobs.build.outputs.artifact_name_publish_summary }}
       published_targets:
         description: "Comma-separated publish targets that completed successfully"
         value: ${{ jobs.build.outputs.published_targets }}
       published_storage_uris:
-        description: "JSON object with published storage archive URIs by target"
+        description: "Deprecated: always {}. Use artifact_name_publish_summary artifact instead."
         value: ${{ jobs.build.outputs.published_storage_uris }}
       published_metadata_uris:
-        description: "JSON object with published metadata URIs by target"
+        description: "Deprecated: always {}. Use artifact_name_publish_summary artifact instead."
         value: ${{ jobs.build.outputs.published_metadata_uris }}
       published_manifest_uris:
-        description: "JSON object with published manifest URIs by target"
+        description: "Deprecated: always {}. Use artifact_name_publish_summary artifact instead."
         value: ${{ jobs.build.outputs.published_manifest_uris }}
       published_bootstrap_uris:
-        description: "JSON object with published bootstrap URIs by target"
+        description: "Deprecated: always {}. Use artifact_name_publish_summary artifact instead."
         value: ${{ jobs.build.outputs.published_bootstrap_uris }}
       published_models_uris:
-        description: "JSON object with published models archive URIs by target"
+        description: "Deprecated: always {}. Use artifact_name_publish_summary artifact instead."
         value: ${{ jobs.build.outputs.published_models_uris }}
   workflow_dispatch:
     inputs:
@@ -562,7 +565,7 @@ jobs:
   build:
     name: Build, validate, and publish storage artifact
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 120
     needs: prepare
     outputs:
       manifest_hash: ${{ steps.collect.outputs.manifest_hash }}
@@ -573,12 +576,13 @@ jobs:
       artifact_name_metadata: ${{ steps.collect.outputs.artifact_name_metadata }}
       artifact_name_manifest: ${{ steps.collect.outputs.artifact_name_manifest }}
       artifact_name_bootstrap: ${{ steps.collect.outputs.artifact_name_bootstrap }}
+      artifact_name_publish_summary: ${{ steps.collect.outputs.artifact_name_publish_summary }}
       published_targets: ${{ steps.publish.outputs.published_targets || '' }}
-      published_storage_uris: ${{ steps.publish.outputs.published_storage_uris || '{}' }}
-      published_metadata_uris: ${{ steps.publish.outputs.published_metadata_uris || '{}' }}
-      published_manifest_uris: ${{ steps.publish.outputs.published_manifest_uris || '{}' }}
-      published_bootstrap_uris: ${{ steps.publish.outputs.published_bootstrap_uris || '{}' }}
-      published_models_uris: ${{ steps.publish.outputs.published_models_uris || '{}' }}
+      published_storage_uris: ${{ steps.publish.outputs.published_storage_uris_legacy || '{}' }}
+      published_metadata_uris: ${{ steps.publish.outputs.published_metadata_uris_legacy || '{}' }}
+      published_manifest_uris: ${{ steps.publish.outputs.published_manifest_uris_legacy || '{}' }}
+      published_bootstrap_uris: ${{ steps.publish.outputs.published_bootstrap_uris_legacy || '{}' }}
+      published_models_uris: ${{ steps.publish.outputs.published_models_uris_legacy || '{}' }}
     env:
       DBT_NOVA_STORAGE_DIR: ${{ needs.prepare.outputs.storage_dir }}
       DBT_NOVA_EMBEDDINGS_CACHE_DIR: ${{ needs.prepare.outputs.models_dir }}
@@ -845,6 +849,7 @@ jobs:
           artifact_name_metadata="${artifact_name_storage}-metadata"
           artifact_name_manifest="${artifact_name_storage}-manifest"
           artifact_name_bootstrap="${artifact_name_storage}-bootstrap"
+          artifact_name_publish_summary="${artifact_name_storage}-publish-summary"
 
           manifest_export_path="out/manifest.json"
           if [[ -n "${manifest_uri}" ]]; then
@@ -932,6 +937,7 @@ jobs:
           echo "artifact_name_metadata=${artifact_name_metadata}" >> "$GITHUB_OUTPUT"
           echo "artifact_name_manifest=${artifact_name_manifest}" >> "$GITHUB_OUTPUT"
           echo "artifact_name_bootstrap=${artifact_name_bootstrap}" >> "$GITHUB_OUTPUT"
+          echo "artifact_name_publish_summary=${artifact_name_publish_summary}" >> "$GITHUB_OUTPUT"
           echo "metadata_path=${metadata_path}" >> "$GITHUB_OUTPUT"
           echo "manifest_export_path=${manifest_export_path}" >> "$GITHUB_OUTPUT"
 
@@ -942,6 +948,7 @@ jobs:
             echo "- artifact_name_metadata: \`${artifact_name_metadata}\`"
             echo "- artifact_name_manifest: \`${artifact_name_manifest}\`"
             echo "- artifact_name_bootstrap: \`${artifact_name_bootstrap}\`"
+            echo "- artifact_name_publish_summary: \`${artifact_name_publish_summary}\`"
             echo "- contract_version: \`v1\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -1011,6 +1018,8 @@ jobs:
           metadata_filename="${{ steps.collect.outputs.artifact_name_metadata }}.json"
           metadata_publish_path="out/${metadata_filename}"
           bootstrap_filename="${{ steps.collect.outputs.artifact_name_bootstrap }}.json"
+          publish_summary_filename="${{ steps.collect.outputs.artifact_name_publish_summary }}.json"
+          publish_summary_path="out/${publish_summary_filename}"
           bootstrap_dir="out/bootstrap"
           mkdir -p "${bootstrap_dir}"
           cp "${manifest_source}" "${manifest_publish_path}"
@@ -1023,18 +1032,35 @@ jobs:
 
           # Defaults for workflow outputs when publish is disabled.
           if [[ -z "${publish_targets}" ]]; then
+            jq -n \
+              --arg published_targets "" \
+              --argjson published_storage_uris '{}' \
+              --argjson published_manifest_uris '{}' \
+              --argjson published_metadata_uris '{}' \
+              --argjson published_bootstrap_uris '{}' \
+              --argjson published_models_uris '{}' \
+              '{
+                published_targets: $published_targets,
+                published_storage_uris: $published_storage_uris,
+                published_manifest_uris: $published_manifest_uris,
+                published_metadata_uris: $published_metadata_uris,
+                published_bootstrap_uris: $published_bootstrap_uris,
+                published_models_uris: $published_models_uris
+              }' > "${publish_summary_path}"
             {
               echo "published_targets="
-              echo 'published_storage_uris={}'
-              echo 'published_metadata_uris={}'
-              echo 'published_manifest_uris={}'
-              echo 'published_bootstrap_uris={}'
-              echo 'published_models_uris={}'
+              echo "publish_summary_path=${publish_summary_path}"
+              echo 'published_storage_uris_legacy={}'
+              echo 'published_metadata_uris_legacy={}'
+              echo 'published_manifest_uris_legacy={}'
+              echo 'published_bootstrap_uris_legacy={}'
+              echo 'published_models_uris_legacy={}'
             } >> "$GITHUB_OUTPUT"
             {
               echo "### Remote Publish"
               echo ""
               echo "Remote publish disabled (publish_targets is empty)."
+              echo "- publish_summary_path: \`${publish_summary_path}\`"
             } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
@@ -1416,13 +1442,30 @@ jobs:
             | if $gcs != "" then . + {gcs: $gcs} else . end
             | if $dbfs != "" then . + {dbfs: $dbfs} else . end')"
 
+          jq -n \
+            --arg published_targets "${published_targets_success}" \
+            --argjson published_storage_uris "${published_storage_uris}" \
+            --argjson published_manifest_uris "${published_manifest_uris}" \
+            --argjson published_metadata_uris "${published_metadata_uris}" \
+            --argjson published_bootstrap_uris "${published_bootstrap_uris}" \
+            --argjson published_models_uris "${published_models_uris}" \
+            '{
+              published_targets: $published_targets,
+              published_storage_uris: $published_storage_uris,
+              published_manifest_uris: $published_manifest_uris,
+              published_metadata_uris: $published_metadata_uris,
+              published_bootstrap_uris: $published_bootstrap_uris,
+              published_models_uris: $published_models_uris
+            }' > "${publish_summary_path}"
+
           {
             echo "published_targets=${published_targets_success}"
-            echo "published_storage_uris=${published_storage_uris}"
-            echo "published_manifest_uris=${published_manifest_uris}"
-            echo "published_metadata_uris=${published_metadata_uris}"
-            echo "published_bootstrap_uris=${published_bootstrap_uris}"
-            echo "published_models_uris=${published_models_uris}"
+            echo "publish_summary_path=${publish_summary_path}"
+            echo 'published_storage_uris_legacy={}'
+            echo 'published_manifest_uris_legacy={}'
+            echo 'published_metadata_uris_legacy={}'
+            echo 'published_bootstrap_uris_legacy={}'
+            echo 'published_models_uris_legacy={}'
           } >> "$GITHUB_OUTPUT"
 
           {
@@ -1430,18 +1473,26 @@ jobs:
             echo ""
             echo "- dry_run: \`${publish_dry_run}\`"
             echo "- targets: \`${published_targets_success}\`"
-            echo "- storage_uris: \`${published_storage_uris}\`"
-            echo "- manifest_uris: \`${published_manifest_uris}\`"
-            echo "- metadata_uris: \`${published_metadata_uris}\`"
-            echo "- bootstrap_uris: \`${published_bootstrap_uris}\`"
-            echo "- models_uris: \`${published_models_uris}\`"
+            echo "- publish_summary_path: \`${publish_summary_path}\`"
+            echo ""
+            echo '```json'
+            jq . "${publish_summary_path}"
+            echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload bootstrap contract artifact
-        if: ${{ steps.publish.outputs.published_bootstrap_uris != '{}' }}
+        if: ${{ steps.publish.outputs.published_targets != '' }}
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
         with:
           name: ${{ steps.collect.outputs.artifact_name_bootstrap }}
           path: out/bootstrap/*.json
+          retention-days: ${{ inputs.retention_days }}
+          if-no-files-found: error
+
+      - name: Upload publish summary artifact
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        with:
+          name: ${{ steps.collect.outputs.artifact_name_publish_summary }}
+          path: ${{ steps.publish.outputs.publish_summary_path }}
           retention-days: ${{ inputs.retention_days }}
           if-no-files-found: error

--- a/docs/operations/prebuilt-assets.md
+++ b/docs/operations/prebuilt-assets.md
@@ -96,7 +96,7 @@ The producer emits:
 - metadata contract artifact (`nova-build-metadata.json`, required)
 - models artifact (optional when `include_models_cache=true`)
 - bootstrap contract artifact(s) when remote publish is configured
-- optional remote publish outputs (`published_*_uris`) when `publish_targets` is configured
+- publish summary artifact (`artifact_name_publish_summary`) with published URIs by target
 
 ## Optional remote publish targets
 
@@ -143,16 +143,16 @@ Published object naming is deterministic:
 Producer outputs include:
 
 - `published_targets` (comma-separated successful targets)
-- `published_storage_uris` (JSON object by target)
-- `published_manifest_uris` (JSON object by target)
-- `published_metadata_uris` (JSON object by target)
-- `published_bootstrap_uris` (JSON object by target)
-- `published_models_uris` (JSON object by target)
+- `artifact_name_publish_summary` (artifact containing `published_*_uris` JSON payloads)
+- legacy `published_*_uris` outputs are deprecated and return `{}` for compatibility
 
-Example (extract DBFS bootstrap URI from workflow outputs):
+Example (extract DBFS bootstrap URI from publish summary artifact):
 
 ```bash
-BOOTSTRAP_URI="$(jq -r '.dbfs' <<< "${PUBLISHED_BOOTSTRAP_URIS}")"
+PUBLISH_SUMMARY_DIR="$(mktemp -d)"
+gh run download "$GITHUB_RUN_ID" --name "$ARTIFACT_NAME_PUBLISH_SUMMARY" --dir "$PUBLISH_SUMMARY_DIR"
+PUBLISH_SUMMARY_JSON="$(find "$PUBLISH_SUMMARY_DIR" -type f -name '*.json' | head -n 1)"
+BOOTSTRAP_URI="$(jq -r '.published_bootstrap_uris.dbfs' "$PUBLISH_SUMMARY_JSON")"
 ```
 
 ## Consumer (reuse in read-only mode)


### PR DESCRIPTION
## Summary
- increase reusable `build` job timeout from 60m to 120m to avoid publish-stage cancellation
- stop passing remote publish URIs via job outputs (GitHub secret suppression can blank those outputs)
- add `artifact_name_publish_summary` output and upload a publish-summary JSON artifact containing all `published_*_uris` payloads
- keep legacy `published_*_uris` outputs for compatibility, but mark them deprecated and return `{}`
- update CI reusable workflow assertions to consume/download the publish-summary artifact
- update prebuilt-assets docs to document artifact-based handoff

## First-principles review
- correctness: publish summary is produced both when publish targets are empty and when they are configured
- compatibility: legacy outputs remain present to avoid breaking existing callers
- reliability: timeout increase addresses long-running publish jobs
- observability: step summary includes publish-summary JSON

## Validation
- YAML parse check for `.github/workflows/nova-build-assets.yml` and `.github/workflows/ci.yml`
- `uv run mkdocs build --strict`
