### PR TITLE
docs: fully document install/runtime combinations

### DIFF
--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -7,6 +7,9 @@ search on real‑world manifests.
 `src/config/` via `scripts/update_config_reference.sh`. When defaults change, regenerate
 that file and ensure this page stays in sync.
 
+For end-to-end install/runtime composition patterns (binary + manifest + artifacts + models + SQL provider),
+see [Modes & Combinations](../getting-started/modes-and-combinations.md).
+
 ## Core
 
 - `DBT_MANIFEST_PATH` – path to `manifest.json` (default: `manifest.json`)
@@ -74,6 +77,12 @@ Remote manifest notes:
 - `DBT_NOVA_STORAGE_READ_ONLY` – do not build indexes (`true`|`false`, default: `false`)
 - `DBT_NOVA_ENTITY_CACHE_SIZE` – max entities cached in memory (`0` disables, default: `1000`)
 - `DBT_NOVA_EMBEDDINGS_CACHE_DIR` – embeddings cache directory (default: `models/` next to executable if present, else `<storage_root>/.fastembed_cache`)
+
+Embeddings cache resolution order when `DBT_NOVA_EMBEDDINGS_CACHE_DIR` is unset:
+
+1. `models/` next to the active executable
+2. `~/.local/bin/models` (if present)
+3. `<storage_root>/.fastembed_cache`
 
 Notes:
 - The entity cache backend is currently fixed to `moka` (no env override).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -58,6 +58,9 @@ curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
 The installer places `dbt-nova` in `~/.local/bin`. For bundled installs, it also
 places `models/` next to the binary so Nova auto-discovers it.
 
+Need to decide between local builds, bootstrap contracts, remote prebuilt artifacts,
+or remote model hydration? See [Modes & Combinations](modes-and-combinations.md).
+
 ### Optional: Install + Pre-Warm Models
 
 If you want users to avoid first-run model downloads, pre-warm during install:
@@ -158,6 +161,9 @@ cargo install --path . --features embeddings --locked
 
 Published release assets are **slim** (binary only). Models download on first run
 or can be pre-warmed with `scripts/warm_models.sh`.
+
+If you request `--bundled` and no bundled artifact exists for that release/target,
+the installer automatically falls back to slim.
 
 Published targets:
 

--- a/docs/getting-started/mcp-clients.md
+++ b/docs/getting-started/mcp-clients.md
@@ -12,6 +12,10 @@ For all SQL providers, object-level preflight checks (`preflight_catalog`,
 `preflight_schema`, `preflight_relation`) pass only when the probe returns at
 least one row.
 
+For full installation/runtime combination guidance (manifest vs bootstrap vs
+remote artifacts vs model cache strategies), see
+[Modes & Combinations](modes-and-combinations.md).
+
 For slim installs, set a stable `DBT_NOVA_EMBEDDINGS_CACHE_DIR` (recommended:
 `~/.dbt-nova/models`) so model downloads are reused across sessions/clients.
 If you installed with:
@@ -48,6 +52,12 @@ Recommended with prebuilt artifacts:
   manifest content used by the producer build.
 - Use the same Nova release on producer and consumer.
 - Keep artifact URIs stable and allow Nova to cache them locally.
+
+Bootstrap precedence reminder:
+
+- Explicit env vars win.
+- Bootstrap only fills missing fields.
+- `manifest_uri` from bootstrap is skipped when `DBT_MANIFEST_PATH` was explicitly set.
 
 Codex TOML example:
 

