### PR TITLE
Preserve caller GCS token fallback in asset publish workflow

### DIFF
--- a/.github/workflows/nova-build-assets.yml
+++ b/.github/workflows/nova-build-assets.yml
@@ -2115,7 +2115,6 @@ jobs:
         id: publish
         shell: bash
         env:
-          DBT_NOVA_GCP_ACCESS_TOKEN: ${{ steps.gcp_auth.outputs.access_token || '' }}
           INPUT_PUBLISH_MODELS_ARCHIVE: ${{ needs.prepare.outputs.publish_models_archive }}
           INPUT_INCLUDE_MODELS_IN_BOOTSTRAP: ${{ needs.prepare.outputs.include_models_in_bootstrap }}
           STORAGE_ARCHIVE_NAME: ${{ steps.collect.outputs.artifact_name_storage }}.tar.gz


### PR DESCRIPTION
## Summary
- stop the reusable asset publish step from unconditionally setting `DBT_NOVA_GCP_ACCESS_TOKEN` to an empty string
- preserve the documented non-OIDC static-token path for GCS publish/download

## Why
`#142` merged before this follow-up fix landed. In the merged workflow, the publish step injects:

```yaml
DBT_NOVA_GCP_ACCESS_TOKEN: ${{ steps.gcp_auth.outputs.access_token || '' }}
```

When the OIDC auth step is skipped, that overwrites any caller-provided token with an empty string and regresses the documented static-token fallback for GCS.

## Fix
Remove the unconditional env injection. OIDC-backed runs still work through ADC / `gcloud`, and callers using a static token continue to work.

## Validation
- workflow YAML parsed locally
- diff is a single-line deletion in `.github/workflows/nova-build-assets.yml`
