### PR TITLE
workflow: normalize models archives for artifact extraction

### DIFF
--- a/.github/workflows/nova-build-assets.yml
+++ b/.github/workflows/nova-build-assets.yml
@@ -989,7 +989,36 @@ jobs:
         run: |
           set -euo pipefail
           models_archive="${{ steps.collect.outputs.artifact_name_models }}.tar.gz"
-          tar -C "$(dirname "${DBT_NOVA_EMBEDDINGS_CACHE_DIR}")" -czf "${models_archive}" "$(basename "${DBT_NOVA_EMBEDDINGS_CACHE_DIR}")"
+          # Dereference links so remote consumers receive a regular-file archive.
+          tar \
+            -C "$(dirname "${DBT_NOVA_EMBEDDINGS_CACHE_DIR}")" \
+            --dereference \
+            --hard-dereference \
+            -czf "${models_archive}" \
+            "$(basename "${DBT_NOVA_EMBEDDINGS_CACHE_DIR}")"
+
+      - name: Validate models archive entry types
+        if: ${{ inputs.include_models_cache }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          models_archive="${{ steps.collect.outputs.artifact_name_models }}.tar.gz"
+          # Only regular files and directories are allowed for safe extraction.
+          tar -tvf "${models_archive}" | awk '
+            {
+              entry_type = substr($1, 1, 1)
+              if (entry_type != "-" && entry_type != "d") {
+                print $0
+                bad = 1
+              }
+            }
+            END {
+              if (bad == 1) {
+                print "models archive contains unsupported entry types" > "/dev/stderr"
+                exit 1
+              }
+            }
+          '
 
       - name: Upload models artifact
         if: ${{ inputs.include_models_cache }}


### PR DESCRIPTION
## Summary
- package models cache tarballs with `--dereference --hard-dereference` so archives contain regular files/directories only
- add a validation step that fails the workflow if a models archive still includes unsupported entry types (symlink/hardlink/device/etc)

## Why
Bootstrap-based artifact materialization failed at runtime when extracting the models archive:
- `archive contains unsupported entry type ... tokenizer.json`

The source HF cache can include links. This change normalizes archive contents for safe downstream extraction.

## Validation
- YAML parse check: `.github/workflows/nova-build-assets.yml`