--- a/docs/getting-started/modes-and-combinations.md
+++ b/docs/getting-started/modes-and-combinations.md
@@ -1,0 +1,146 @@
+# Modes & Combinations
+
+dbt-nova behavior is the product of **five independent planes**:
+
+1. How you install the binary
+2. Where manifest content comes from
+3. Where storage/index artifacts come from
+4. Where embedding/reranker model files come from
+5. Which SQL provider is active
+
+This page maps those planes, shows precedence rules, and gives validated deployment profiles.
+
+## 1) Binary Installation Plane
+
+| Mode | How | Notes |
+|---|---|---|
+| Release slim (default) | `scripts/install.sh --slim` | Binary only. Model files are resolved at runtime (downloaded or pre-warmed). |
+| Release bundled | `scripts/install.sh --bundled` | Binary + colocated `models/` when bundled assets exist. Installer falls back to slim if bundled artifact is unavailable. |
+| Source build | `cargo build --release` | Use for unreleased commits or unsupported runner/platform. |
+
+Installer controls:
+
+- `DBT_NOVA_INSTALL_FLAVOR=bundled|slim`
+- `DBT_NOVA_INSTALL_WARM_MODELS=1` (or `--warm-models`, slim only)
+- `DBT_NOVA_INSTALL_SKILLS=1` (or `--install-skills`)
+- `DBT_NOVA_INSTALL_NONINTERACTIVE=1`
+- `DBT_NOVA_INSTALL_DIR`, `DBT_NOVA_SKILLS_DIR`
+- `DBT_NOVA_VERIFY_CHECKSUM=1|0`, `DBT_NOVA_VERIFY_SIGNATURE=1|0`
+
+## 2) Manifest Source Plane
+
+| Source | Primary config | Typical use |
+|---|---|---|
+| Local file | `DBT_MANIFEST_PATH` | Local dev, deterministic testing |
+| Remote manifest URI | `DBT_NOVA_MANIFEST_URI` | Centralized manifest hosting (`s3://`, `gs://`, `dbfs:/`, `https://`) |
+| Bootstrap contract | `DBT_NOVA_BOOTSTRAP_URI` | One-URI onboarding (can set `manifest_uri` + artifact URIs) |
+
+Manifest precedence:
+
+1. Explicit env/CLI values win.
+2. Bootstrap only fills missing fields.
+3. `manifest_uri` from bootstrap is only applied when:
+   - `DBT_NOVA_MANIFEST_URI` is empty, and
+   - `DBT_MANIFEST_PATH` was not explicitly set (including explicit `manifest.json`).
+
+## 3) Storage / Index Artifact Plane
+
+| Mode | Required config | Behavior |
+|---|---|---|
+| Local build (mutable) | none (default) | Nova builds indexes locally from manifest and refresh policy. |
+| Remote artifact consumer | `DBT_NOVA_STORAGE_ARTIFACT_URI` + `DBT_NOVA_METADATA_ARTIFACT_URI` | Nova materializes prebuilt storage artifacts locally, then serves from them. |
+| Bootstrap-driven remote consumer | `DBT_NOVA_BOOTSTRAP_URI` | Bootstrap can inject storage/metadata/model artifact URIs. |
+
+Artifact controls:
+
+- `DBT_NOVA_ARTIFACT_FETCH_POLICY=if_missing|always|never`
+- `DBT_NOVA_ARTIFACTS_CACHE_DIR`
+- `DBT_NOVA_ARTIFACT_TIMEOUT_SECS`
+- `DBT_NOVA_STORAGE_READ_ONLY=true` (recommended for consumers)
+
+Rule: remote artifact mode is valid only when **both** storage + metadata artifact URIs are present.
+
+## 4) Model Asset Plane (Embeddings + Sparse + Reranker)
+
+### Resolution Order
+
+If `DBT_NOVA_EMBEDDINGS_CACHE_DIR` is unset, Nova resolves model path in this order:
+
+1. `models/` next to the executable
+2. `~/.local/bin/models` (if present)
+3. `<storage_root>/.fastembed_cache`
+
+### Ways to supply models
+
+| Strategy | How | Best for |
+|---|---|---|
+| Colocated bundled models | Bundled install with `models/` beside binary | Air-gapped/local fixed runtime |
+| Pre-warmed local cache | `--warm-models` or `scripts/warm_models.sh` + fixed `DBT_NOVA_EMBEDDINGS_CACHE_DIR` | Laptops, consistent MCP startup |
+| Remote models artifact | `DBT_NOVA_MODELS_ARTIFACT_URI` (or bootstrap field) | Fully centralized artifact distribution |
+| On-demand download | Slim install without prewarm | Fastest install path, slower first semantic startup |
+
+Important: if bootstrap omits `models_artifact_uri` (for example producer `models_distribution_mode=none`), consumers must rely on pre-warmed/local cache or on-demand model download.
+
+## 5) SQL Provider Plane
+
+`execute_sql` and `run_recipe` use `DBT_NOVA_SQL_PROVIDER`:
+
+- `databricks` (default): requires Databricks host/token + warehouse pointer
+- `bigquery`: requires project id + Google auth path/token
+- `duckdb`: requires `DBT_NOVA_DUCKDB_PATH` (read-only execution model)
+
+Provider diagnostics:
+
+```bash
+dbt-nova tool call execute_sql \
+  --params-json '{"preflight_only":true}' \
+  --json
+```
+
+## Recommended Deployment Profiles
+
+| Profile | Manifest | Storage | Models | Key config |
+|---|---|---|---|---|
+| Local dev (simple) | local path | local build | on-demand | `DBT_MANIFEST_PATH` |
+| Local dev (stable) | local path | local build | pre-warmed local cache | `DBT_MANIFEST_PATH`, `DBT_NOVA_EMBEDDINGS_CACHE_DIR` |
+| Remote manifest, local index | `DBT_NOVA_MANIFEST_URI` | local build | pre-warmed local cache | `DBT_NOVA_MANIFEST_URI`, `DBT_NOVA_EMBEDDINGS_CACHE_DIR` |
+| Prebuilt read-only (no remote models) | bootstrap or explicit artifact URIs | prebuilt artifacts | local pre-warmed cache | `DBT_NOVA_STORAGE_READ_ONLY=true`, bootstrap/artifact vars, `DBT_NOVA_EMBEDDINGS_CACHE_DIR` |
+| Prebuilt read-only (full remote) | bootstrap | prebuilt artifacts | remote models artifact | `DBT_NOVA_STORAGE_READ_ONLY=true`, `DBT_NOVA_BOOTSTRAP_URI`, fetch policy |
+
+## Producer/Consumer Alignment (Prebuilt Assets)
+
+When using `.github/workflows/nova-build-assets.yml`:
+
+- `models_distribution_mode=none`: no models artifact published, bootstrap excludes models URI
+- `models_distribution_mode=publish_only`: models artifact published, bootstrap still excludes models URI
+- `models_distribution_mode=publish_and_bootstrap`: models artifact published and bootstrap includes models URI
+
+Use `publish_and_bootstrap` only when you want consumers to hydrate models from remote artifacts by default.
+
+## Validation Checklist
+
+```bash
+# 1) Validate merged config
+dbt-nova config validate --json
+
+# 2) Check runtime state and what was applied
+dbt-nova health check --json
+
+# 3) Confirm SQL provider wiring
+dbt-nova tool call execute_sql --params-json '{"preflight_only":true}' --json
+```
+
+In `health`, verify:
+
+- `bootstrap.loaded`, `bootstrap.applied_fields`
+- `artifact_consumer.enabled`, `artifact_consumer.fetch_policy`
+- `artifact_consumer.storage_materialized`
+- `artifact_consumer.models_materialized`
+- `status` is `ready` for steady-state operation
+
+## See Also
+
+- [Installation](installation.md)
+- [MCP Client Configs](mcp-clients.md)
+- [Configuration Reference](../configuration/reference.md)
+- [Prebuilt Asset Workflow](../operations/prebuilt-assets.md)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -229,6 +229,7 @@ parameter contracts, and execution order rules.
 ## Next Steps
 
 - [CLI Commands](cli.md) - One-shot command groups, JSON mode, and exit codes
+- [Modes & Combinations](modes-and-combinations.md) - Install/runtime decision matrix
 - [Configuration Reference](../configuration/reference.md) - All configuration options
 - [Tools Reference](../api/tools.md) - Available tools and parameters
 - [Personas](../personas/overview.md) - Workflow guides by role

--- a/docs/operations/prebuilt-assets.md
+++ b/docs/operations/prebuilt-assets.md
@@ -105,6 +105,14 @@ Models distribution modes:
 - `publish_only`: package/publish models artifact, but bootstrap still omits `models_artifact_uri`.
 - `publish_and_bootstrap`: package/publish models artifact and include `models_artifact_uri` in bootstrap.
 
+Consumer impact by mode:
+
+| `models_distribution_mode` | Models archive published | Bootstrap includes models URI | Consumer expectation |
+|---|---|---|---|
+| `none` | No | No | Use local model cache (`DBT_NOVA_EMBEDDINGS_CACHE_DIR`) or on-demand model download |
+| `publish_only` | Yes | No | Optional manual consumer opt-in via `DBT_NOVA_MODELS_ARTIFACT_URI` |
+| `publish_and_bootstrap` | Yes | Yes | Bootstrap-native remote model hydration |
+
 ## Optional remote publish targets
 
 Use this when consumers should pull artifacts from cloud storage instead of
@@ -294,5 +302,6 @@ tar -xzf <artifact_name_storage>.tar.gz
 ## Related docs
 
 - [MCP Client Configs](../getting-started/mcp-clients.md)
+- [Modes & Combinations](../getting-started/modes-and-combinations.md)
 - [Troubleshooting](troubleshooting.md)
 - [CI & Automation](../development/ci.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
   - Home: index.md
   - Getting Started:
     - Installation: getting-started/installation.md
+    - Modes & Combinations: getting-started/modes-and-combinations.md
     - Quick Start: getting-started/quickstart.md
     - CLI Commands: getting-started/cli.md
     - MCP Clients: getting-started/mcp-clients.md


### PR DESCRIPTION
## Summary
- add a new **Modes & Combinations** guide that models dbt-nova setup across 5 planes:
  - binary installation mode
  - manifest source mode
  - storage/index artifact mode
  - model asset mode
  - SQL provider mode
- document precedence and validity rules (explicit env vs bootstrap, required artifact pair, model resolution order)
- add producer/consumer impact table for `models_distribution_mode`
- cross-link the new guide from installation, quickstart, MCP client config, prebuilt assets, and config reference

## Validation
- `uv run mkdocs build --strict`
