### PR TITLE
Add reusable metadata audit workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,81 @@ jobs:
       installer_repository: ${{ github.repository }}
       installer_ref: ${{ github.sha }}
 
+  reusable-metadata-audit-project:
+    name: reusable-metadata-audit-project
+    permissions:
+      contents: read
+    uses: ./.github/workflows/nova-metadata-audit.yml
+    with:
+      manifest_path: tests/fixtures/nova_manifest.json
+      storage_instance_id: ci-metadata-audit-project
+      artifact_name_prefix: ci-metadata-audit-project
+      retention_days: 1
+      installer_repository: ${{ github.repository }}
+      installer_ref: ${{ github.sha }}
+      selection_mode: project
+      resource_types_json: '["model"]'
+      personas_json: '["engineer"]'
+      thresholds_json: '{}'
+
+  reusable-metadata-audit-changed:
+    name: reusable-metadata-audit-changed
+    permissions:
+      contents: read
+    uses: ./.github/workflows/nova-metadata-audit.yml
+    with:
+      manifest_path: tests/fixtures/nova_manifest.json
+      storage_instance_id: ci-metadata-audit-changed
+      artifact_name_prefix: ci-metadata-audit-changed
+      retention_days: 1
+      installer_repository: ${{ github.repository }}
+      installer_ref: ${{ github.sha }}
+      selection_mode: changed
+      changed_files_json: '["models/staging/traffic/stg__traffic_sessions.sql"]'
+      resource_types_json: '["model"]'
+      personas_json: '["engineer","analyst"]'
+      thresholds_json: '{"entity":{"engineer":{"min_score":0,"severity":"required"},"analyst":{"min_score":0,"severity":"advisory"}}}'
+
+  reusable-metadata-audit-structured-dbt:
+    name: reusable-metadata-audit-structured-dbt
+    permissions:
+      contents: read
+    uses: ./.github/workflows/nova-metadata-audit.yml
+    with:
+      dbt_generate_manifest: true
+      dbt_executable: python3
+      dbt_allow_unsafe_executable: true
+      dbt_command_args_json: >-
+        ["-c","from pathlib import Path; Path('target').mkdir(exist_ok=True); Path('target/manifest.json').write_text(Path('tests/fixtures/nova_manifest.json').read_text(encoding='utf-8'), encoding='utf-8')"]
+      storage_instance_id: ci-metadata-audit-structured
+      artifact_name_prefix: ci-metadata-audit-structured
+      retention_days: 1
+      installer_repository: ${{ github.repository }}
+      installer_ref: ${{ github.sha }}
+      selection_mode: changed
+      changed_files_json: '["models/staging/traffic/stg__traffic_sessions.sql"]'
+      thresholds_json: '{"entity":{"engineer":{"min_score":0,"severity":"required"}}}'
+
+  reusable-metadata-audit-trusted-dbt:
+    name: reusable-metadata-audit-trusted-dbt
+    permissions:
+      contents: read
+    uses: ./.github/workflows/nova-metadata-audit.yml
+    with:
+      dbt_generate_manifest: true
+      dbt_command: |
+        set -euo pipefail
+        mkdir -p target
+        cp tests/fixtures/nova_manifest.json target/manifest.json
+      storage_instance_id: ci-metadata-audit-trusted
+      artifact_name_prefix: ci-metadata-audit-trusted
+      retention_days: 1
+      installer_repository: ${{ github.repository }}
+      installer_ref: ${{ github.sha }}
+      selection_mode: entities
+      entity_ids_json: '["model.nova_test.stg__traffic_sessions"]'
+      thresholds_json: '{"entity":{"engineer":{"min_score":0,"severity":"required"}}}'
+
   reusable-assets-remote-publish-dryrun:
     name: reusable-assets-remote-publish-dryrun
     permissions:

--- a/.github/workflows/nova-metadata-audit.yml
+++ b/.github/workflows/nova-metadata-audit.yml
@@ -1,0 +1,830 @@
+name: Nova Metadata Audit
+
+on:
+  workflow_call:
+    inputs:
+      manifest_path:
+        description: "Path to manifest.json in the caller repository"
+        required: false
+        type: string
+        default: ""
+      manifest_uri:
+        description: "Remote manifest URI (file/http(s)/s3/gs/dbfs)"
+        required: false
+        type: string
+        default: ""
+      installer_repository:
+        description: "Repository to checkout for building dbt-nova (default: joe-broadhead/dbt-nova)"
+        required: false
+        type: string
+        default: "joe-broadhead/dbt-nova"
+      installer_ref:
+        description: "Git ref to checkout for installer_repository (defaults to resolved reusable workflow ref)"
+        required: false
+        type: string
+        default: ""
+      installer_install_mode:
+        description: "How to install dbt-nova in CI: auto (try release, fallback source), release, or source"
+        required: false
+        type: string
+        default: "auto"
+      dbt_generate_manifest:
+        description: "Whether to run dbt before auditing metadata"
+        required: false
+        type: boolean
+        default: false
+      dbt_command:
+        description: "Trusted shell command executed via bash -lc when dbt_generate_manifest=true"
+        required: false
+        type: string
+        default: ""
+      dbt_command_args_json:
+        description: "Structured dbt invocation args as JSON array (e.g. [\"parse\",\"--target\",\"prod\"])"
+        required: false
+        type: string
+        default: "[]"
+      dbt_executable:
+        description: "Executable used for structured dbt invocation when dbt_command_args_json is set"
+        required: false
+        type: string
+        default: "dbt"
+      dbt_allow_unsafe_executable:
+        description: "Allow non-dbt dbt_executable values (trusted callers only)"
+        required: false
+        type: boolean
+        default: false
+      dbt_env_json:
+        description: "JSON object of non-secret env vars exported before dbt invocation"
+        required: false
+        type: string
+        default: "{}"
+      dbt_secret_env_map_json:
+        description: "JSON object mapping env var names to secret names"
+        required: false
+        type: string
+        default: "{}"
+      selection_mode:
+        description: "Entity selection mode: project, changed, or entities"
+        required: false
+        type: string
+        default: "project"
+      changed_files_json:
+        description: "Optional JSON array of changed file paths when selection_mode=changed"
+        required: false
+        type: string
+        default: "[]"
+      entity_ids_json:
+        description: "Optional JSON array of explicit entity ids/names when selection_mode=entities"
+        required: false
+        type: string
+        default: "[]"
+      resource_types_json:
+        description: "JSON array of resource types to audit (default: [\"model\"])"
+        required: false
+        type: string
+        default: "[\"model\"]"
+      personas_json:
+        description: "JSON array of personas to score (default: [\"engineer\"])"
+        required: false
+        type: string
+        default: "[\"engineer\"]"
+      thresholds_json:
+        description: "JSON object describing persona-specific pass/fail thresholds"
+        required: false
+        type: string
+        default: >-
+          {"entity":{"engineer":{"min_score":70,"severity":"required"},"analyst":{"min_score":65,"severity":"advisory"},"governance":{"min_score":65,"severity":"advisory"}}}
+      include_breakdown:
+        description: "Include per-check metadata score breakdowns"
+        required: false
+        type: boolean
+        default: true
+      include_recommendations:
+        description: "Include metadata score recommendations"
+        required: false
+        type: boolean
+        default: true
+      fail_on_no_targets:
+        description: "Fail when the selection resolves to zero entities"
+        required: false
+        type: boolean
+        default: false
+      storage_instance_id:
+        description: "Optional stable storage instance id used for CLI manifest load"
+        required: false
+        type: string
+        default: "metadata-audit"
+      artifact_name_prefix:
+        description: "Prefix used when naming output artifacts"
+        required: false
+        type: string
+        default: "dbt-nova-metadata-audit"
+      retention_days:
+        description: "Artifact retention period in days (1-90)"
+        required: false
+        type: number
+        default: 14
+    secrets:
+      DBT_NOVA_SECRET_BUNDLE_JSON:
+        description: "Optional JSON object of secret-name -> secret-value pairs used by dbt_secret_env_map_json"
+        required: false
+    outputs:
+      gate_status:
+        description: "Overall audit gate status (pass, advisory, fail)"
+        value: ${{ jobs.audit.outputs.gate_status }}
+      target_count:
+        description: "Number of selected entities"
+        value: ${{ jobs.audit.outputs.target_count }}
+      scored_count:
+        description: "Number of scored entities"
+        value: ${{ jobs.audit.outputs.scored_count }}
+      required_fail_count:
+        description: "Number of required threshold failures"
+        value: ${{ jobs.audit.outputs.required_fail_count }}
+      advisory_fail_count:
+        description: "Number of advisory threshold failures"
+        value: ${{ jobs.audit.outputs.advisory_fail_count }}
+      artifact_name_report_json:
+        description: "Uploaded JSON report artifact name"
+        value: ${{ jobs.audit.outputs.artifact_name_report_json }}
+      artifact_name_report_md:
+        description: "Uploaded Markdown report artifact name"
+        value: ${{ jobs.audit.outputs.artifact_name_report_md }}
+  workflow_dispatch:
+    inputs:
+      manifest_path:
+        description: "Path to manifest.json in the caller repository"
+        required: false
+        type: string
+        default: ""
+      manifest_uri:
+        description: "Remote manifest URI (file/http(s)/s3/gs/dbfs)"
+        required: false
+        type: string
+        default: ""
+      installer_repository:
+        description: "Repository to checkout for building dbt-nova (default: joe-broadhead/dbt-nova)"
+        required: false
+        type: string
+        default: "joe-broadhead/dbt-nova"
+      installer_ref:
+        description: "Git ref to checkout for installer_repository (defaults to resolved reusable workflow ref)"
+        required: false
+        type: string
+        default: ""
+      installer_install_mode:
+        description: "How to install dbt-nova in CI: auto (try release, fallback source), release, or source"
+        required: false
+        type: string
+        default: "auto"
+      dbt_generate_manifest:
+        description: "Whether to run dbt before auditing metadata"
+        required: false
+        type: boolean
+        default: false
+      dbt_command:
+        description: "Trusted shell command executed via bash -lc when dbt_generate_manifest=true"
+        required: false
+        type: string
+        default: ""
+      dbt_command_args_json:
+        description: "Structured dbt invocation args as JSON array (e.g. [\"parse\",\"--target\",\"prod\"])"
+        required: false
+        type: string
+        default: "[]"
+      dbt_executable:
+        description: "Executable used for structured dbt invocation when dbt_command_args_json is set"
+        required: false
+        type: string
+        default: "dbt"
+      dbt_allow_unsafe_executable:
+        description: "Allow non-dbt dbt_executable values (trusted callers only)"
+        required: false
+        type: boolean
+        default: false
+      dbt_env_json:
+        description: "JSON object of non-secret env vars exported before dbt invocation"
+        required: false
+        type: string
+        default: "{}"
+      dbt_secret_env_map_json:
+        description: "JSON object mapping env var names to secret names"
+        required: false
+        type: string
+        default: "{}"
+      selection_mode:
+        description: "Entity selection mode: project, changed, or entities"
+        required: false
+        type: string
+        default: "project"
+      changed_files_json:
+        description: "Optional JSON array of changed file paths when selection_mode=changed"
+        required: false
+        type: string
+        default: "[]"
+      entity_ids_json:
+        description: "Optional JSON array of explicit entity ids/names when selection_mode=entities"
+        required: false
+        type: string
+        default: "[]"
+      resource_types_json:
+        description: "JSON array of resource types to audit (default: [\"model\"])"
+        required: false
+        type: string
+        default: "[\"model\"]"
+      personas_json:
+        description: "JSON array of personas to score (default: [\"engineer\"])"
+        required: false
+        type: string
+        default: "[\"engineer\"]"
+      thresholds_json:
+        description: "JSON object describing persona-specific pass/fail thresholds"
+        required: false
+        type: string
+        default: >-
+          {"entity":{"engineer":{"min_score":70,"severity":"required"},"analyst":{"min_score":65,"severity":"advisory"},"governance":{"min_score":65,"severity":"advisory"}}}
+      include_breakdown:
+        description: "Include per-check metadata score breakdowns"
+        required: false
+        type: boolean
+        default: true
+      include_recommendations:
+        description: "Include metadata score recommendations"
+        required: false
+        type: boolean
+        default: true
+      fail_on_no_targets:
+        description: "Fail when the selection resolves to zero entities"
+        required: false
+        type: boolean
+        default: false
+      storage_instance_id:
+        description: "Optional stable storage instance id used for CLI manifest load"
+        required: false
+        type: string
+        default: "metadata-audit"
+      artifact_name_prefix:
+        description: "Prefix used when naming output artifacts"
+        required: false
+        type: string
+        default: "dbt-nova-metadata-audit"
+      retention_days:
+        description: "Artifact retention period in days (1-90)"
+        required: false
+        type: number
+        default: 14
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nova-metadata-audit-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    runs-on: ubuntu-22.04
+    outputs:
+      manifest_path: ${{ steps.resolve.outputs.manifest_path }}
+      manifest_uri: ${{ steps.resolve.outputs.manifest_uri }}
+      installer_repository: ${{ steps.resolve.outputs.installer_repository }}
+      installer_ref: ${{ steps.resolve.outputs.installer_ref }}
+      installer_install_mode: ${{ steps.resolve.outputs.installer_install_mode }}
+      dbt_invocation_mode: ${{ steps.resolve.outputs.dbt_invocation_mode }}
+      dbt_command_args_json: ${{ steps.resolve.outputs.dbt_command_args_json }}
+      dbt_executable: ${{ steps.resolve.outputs.dbt_executable }}
+      dbt_env_json: ${{ steps.resolve.outputs.dbt_env_json }}
+      dbt_secret_env_map_json: ${{ steps.resolve.outputs.dbt_secret_env_map_json }}
+      selection_mode: ${{ steps.resolve.outputs.selection_mode }}
+      changed_files_json: ${{ steps.resolve.outputs.changed_files_json }}
+      entity_ids_json: ${{ steps.resolve.outputs.entity_ids_json }}
+      resource_types_json: ${{ steps.resolve.outputs.resource_types_json }}
+      personas_json: ${{ steps.resolve.outputs.personas_json }}
+      thresholds_json: ${{ steps.resolve.outputs.thresholds_json }}
+      storage_instance_id: ${{ steps.resolve.outputs.storage_instance_id }}
+      artifact_name_report_json: ${{ steps.resolve.outputs.artifact_name_report_json }}
+      artifact_name_report_md: ${{ steps.resolve.outputs.artifact_name_report_md }}
+      retention_days: ${{ steps.resolve.outputs.retention_days }}
+    steps:
+      - name: Resolve contract
+        id: resolve
+        shell: bash
+        env:
+          INPUT_MANIFEST_PATH: ${{ inputs.manifest_path }}
+          INPUT_MANIFEST_URI: ${{ inputs.manifest_uri }}
+          INPUT_INSTALLER_REPOSITORY: ${{ inputs.installer_repository }}
+          INPUT_INSTALLER_REF: ${{ inputs.installer_ref }}
+          INPUT_INSTALLER_INSTALL_MODE: ${{ inputs.installer_install_mode }}
+          INPUT_DBT_GENERATE_MANIFEST: ${{ inputs.dbt_generate_manifest }}
+          INPUT_DBT_COMMAND: ${{ inputs.dbt_command }}
+          INPUT_DBT_COMMAND_ARGS_JSON: ${{ inputs.dbt_command_args_json }}
+          INPUT_DBT_EXECUTABLE: ${{ inputs.dbt_executable }}
+          INPUT_DBT_ALLOW_UNSAFE_EXECUTABLE: ${{ inputs.dbt_allow_unsafe_executable }}
+          INPUT_DBT_ENV_JSON: ${{ inputs.dbt_env_json }}
+          INPUT_DBT_SECRET_ENV_MAP_JSON: ${{ inputs.dbt_secret_env_map_json }}
+          INPUT_SELECTION_MODE: ${{ inputs.selection_mode }}
+          INPUT_CHANGED_FILES_JSON: ${{ inputs.changed_files_json }}
+          INPUT_ENTITY_IDS_JSON: ${{ inputs.entity_ids_json }}
+          INPUT_RESOURCE_TYPES_JSON: ${{ inputs.resource_types_json }}
+          INPUT_PERSONAS_JSON: ${{ inputs.personas_json }}
+          INPUT_THRESHOLDS_JSON: ${{ inputs.thresholds_json }}
+          INPUT_STORAGE_INSTANCE_ID: ${{ inputs.storage_instance_id }}
+          INPUT_ARTIFACT_NAME_PREFIX: ${{ inputs.artifact_name_prefix }}
+          INPUT_RETENTION_DAYS: ${{ inputs.retention_days }}
+          JOB_WORKFLOW_REF: ${{ github.job_workflow_ref }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          ACTION_REPOSITORY: ${{ github.action_repository }}
+          CURRENT_REPOSITORY: ${{ github.repository }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import sys
+
+          def fail(message: str) -> None:
+              print(message, file=sys.stderr)
+              sys.exit(1)
+
+          def parse_json_array(raw: str, name: str):
+              try:
+                  payload = json.loads(raw)
+              except json.JSONDecodeError as exc:
+                  fail(f"{name} must be valid JSON: {exc}")
+              if not isinstance(payload, list) or any(not isinstance(v, str) for v in payload):
+                  fail(f"{name} must be a JSON array of strings.")
+              return payload
+
+          def parse_json_object(raw: str, name: str):
+              try:
+                  payload = json.loads(raw)
+              except json.JSONDecodeError as exc:
+                  fail(f"{name} must be valid JSON: {exc}")
+              if not isinstance(payload, dict):
+                  fail(f"{name} must be a JSON object.")
+              return payload
+
+          manifest_path = os.environ["INPUT_MANIFEST_PATH"].strip()
+          manifest_uri = os.environ["INPUT_MANIFEST_URI"].strip()
+          installer_repository = os.environ["INPUT_INSTALLER_REPOSITORY"].strip()
+          installer_ref = os.environ["INPUT_INSTALLER_REF"].strip()
+          installer_install_mode = os.environ["INPUT_INSTALLER_INSTALL_MODE"].strip()
+          dbt_generate_manifest = os.environ["INPUT_DBT_GENERATE_MANIFEST"].strip().lower()
+          dbt_command = os.environ["INPUT_DBT_COMMAND"]
+          dbt_command_args_json = os.environ["INPUT_DBT_COMMAND_ARGS_JSON"]
+          dbt_executable = os.environ["INPUT_DBT_EXECUTABLE"].strip() or "dbt"
+          dbt_allow_unsafe_executable = os.environ["INPUT_DBT_ALLOW_UNSAFE_EXECUTABLE"].strip().lower()
+          dbt_env_json = os.environ["INPUT_DBT_ENV_JSON"]
+          dbt_secret_env_map_json = os.environ["INPUT_DBT_SECRET_ENV_MAP_JSON"]
+          selection_mode = os.environ["INPUT_SELECTION_MODE"].strip().lower() or "project"
+          changed_files_json = os.environ["INPUT_CHANGED_FILES_JSON"]
+          entity_ids_json = os.environ["INPUT_ENTITY_IDS_JSON"]
+          resource_types_json = os.environ["INPUT_RESOURCE_TYPES_JSON"]
+          personas_json = os.environ["INPUT_PERSONAS_JSON"]
+          thresholds_json = os.environ["INPUT_THRESHOLDS_JSON"]
+          storage_instance_id = os.environ["INPUT_STORAGE_INSTANCE_ID"].strip() or "metadata-audit"
+          artifact_name_prefix = os.environ["INPUT_ARTIFACT_NAME_PREFIX"].strip() or "dbt-nova-metadata-audit"
+          retention_days = os.environ["INPUT_RETENTION_DAYS"].strip()
+          job_workflow_ref = os.environ.get("JOB_WORKFLOW_REF", "")
+          workflow_ref = os.environ.get("WORKFLOW_REF", "")
+          action_repository = os.environ.get("ACTION_REPOSITORY", "")
+          current_repository = os.environ.get("CURRENT_REPOSITORY", "")
+          current_sha = os.environ.get("CURRENT_SHA", "")
+
+          if not manifest_path and not manifest_uri and dbt_generate_manifest != "true":
+              fail("Provide manifest_path or manifest_uri, or set dbt_generate_manifest=true.")
+          if manifest_path and manifest_uri:
+              fail("Provide only one of manifest_path or manifest_uri.")
+          if not manifest_path and not manifest_uri and dbt_generate_manifest == "true":
+              manifest_path = "target/manifest.json"
+
+          if installer_install_mode not in {"auto", "release", "source"}:
+              fail("installer_install_mode must be one of: auto, release, source.")
+
+          if installer_repository and not re.match(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$", installer_repository):
+              fail("installer_repository must match owner/repo.")
+
+          parse_json_array(dbt_command_args_json, "dbt_command_args_json")
+          parse_json_object(dbt_env_json, "dbt_env_json")
+          parse_json_object(dbt_secret_env_map_json, "dbt_secret_env_map_json")
+          parse_json_array(changed_files_json, "changed_files_json")
+          parse_json_array(entity_ids_json, "entity_ids_json")
+          parse_json_array(resource_types_json, "resource_types_json")
+          parse_json_array(personas_json, "personas_json")
+          parse_json_object(thresholds_json, "thresholds_json")
+
+          if selection_mode not in {"project", "changed", "entities"}:
+              fail("selection_mode must be one of: project, changed, entities.")
+
+          dbt_invocation_mode = "none"
+          if dbt_generate_manifest == "true":
+              trusted = bool(dbt_command.strip())
+              structured = len(json.loads(dbt_command_args_json)) > 0
+              if trusted and structured:
+                  fail("Provide only one of dbt_command or dbt_command_args_json.")
+              if not trusted and not structured:
+                  fail("dbt_generate_manifest=true requires dbt_command or dbt_command_args_json.")
+              dbt_invocation_mode = "structured" if structured else "trusted_shell"
+          elif dbt_command.strip() or len(json.loads(dbt_command_args_json)) > 0:
+              fail("dbt_command/dbt_command_args_json require dbt_generate_manifest=true.")
+
+          if " " in dbt_executable:
+              fail("dbt_executable must not contain whitespace.")
+          if dbt_allow_unsafe_executable != "true":
+              if not re.match(r"(^|.*/)(dbt|dbt\\.exe)$", dbt_executable):
+                  fail("dbt_executable must resolve to dbt/dbt.exe unless dbt_allow_unsafe_executable=true.")
+
+          if not re.match(r"^[A-Za-z0-9._-]+$", storage_instance_id):
+              fail("storage_instance_id must match ^[A-Za-z0-9._-]+$.")
+          if not re.match(r"^[A-Za-z0-9._-]+$", artifact_name_prefix):
+              fail("artifact_name_prefix must match ^[A-Za-z0-9._-]+$.")
+          if not retention_days.isdigit() or not (1 <= int(retention_days) <= 90):
+              fail("retention_days must be an integer between 1 and 90.")
+
+          if (not installer_repository or not installer_ref) and job_workflow_ref and "/.github/workflows/" in job_workflow_ref and "@" in job_workflow_ref:
+              workflow_repository = job_workflow_ref.split("/.github/workflows/")[0]
+              workflow_ref_value = job_workflow_ref.rsplit("@", 1)[1]
+              if not installer_repository:
+                  installer_repository = workflow_repository
+              if not installer_ref and installer_repository == workflow_repository:
+                  installer_ref = workflow_ref_value
+          if (not installer_repository or not installer_ref) and workflow_ref and "/.github/workflows/" in workflow_ref and "@" in workflow_ref:
+              workflow_repository = workflow_ref.split("/.github/workflows/")[0]
+              workflow_ref_value = workflow_ref.rsplit("@", 1)[1]
+              if not installer_repository:
+                  installer_repository = workflow_repository
+              if not installer_ref:
+                  installer_ref = workflow_ref_value
+          if not installer_repository:
+              installer_repository = action_repository or current_repository
+          if installer_ref.startswith("refs/heads/"):
+              installer_ref = installer_ref[len("refs/heads/"):]
+          if installer_ref.startswith("refs/tags/"):
+              installer_ref = installer_ref[len("refs/tags/"):]
+          if not installer_ref and installer_repository == current_repository and current_sha:
+              installer_ref = current_sha
+          if not installer_repository or not installer_ref:
+              fail("failed to resolve installer_repository/installer_ref; set installer_ref explicitly.")
+
+          run_suffix = os.environ.get("GITHUB_RUN_ID", "local")
+          artifact_name_report_json = f"{artifact_name_prefix}-report-{run_suffix}"
+          artifact_name_report_md = f"{artifact_name_prefix}-report-md-{run_suffix}"
+
+          outputs = {
+              "manifest_path": manifest_path,
+              "manifest_uri": manifest_uri,
+              "installer_repository": installer_repository,
+              "installer_ref": installer_ref,
+              "installer_install_mode": installer_install_mode,
+              "dbt_invocation_mode": dbt_invocation_mode,
+              "dbt_command_args_json": json.dumps(json.loads(dbt_command_args_json), separators=(",", ":")),
+              "dbt_executable": dbt_executable,
+              "dbt_env_json": json.dumps(json.loads(dbt_env_json), separators=(",", ":")),
+              "dbt_secret_env_map_json": json.dumps(json.loads(dbt_secret_env_map_json), separators=(",", ":")),
+              "selection_mode": selection_mode,
+              "changed_files_json": json.dumps(json.loads(changed_files_json), separators=(",", ":")),
+              "entity_ids_json": json.dumps(json.loads(entity_ids_json), separators=(",", ":")),
+              "resource_types_json": json.dumps(json.loads(resource_types_json), separators=(",", ":")),
+              "personas_json": json.dumps(json.loads(personas_json), separators=(",", ":")),
+              "thresholds_json": json.dumps(json.loads(thresholds_json), separators=(",", ":")),
+              "storage_instance_id": storage_instance_id,
+              "artifact_name_report_json": artifact_name_report_json,
+              "artifact_name_report_md": artifact_name_report_md,
+              "retention_days": retention_days,
+          }
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              for key, value in outputs.items():
+                  fh.write(f"{key}={value}\n")
+          PY
+
+      - name: Summarize contract
+        shell: bash
+        run: |
+          {
+            echo "### Reusable Workflow Contract"
+            echo
+            echo "- installer_repository: \`${{ steps.resolve.outputs.installer_repository }}\`"
+            echo "- installer_ref: \`${{ steps.resolve.outputs.installer_ref }}\`"
+            echo "- installer_install_mode: \`${{ steps.resolve.outputs.installer_install_mode }}\`"
+            echo "- selection_mode: \`${{ steps.resolve.outputs.selection_mode }}\`"
+            echo "- resource_types_json: \`${{ steps.resolve.outputs.resource_types_json }}\`"
+            echo "- personas_json: \`${{ steps.resolve.outputs.personas_json }}\`"
+            echo "- storage_instance_id: \`${{ steps.resolve.outputs.storage_instance_id }}\`"
+            echo "- artifact_name_report_json: \`${{ steps.resolve.outputs.artifact_name_report_json }}\`"
+            echo "- artifact_name_report_md: \`${{ steps.resolve.outputs.artifact_name_report_md }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  audit:
+    runs-on: ubuntu-22.04
+    needs: prepare
+    timeout-minutes: 60
+    outputs:
+      gate_status: ${{ steps.collect.outputs.gate_status }}
+      target_count: ${{ steps.collect.outputs.target_count }}
+      scored_count: ${{ steps.collect.outputs.scored_count }}
+      required_fail_count: ${{ steps.collect.outputs.required_fail_count }}
+      advisory_fail_count: ${{ steps.collect.outputs.advisory_fail_count }}
+      artifact_name_report_json: ${{ needs.prepare.outputs.artifact_name_report_json }}
+      artifact_name_report_md: ${{ needs.prepare.outputs.artifact_name_report_md }}
+    env:
+      DBT_NOVA_SEARCH_ENABLE_VECTOR: "false"
+      DBT_NOVA_SEARCH_ENABLE_SPARSE: "false"
+      DBT_NOVA_SEARCH_ENABLE_RERANKER: "false"
+      DBT_NOVA_SEARCH_ENABLE_NGRAM: "false"
+      DBT_NOVA_COLUMN_LINEAGE_PRECOMPUTE: "false"
+    steps:
+      - name: Checkout caller repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+
+      - name: Install jq
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Install dbt-nova from release assets
+        id: install_release
+        if: ${{ needs.prepare.outputs.installer_install_mode != 'source' }}
+        shell: bash
+        env:
+          INSTALLER_REPOSITORY: ${{ needs.prepare.outputs.installer_repository }}
+          INSTALLER_REF: ${{ needs.prepare.outputs.installer_ref }}
+          INSTALLER_INSTALL_MODE: ${{ needs.prepare.outputs.installer_install_mode }}
+        run: |
+          set -euo pipefail
+          base_url="https://github.com/${INSTALLER_REPOSITORY}/releases/download/${INSTALLER_REF}"
+          work_dir="${RUNNER_TEMP}/dbt-nova-release-install"
+          tarball_path="${work_dir}/dbt-nova-linux-x86_64.tar.gz"
+          checksum_path="${work_dir}/dbt-nova-linux-x86_64.sha256"
+          mkdir -p "${work_dir}"
+
+          download_asset() {
+            local asset_name="$1"
+            local destination_path="$2"
+            local asset_url="${base_url}/${asset_name}"
+            curl --fail --location --silent --show-error --output "${destination_path}" "${asset_url}"
+          }
+
+          if ! download_asset "dbt-nova-linux-x86_64.tar.gz" "${tarball_path}"; then
+            if [[ "${INSTALLER_INSTALL_MODE}" == "auto" ]]; then
+              echo "installed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            exit 1
+          fi
+          if ! download_asset "dbt-nova-linux-x86_64.sha256" "${checksum_path}"; then
+            if [[ "${INSTALLER_INSTALL_MODE}" == "auto" ]]; then
+              echo "installed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            exit 1
+          fi
+
+          expected_sha="$(awk '{print $1}' "${checksum_path}")"
+          actual_sha="$(sha256sum "${tarball_path}" | awk '{print $1}')"
+          if [[ -z "${expected_sha}" || "${expected_sha}" != "${actual_sha}" ]]; then
+            echo "release checksum mismatch"
+            exit 1
+          fi
+
+          tar -xzf "${tarball_path}" -C "${work_dir}"
+          binary_path="$(find "${work_dir}" -maxdepth 2 -type f -name dbt-nova | head -n 1)"
+          [[ -n "${binary_path}" ]]
+          mkdir -p "$HOME/.local/bin"
+          install -m 755 "${binary_path}" "$HOME/.local/bin/dbt-nova"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "installed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout installer source
+        if: ${{ needs.prepare.outputs.installer_install_mode == 'source' || (needs.prepare.outputs.installer_install_mode == 'auto' && steps.install_release.outputs.installed != 'true') }}
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          repository: ${{ needs.prepare.outputs.installer_repository }}
+          ref: ${{ needs.prepare.outputs.installer_ref }}
+          path: .nova-installer-source
+          fetch-depth: 1
+
+      - name: Install Rust toolchain
+        if: ${{ needs.prepare.outputs.installer_install_mode == 'source' || (needs.prepare.outputs.installer_install_mode == 'auto' && steps.install_release.outputs.installed != 'true') }}
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
+
+      - name: Rust cache (installer source)
+        if: ${{ needs.prepare.outputs.installer_install_mode == 'source' || (needs.prepare.outputs.installer_install_mode == 'auto' && steps.install_release.outputs.installed != 'true') }}
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        with:
+          workspaces: ".nova-installer-source -> target"
+
+      - name: Build dbt-nova from pinned workflow source
+        if: ${{ needs.prepare.outputs.installer_install_mode == 'source' || (needs.prepare.outputs.installer_install_mode == 'auto' && steps.install_release.outputs.installed != 'true') }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --locked --release --manifest-path .nova-installer-source/Cargo.toml
+          mkdir -p "$HOME/.local/bin"
+          install -m 755 .nova-installer-source/target/release/dbt-nova "$HOME/.local/bin/dbt-nova"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Optionally generate manifest via dbt
+        if: ${{ inputs.dbt_generate_manifest }}
+        shell: bash
+        env:
+          INPUT_DBT_COMMAND: ${{ inputs.dbt_command }}
+          INPUT_DBT_INVOCATION_MODE: ${{ needs.prepare.outputs.dbt_invocation_mode }}
+          INPUT_DBT_COMMAND_ARGS_JSON: ${{ needs.prepare.outputs.dbt_command_args_json }}
+          INPUT_DBT_EXECUTABLE: ${{ needs.prepare.outputs.dbt_executable }}
+          INPUT_DBT_ENV_JSON: ${{ needs.prepare.outputs.dbt_env_json }}
+          INPUT_DBT_SECRET_ENV_MAP_JSON: ${{ needs.prepare.outputs.dbt_secret_env_map_json }}
+          INHERITED_SECRETS_JSON: ${{ toJSON(secrets) }}
+          DBT_NOVA_SECRET_BUNDLE_JSON: ${{ secrets.DBT_NOVA_SECRET_BUNDLE_JSON || '' }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import subprocess
+          import sys
+
+          mode = os.environ["INPUT_DBT_INVOCATION_MODE"]
+          command = os.environ["INPUT_DBT_COMMAND"]
+          command_args = json.loads(os.environ["INPUT_DBT_COMMAND_ARGS_JSON"])
+          executable = os.environ["INPUT_DBT_EXECUTABLE"]
+          plain_env = json.loads(os.environ["INPUT_DBT_ENV_JSON"])
+          secret_env_map = json.loads(os.environ["INPUT_DBT_SECRET_ENV_MAP_JSON"])
+          inherited_secrets = json.loads(os.environ["INHERITED_SECRETS_JSON"])
+          secret_bundle_raw = os.environ.get("DBT_NOVA_SECRET_BUNDLE_JSON", "").strip()
+          secret_bundle = json.loads(secret_bundle_raw) if secret_bundle_raw else {}
+
+          runtime_env = os.environ.copy()
+          for helper_var in (
+              "INHERITED_SECRETS_JSON",
+              "INPUT_DBT_ENV_JSON",
+              "INPUT_DBT_SECRET_ENV_MAP_JSON",
+              "INPUT_DBT_COMMAND",
+              "DBT_NOVA_SECRET_BUNDLE_JSON",
+          ):
+              runtime_env.pop(helper_var, None)
+
+          for env_name, env_value in plain_env.items():
+              runtime_env[env_name] = env_value
+
+          def add_mask(secret_value: str) -> None:
+              escaped_value = (
+                  secret_value.replace("%", "%25")
+                  .replace("\r", "%0D")
+                  .replace("\n", "%0A")
+              )
+              print(f"::add-mask::{escaped_value}")
+
+          for env_name, secret_name in secret_env_map.items():
+              secret_value = secret_bundle.get(secret_name)
+              if not isinstance(secret_value, str) or not secret_value:
+                  secret_value = inherited_secrets.get(secret_name, "")
+              if not secret_value:
+                  print(
+                      f"missing secret '{secret_name}' requested by dbt_secret_env_map_json for env var '{env_name}'",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+              add_mask(secret_value)
+              runtime_env[env_name] = secret_value
+
+          if mode == "trusted_shell":
+              completed = subprocess.run(["bash", "-lc", command], env=runtime_env, check=False)
+          elif mode == "structured":
+              completed = subprocess.run([executable, *command_args], env=runtime_env, check=False)
+          else:
+              print(f"unsupported dbt invocation mode '{mode}'", file=sys.stderr)
+              sys.exit(1)
+          sys.exit(completed.returncode)
+          PY
+
+      - name: Resolve changed files when omitted
+        id: changed_files
+        shell: bash
+        env:
+          SELECTION_MODE: ${{ needs.prepare.outputs.selection_mode }}
+          INPUT_CHANGED_FILES_JSON: ${{ needs.prepare.outputs.changed_files_json }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          changed_files_json="${INPUT_CHANGED_FILES_JSON}"
+          if [[ "${SELECTION_MODE}" == "changed" && "${changed_files_json}" == "[]" && -n "${BASE_REF}" ]]; then
+            git fetch --no-tags --depth=1 origin "${BASE_REF}"
+            changed_files_json="$(
+              git diff --name-only "origin/${BASE_REF}...${GITHUB_SHA}" | \
+                jq -R -s -c 'split("\n") | map(select(length > 0))'
+            )"
+          fi
+          echo "changed_files_json=${changed_files_json}" >> "$GITHUB_OUTPUT"
+
+      - name: Run metadata audit
+        id: audit
+        shell: bash
+        env:
+          INPUT_MANIFEST_PATH: ${{ needs.prepare.outputs.manifest_path }}
+          INPUT_MANIFEST_URI: ${{ needs.prepare.outputs.manifest_uri }}
+          INPUT_STORAGE_INSTANCE_ID: ${{ needs.prepare.outputs.storage_instance_id }}
+          INPUT_SELECTION_MODE: ${{ needs.prepare.outputs.selection_mode }}
+          INPUT_CHANGED_FILES_JSON: ${{ steps.changed_files.outputs.changed_files_json }}
+          INPUT_ENTITY_IDS_JSON: ${{ needs.prepare.outputs.entity_ids_json }}
+          INPUT_RESOURCE_TYPES_JSON: ${{ needs.prepare.outputs.resource_types_json }}
+          INPUT_PERSONAS_JSON: ${{ needs.prepare.outputs.personas_json }}
+          INPUT_THRESHOLDS_JSON: ${{ needs.prepare.outputs.thresholds_json }}
+          INPUT_INCLUDE_BREAKDOWN: ${{ inputs.include_breakdown }}
+          INPUT_INCLUDE_RECOMMENDATIONS: ${{ inputs.include_recommendations }}
+          INPUT_FAIL_ON_NO_TARGETS: ${{ inputs.fail_on_no_targets }}
+          REPORT_JSON_PATH: out/metadata-audit-report.json
+          REPORT_MD_PATH: out/metadata-audit-report.md
+        run: |
+          set +e
+          mkdir -p out
+          args=(audit metadata-score
+            --selection-mode "${INPUT_SELECTION_MODE}"
+            --resource-types-json "${INPUT_RESOURCE_TYPES_JSON}"
+            --personas-json "${INPUT_PERSONAS_JSON}"
+            --thresholds-json "${INPUT_THRESHOLDS_JSON}"
+            --storage-instance-id "${INPUT_STORAGE_INSTANCE_ID}"
+            --report-json-path "${REPORT_JSON_PATH}"
+            --report-md-path "${REPORT_MD_PATH}"
+            --include-breakdown "${INPUT_INCLUDE_BREAKDOWN}"
+            --include-recommendations "${INPUT_INCLUDE_RECOMMENDATIONS}"
+            --json
+          )
+          if [[ "${INPUT_FAIL_ON_NO_TARGETS}" == "true" ]]; then
+            args+=(--fail-on-no-targets)
+          fi
+          if [[ -n "${INPUT_MANIFEST_PATH}" ]]; then
+            args+=(--manifest-path "${INPUT_MANIFEST_PATH}")
+          fi
+          if [[ -n "${INPUT_MANIFEST_URI}" ]]; then
+            args+=(--manifest-uri "${INPUT_MANIFEST_URI}")
+          fi
+          if [[ "${INPUT_SELECTION_MODE}" == "changed" ]]; then
+            args+=(--changed-files-json "${INPUT_CHANGED_FILES_JSON}")
+          fi
+          if [[ "${INPUT_SELECTION_MODE}" == "entities" ]]; then
+            args+=(--entity-ids-json "${INPUT_ENTITY_IDS_JSON}")
+          fi
+          dbt-nova "${args[@]}" | tee out/metadata-audit-cli.json
+          exit_code="${PIPESTATUS[0]}"
+          echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Collect audit outputs
+        id: collect
+        if: ${{ always() && hashFiles('out/metadata-audit-report.json') != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          report_path="out/metadata-audit-report.json"
+          gate_status="$(jq -r '.gate_status' "${report_path}")"
+          target_count="$(jq -r '.target_count' "${report_path}")"
+          scored_count="$(jq -r '.scored_count' "${report_path}")"
+          required_fail_count="$(jq -r '.summary.required_fail_count' "${report_path}")"
+          advisory_fail_count="$(jq -r '.summary.advisory_fail_count' "${report_path}")"
+          echo "gate_status=${gate_status}" >> "$GITHUB_OUTPUT"
+          echo "target_count=${target_count}" >> "$GITHUB_OUTPUT"
+          echo "scored_count=${scored_count}" >> "$GITHUB_OUTPUT"
+          echo "required_fail_count=${required_fail_count}" >> "$GITHUB_OUTPUT"
+          echo "advisory_fail_count=${advisory_fail_count}" >> "$GITHUB_OUTPUT"
+
+      - name: Append audit summary
+        if: ${{ always() && hashFiles('out/metadata-audit-report.md') != '' }}
+        shell: bash
+        run: cat out/metadata-audit-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload JSON report artifact
+        if: ${{ always() && hashFiles('out/metadata-audit-report.json') != '' }}
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        with:
+          name: ${{ needs.prepare.outputs.artifact_name_report_json }}
+          path: out/metadata-audit-report.json
+          retention-days: ${{ fromJSON(needs.prepare.outputs.retention_days) }}
+
+      - name: Upload Markdown report artifact
+        if: ${{ always() && hashFiles('out/metadata-audit-report.md') != '' }}
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        with:
+          name: ${{ needs.prepare.outputs.artifact_name_report_md }}
+          path: out/metadata-audit-report.md
+          retention-days: ${{ fromJSON(needs.prepare.outputs.retention_days) }}
+
+      - name: Upload CLI output artifact
+        if: ${{ always() && hashFiles('out/metadata-audit-cli.json') != '' }}
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        with:
+          name: ${{ needs.prepare.outputs.artifact_name_report_json }}-cli
+          path: out/metadata-audit-cli.json
+          retention-days: ${{ fromJSON(needs.prepare.outputs.retention_days) }}
+
+      - name: Fail on audit gate
+        if: ${{ steps.audit.outputs.exit_code != '0' }}
+        shell: bash
+        run: exit "${{ steps.audit.outputs.exit_code }}"

--- a/.github/workflows/nova-metadata-audit.yml
+++ b/.github/workflows/nova-metadata-audit.yml
@@ -277,10 +277,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: nova-metadata-audit-${{ github.repository }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   prepare:
     runs-on: ubuntu-22.04
@@ -522,6 +518,9 @@ jobs:
     runs-on: ubuntu-22.04
     needs: prepare
     timeout-minutes: 60
+    concurrency:
+      group: nova-metadata-audit-${{ github.repository }}-${{ needs.prepare.outputs.storage_instance_id }}
+      cancel-in-progress: false
     outputs:
       gate_status: ${{ steps.collect.outputs.gate_status }}
       target_count: ${{ steps.collect.outputs.target_count }}

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -57,6 +57,41 @@ Operational defaults:
   for compatibility and currently return `{}`; consumers should read the
   publish-summary artifact JSON.
 
+### Reusable Nova Metadata Audit Workflow
+
+- **File:** `.github/workflows/nova-metadata-audit.yml`
+- **Use:** reusable workflow invoked by CI and downstream repos for
+  metadata-quality gates and recurring audit reports
+- **Inputs:** follows the same installer and dbt invocation contract as
+  `.github/workflows/nova-build-assets.yml`:
+  `manifest_path` or `manifest_uri`, `storage_instance_id`, optional dbt
+  manifest generation with structured invocation
+  (`dbt_command_args_json`, optional `dbt_executable`,
+  optional `dbt_allow_unsafe_executable`) or trusted shell invocation
+  (`dbt_command`), plus `dbt_env_json`, `dbt_secret_env_map_json`, optional
+  workflow_call secret bundle (`DBT_NOVA_SECRET_BUNDLE_JSON`), and optional
+  installer source override (`installer_repository`, `installer_ref`,
+  `installer_install_mode`)
+- **Audit inputs:** `selection_mode` (`project|changed|entities`),
+  `changed_files_json`, `entity_ids_json`, `resource_types_json`,
+  `personas_json`, `thresholds_json`, `include_breakdown`,
+  `include_recommendations`, and `fail_on_no_targets`
+- **Outputs:** `gate_status`, `target_count`, `scored_count`,
+  `required_fail_count`, `advisory_fail_count`, and report artifact names
+- **Performance defaults:** disables dense vectors, sparse vectors, reranking,
+  n-grams, and column-lineage precompute so CI can run metadata-only audits
+  without paying for full search startup
+- **Artifacts:** uploads JSON and Markdown audit reports and appends the
+  Markdown report to `GITHUB_STEP_SUMMARY`
+
+### Reusable Workflow Smoke Coverage
+
+- **File:** `.github/workflows/ci.yml`
+- **Action:** smoke-tests both reusable workflows directly from the repo
+- **Metadata audit checks:** exercises `project`, `changed`, and `entities`
+  selection modes, plus both structured and trusted dbt manifest generation
+  paths
+
 ### Prepare Release
 
 - **File:** `.github/workflows/release-prepare.yml`

--- a/docs/features/metadata-audit.md
+++ b/docs/features/metadata-audit.md
@@ -60,6 +60,10 @@ Rules:
 - `severity: required` fails the command
 - `severity: advisory` reports the miss without failing
 - if `min_score` and `min_grade` are both set, both must pass
+- `entity` thresholds apply to `changed` and `entities` selection modes
+- `project` thresholds apply to the aggregate project score when
+  `selection_mode=project`; the per-entity table remains informational in that
+  mode
 
 ## Reports
 

--- a/docs/features/metadata-audit.md
+++ b/docs/features/metadata-audit.md
@@ -1,0 +1,91 @@
+# Metadata Audit
+
+Nova includes a CLI-first metadata audit flow for CI gates and recurring
+quality reports.
+
+Use:
+
+- `dbt-nova audit metadata-score`
+
+This command loads a dbt manifest, scores selected entities with the existing
+metadata scoring rubric, and produces:
+
+- JSON report
+- Markdown report
+- required/advisory pass-fail gate result
+
+## Selection Modes
+
+- `project`: score all selected resource types
+- `changed`: score entities whose `original_file_path` or `patch_path` matches
+  changed files
+- `entities`: score explicit entity ids or unique names
+
+## Common PR Gate
+
+```bash
+dbt-nova audit metadata-score \
+  --selection-mode changed \
+  --changed-files-json '["models/marts/orders.sql","models/marts/orders.yml"]' \
+  --resource-types-json '["model"]' \
+  --personas-json '["engineer","analyst","governance"]' \
+  --thresholds-json '{"entity":{"engineer":{"min_score":70,"severity":"required"},"analyst":{"min_score":65,"severity":"advisory"},"governance":{"min_score":65,"severity":"advisory"}}}' \
+  --manifest-path target/manifest.json \
+  --report-json-path out/metadata-audit.json \
+  --report-md-path out/metadata-audit.md \
+  --json
+```
+
+## Threshold Contract
+
+Thresholds are supplied as JSON.
+
+Example:
+
+```json
+{
+  "entity": {
+    "engineer": { "min_score": 70, "severity": "required" },
+    "analyst": { "min_score": 65, "severity": "advisory" },
+    "governance": { "min_score": 65, "severity": "advisory" }
+  },
+  "project": {
+    "engineer": { "min_score": 80, "severity": "required" }
+  }
+}
+```
+
+Rules:
+
+- `severity: required` fails the command
+- `severity: advisory` reports the miss without failing
+- if `min_score` and `min_grade` are both set, both must pass
+
+## Reports
+
+JSON reports include:
+
+- manifest hash/version
+- selected entities
+- per-persona scores
+- per-category breakdowns
+- recommendations
+- gate summary
+
+Markdown reports include:
+
+- overall gate status
+- scored target count
+- pass/fail counts
+- compact per-entity table
+- top findings for failing entities
+
+## CI Workflow
+
+The repository also provides a reusable workflow:
+
+- `.github/workflows/nova-metadata-audit.yml`
+
+It follows the same installer and dbt invocation standards as the reusable
+asset workflow, but disables vector, sparse, and reranker search so CI does not
+pay for full search/model startup during metadata-only audits.

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -13,6 +13,7 @@ dbt-nova
 ├── manifest load [--manifest-path|--manifest-uri] [--storage-instance-id] [--cleanup-storage-on-start] [--read-only] [--json]
 ├── manifest reload [--manifest-path|--manifest-uri] [--refresh-secs] [--storage-instance-id] [--cleanup-storage-on-start] [--read-only] [--json]
 ├── tool call <tool_name> [--params-json|--params-file|--params-stdin] [--manifest-path|--manifest-uri] [--storage-instance-id] [--cleanup-storage-on-start] [--read-only] [--json]
+├── audit metadata-score [--selection-mode] [--changed-files-json|--changed-files-file] [--entity-ids-json|--entity-ids-file] [--resource-types-json] [--personas-json] [--thresholds-json|--thresholds-file] [--manifest-path|--manifest-uri] [--storage-instance-id] [--report-json-path] [--report-md-path] [--fail-on-no-targets] [--json]
 ├── config show [--defaults] [--json]
 ├── config validate [--json]
 ├── storage inspect [--storage-instance-id] [--json]
@@ -74,6 +75,21 @@ dbt-nova manifest reload \
 dbt-nova tool call search \
   --params-json '{"query":"orders","limit":5}' \
   --manifest-path /path/to/target/manifest.json
+```
+
+### Metadata audit for changed models
+
+```bash
+dbt-nova audit metadata-score \
+  --selection-mode changed \
+  --changed-files-json '["models/marts/orders.sql","models/marts/orders.yml"]' \
+  --resource-types-json '["model"]' \
+  --personas-json '["engineer","analyst","governance"]' \
+  --thresholds-json '{"entity":{"engineer":{"min_score":70,"severity":"required"},"analyst":{"min_score":65,"severity":"advisory"},"governance":{"min_score":65,"severity":"advisory"}}}' \
+  --manifest-path /path/to/target/manifest.json \
+  --report-json-path out/metadata-audit.json \
+  --report-md-path out/metadata-audit.md \
+  --json
 ```
 
 ### Health diagnostics

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,7 @@ nav:
   - Features:
     - Analysis Recipes: features/recipes.md
     - Column Lineage: features/column-lineage.md
+    - Metadata Audit: features/metadata-audit.md
     - Metadata Scoring: features/metadata-scoring.md
     - Search Ranking: features/search-ranking.md
     - Persona Summaries: features/persona-summaries.md

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -12,6 +12,7 @@ pub enum Command {
     Server(ServerArgs),
     Manifest(ManifestArgs),
     Tool(ToolArgs),
+    Audit(AuditArgs),
     Config(ConfigArgs),
     Storage(StorageArgs),
     Health(HealthArgs),
@@ -131,6 +132,70 @@ pub struct ToolCallArgs {
 }
 
 #[derive(Debug, Args)]
+pub struct AuditArgs {
+    #[command(subcommand)]
+    pub command: AuditCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum AuditCommand {
+    MetadataScore(MetadataAuditArgs),
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq, Default)]
+pub enum MetadataAuditSelectionModeArg {
+    #[default]
+    Project,
+    Changed,
+    Entities,
+}
+
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Args, Default)]
+pub struct MetadataAuditArgs {
+    #[arg(long, value_enum, default_value_t = MetadataAuditSelectionModeArg::Project)]
+    pub selection_mode: MetadataAuditSelectionModeArg,
+    #[arg(long, value_name = "JSON", conflicts_with = "changed_files_file")]
+    pub changed_files_json: Option<String>,
+    #[arg(long, value_name = "PATH", conflicts_with = "changed_files_json")]
+    pub changed_files_file: Option<String>,
+    #[arg(long, value_name = "JSON", conflicts_with = "entity_ids_file")]
+    pub entity_ids_json: Option<String>,
+    #[arg(long, value_name = "PATH", conflicts_with = "entity_ids_json")]
+    pub entity_ids_file: Option<String>,
+    #[arg(long, value_name = "JSON")]
+    pub resource_types_json: Option<String>,
+    #[arg(long, value_name = "JSON")]
+    pub personas_json: Option<String>,
+    #[arg(long, value_name = "JSON", conflicts_with = "thresholds_file")]
+    pub thresholds_json: Option<String>,
+    #[arg(long, value_name = "PATH", conflicts_with = "thresholds_json")]
+    pub thresholds_file: Option<String>,
+    #[arg(long, value_name = "PATH", conflicts_with = "manifest_uri")]
+    pub manifest_path: Option<String>,
+    #[arg(long, value_name = "URI", conflicts_with = "manifest_path")]
+    pub manifest_uri: Option<String>,
+    #[arg(long, value_name = "INSTANCE_ID")]
+    pub storage_instance_id: Option<String>,
+    #[arg(long, default_value_t = false)]
+    pub cleanup_storage_on_start: bool,
+    #[arg(long, default_value_t = false)]
+    pub read_only: bool,
+    #[arg(long, value_name = "BOOL")]
+    pub include_breakdown: Option<bool>,
+    #[arg(long, value_name = "BOOL")]
+    pub include_recommendations: Option<bool>,
+    #[arg(long, value_name = "PATH")]
+    pub report_json_path: Option<String>,
+    #[arg(long, value_name = "PATH")]
+    pub report_md_path: Option<String>,
+    #[arg(long, default_value_t = false)]
+    pub fail_on_no_targets: bool,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
 pub struct ConfigArgs {
     #[command(subcommand)]
     pub command: ConfigCommand,
@@ -223,8 +288,9 @@ mod tests {
     use clap::Parser;
 
     use super::{
-        Cli, Command, ConfigCommand, HealthCommand, ManifestCommand, ServerCommand,
-        ServerTransportArg, StorageCommand, ToolCommand,
+        AuditCommand, Cli, Command, ConfigCommand, HealthCommand, ManifestCommand,
+        MetadataAuditSelectionModeArg, ServerCommand, ServerTransportArg, StorageCommand,
+        ToolCommand,
     };
 
     #[test]
@@ -266,9 +332,10 @@ mod tests {
 
     #[test]
     fn cli_parses_all_top_level_groups() {
-        let groups: [&[&str]; 5] = [
+        let groups: [&[&str]; 6] = [
             &["dbt-nova", "manifest", "load"],
             &["dbt-nova", "tool", "call", "search"],
+            &["dbt-nova", "audit", "metadata-score"],
             &["dbt-nova", "config", "show"],
             &["dbt-nova", "storage", "inspect"],
             &["dbt-nova", "health", "check"],
@@ -397,6 +464,84 @@ mod tests {
                 assert!(matches!(tool.command, ToolCommand::Call(_)));
             }
             _ => panic!("expected tool command"),
+        }
+    }
+
+    #[test]
+    fn audit_metadata_score_parses_flags() {
+        let cli = Cli::parse_from([
+            "dbt-nova",
+            "audit",
+            "metadata-score",
+            "--selection-mode",
+            "changed",
+            "--changed-files-json",
+            "[\"models/staging/orders.sql\"]",
+            "--resource-types-json",
+            "[\"model\"]",
+            "--personas-json",
+            "[\"engineer\",\"analyst\"]",
+            "--thresholds-json",
+            "{\"entity\":{\"engineer\":{\"min_score\":70,\"severity\":\"required\"}}}",
+            "--manifest-path",
+            "target/manifest.json",
+            "--report-json-path",
+            "out/report.json",
+            "--report-md-path",
+            "out/report.md",
+            "--json",
+        ]);
+        let command = cli.command.expect("command");
+        match command {
+            Command::Audit(audit) => {
+                let AuditCommand::MetadataScore(args) = audit.command;
+                assert_eq!(args.selection_mode, MetadataAuditSelectionModeArg::Changed);
+                assert_eq!(
+                    args.changed_files_json.as_deref(),
+                    Some("[\"models/staging/orders.sql\"]")
+                );
+                assert_eq!(args.manifest_path.as_deref(), Some("target/manifest.json"));
+                assert_eq!(args.report_json_path.as_deref(), Some("out/report.json"));
+                assert_eq!(args.report_md_path.as_deref(), Some("out/report.md"));
+                assert!(args.json);
+            }
+            _ => panic!("expected audit command"),
+        }
+    }
+
+    #[test]
+    fn audit_metadata_score_rejects_conflicting_changed_sources() {
+        let parsed = Cli::try_parse_from([
+            "dbt-nova",
+            "audit",
+            "metadata-score",
+            "--changed-files-json",
+            "[]",
+            "--changed-files-file",
+            "changed.json",
+        ]);
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn audit_metadata_score_parses_explicit_bool_overrides() {
+        let cli = Cli::parse_from([
+            "dbt-nova",
+            "audit",
+            "metadata-score",
+            "--include-breakdown",
+            "false",
+            "--include-recommendations",
+            "true",
+        ]);
+        let command = cli.command.expect("command");
+        match command {
+            Command::Audit(audit) => {
+                let AuditCommand::MetadataScore(args) = audit.command;
+                assert_eq!(args.include_breakdown, Some(false));
+                assert_eq!(args.include_recommendations, Some(true));
+            }
+            _ => panic!("expected audit command"),
         }
     }
 

--- a/src/cli/audit_cmd.rs
+++ b/src/cli/audit_cmd.rs
@@ -42,6 +42,7 @@ struct MetadataAuditReport {
     scored_count: usize,
     gate_status: &'static str,
     summary: AuditSummary,
+    project_summary: Option<BTreeMap<String, ProjectAuditReport>>,
     entities: Vec<EntityAuditReport>,
 }
 
@@ -71,6 +72,15 @@ struct PersonaAuditReport {
     categories: JsonValue,
     breakdown: JsonValue,
     recommendations: JsonValue,
+    threshold: Option<AppliedThreshold>,
+    gate_status: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ProjectAuditReport {
+    overall_score: u8,
+    grade: String,
+    quality_summary: JsonValue,
     threshold: Option<AppliedThreshold>,
     gate_status: &'static str,
 }
@@ -322,12 +332,30 @@ async fn build_metadata_audit_report(
         entities.push(report);
     }
 
-    let gate_status = if required_fail_count > 0 {
-        "fail"
-    } else if advisory_fail_count > 0 {
-        "advisory"
+    let project_summary = if inputs.selection_mode == MetadataAuditSelectionModeArg::Project {
+        let project_summary =
+            score_project_summary(search, inputs, args, selected_entity_ids.len()).await?;
+        required_fail_count = project_summary
+            .values()
+            .filter(|report| report.gate_status == "required_fail")
+            .count();
+        advisory_fail_count = project_summary
+            .values()
+            .filter(|report| report.gate_status == "advisory_fail")
+            .count();
+        pass_count = project_summary
+            .values()
+            .filter(|report| report.gate_status == "pass")
+            .count();
+        Some(project_summary)
     } else {
-        "pass"
+        None
+    };
+
+    let gate_status = match (required_fail_count, advisory_fail_count) {
+        (required, _) if required > 0 => "fail",
+        (0, advisory) if advisory > 0 => "advisory",
+        _ => "pass",
     };
 
     Ok(MetadataAuditReport {
@@ -348,6 +376,7 @@ async fn build_metadata_audit_report(
             pass_count,
             no_target: selected_entity_ids.is_empty(),
         },
+        project_summary,
         entities,
     })
 }
@@ -381,7 +410,11 @@ async fn score_entity(
         })?;
         let overall_score = json_u8(&data, "overall_score")?;
         let grade = json_string(&data, "grade")?;
-        let threshold = threshold_profile.rule_for(persona).cloned();
+        let threshold = if inputs.selection_mode == MetadataAuditSelectionModeArg::Project {
+            None
+        } else {
+            threshold_profile.rule_for(persona).cloned()
+        };
         let persona_gate = evaluate_threshold(overall_score, &grade, threshold.as_ref());
         match persona_gate {
             "required_fail" => required_fail = true,
@@ -429,6 +462,53 @@ async fn score_entity(
         gate_status,
         personas,
     })
+}
+
+async fn score_project_summary(
+    search: &ManifestSearch,
+    inputs: &AuditInputs,
+    args: &MetadataAuditArgs,
+    total_targets: usize,
+) -> Result<BTreeMap<String, ProjectAuditReport>> {
+    let mut summary = BTreeMap::new();
+    for persona in &inputs.personas {
+        let params = GetMetadataScoreParams {
+            persona: Some(persona.clone()),
+            scope: Some("project".to_string()),
+            include_breakdown: args.include_breakdown.unwrap_or(true),
+            include_recommendations: args.include_recommendations.unwrap_or(true),
+            resource_types: inputs.resource_types.clone(),
+            limit: Some(total_targets),
+            offset: Some(0),
+            ..GetMetadataScoreParams::default()
+        };
+        let result = search.get_metadata_score(&params).await?;
+        let data = result.get("data").cloned().ok_or_else(|| {
+            DbtNovaError::ServerError("metadata score response missing data".to_string())
+        })?;
+        let overall_score = json_u8(&data, "overall_score")?;
+        let grade = json_string(&data, "grade")?;
+        let threshold = inputs.thresholds.project.rule_for(persona).cloned();
+        let gate_status = evaluate_threshold(overall_score, &grade, threshold.as_ref());
+        summary.insert(
+            persona.clone(),
+            ProjectAuditReport {
+                overall_score,
+                grade,
+                quality_summary: data
+                    .get("quality_summary")
+                    .cloned()
+                    .unwrap_or(JsonValue::Null),
+                threshold: threshold.map(|rule| AppliedThreshold {
+                    min_score: rule.min_score,
+                    min_grade: rule.min_grade,
+                    severity: rule.severity,
+                }),
+                gate_status,
+            },
+        );
+    }
+    Ok(summary)
 }
 
 fn select_entity_ids(search: &ManifestSearch, inputs: &AuditInputs) -> Result<Vec<String>> {
@@ -562,6 +642,25 @@ fn render_markdown_report(report: &MetadataAuditReport) -> String {
     if report.summary.no_target {
         out.push_str("No entities matched the selection.\n");
         return out;
+    }
+
+    if let Some(project_summary) = &report.project_summary {
+        out.push_str("## Project Summary\n\n");
+        out.push_str("| Persona | Score | Grade | Gate |\n");
+        out.push_str("|---|---:|---|---|\n");
+        for persona in &report.personas {
+            if let Some(score) = project_summary.get(persona) {
+                let _ = writeln!(
+                    out,
+                    "| {} | {} | {} | `{}` |",
+                    title_case(persona),
+                    score.overall_score,
+                    score.grade,
+                    score.gate_status
+                );
+            }
+        }
+        out.push('\n');
     }
 
     out.push_str("| Entity | Type | Gate |");
@@ -843,6 +942,7 @@ mod tests {
                 pass_count: 0,
                 no_target: false,
             },
+            project_summary: None,
             entities: vec![super::EntityAuditReport {
                 unique_id: "model.pkg.orders".to_string(),
                 name: Some("orders".to_string()),
@@ -867,5 +967,41 @@ mod tests {
         let markdown = render_markdown_report(&report);
         assert!(markdown.contains("gate_status: `fail`"));
         assert!(markdown.contains("model.pkg.orders"));
+    }
+
+    #[tokio::test]
+    async fn project_selection_uses_project_thresholds_for_gate_status() {
+        let args = MetadataAuditArgs {
+            selection_mode: MetadataAuditSelectionModeArg::Project,
+            resource_types_json: Some("[\"model\"]".to_string()),
+            personas_json: Some("[\"engineer\"]".to_string()),
+            thresholds_json: Some(
+                "{\"project\":{\"engineer\":{\"min_score\":101,\"severity\":\"required\"}}}"
+                    .to_string(),
+            ),
+            manifest_path: Some(fixture_manifest_path_string()),
+            read_only: true,
+            ..MetadataAuditArgs::default()
+        };
+        let inputs = super::parse_audit_inputs(&args).expect("audit inputs");
+        let load_args = crate::cli::args::ManifestLoadArgs {
+            manifest_path: args.manifest_path.clone(),
+            read_only: true,
+            ..crate::cli::args::ManifestLoadArgs::default()
+        };
+        let config = build_manifest_load_config(&load_args).expect("config");
+        let loaded = execute_manifest_load(config).await.expect("load");
+        let report = super::build_metadata_audit_report(&loaded.search, &inputs, &args)
+            .await
+            .expect("report");
+        assert_eq!(report.gate_status, "fail");
+        assert_eq!(report.summary.required_fail_count, 1);
+        assert!(report.project_summary.is_some());
+        assert!(
+            report
+                .entities
+                .iter()
+                .all(|entity| entity.gate_status == "pass")
+        );
     }
 }

--- a/src/cli/audit_cmd.rs
+++ b/src/cli/audit_cmd.rs
@@ -884,13 +884,15 @@ mod tests {
                 "[\"models/staging/traffic/stg__traffic_sessions.sql\"]".to_string(),
             ),
             manifest_path: Some(fixture_manifest_path_string()),
-            read_only: true,
+            storage_instance_id: Some("audit-changed-selection-test".to_string()),
+            cleanup_storage_on_start: true,
             ..MetadataAuditArgs::default()
         };
         let inputs = super::parse_audit_inputs(&args).expect("audit inputs");
         let load_args = crate::cli::args::ManifestLoadArgs {
             manifest_path: args.manifest_path.clone(),
-            read_only: true,
+            storage_instance_id: args.storage_instance_id.clone(),
+            cleanup_storage_on_start: args.cleanup_storage_on_start,
             ..crate::cli::args::ManifestLoadArgs::default()
         };
         let config = build_manifest_load_config(&load_args).expect("config");
@@ -980,13 +982,15 @@ mod tests {
                     .to_string(),
             ),
             manifest_path: Some(fixture_manifest_path_string()),
-            read_only: true,
+            storage_instance_id: Some("audit-project-selection-test".to_string()),
+            cleanup_storage_on_start: true,
             ..MetadataAuditArgs::default()
         };
         let inputs = super::parse_audit_inputs(&args).expect("audit inputs");
         let load_args = crate::cli::args::ManifestLoadArgs {
             manifest_path: args.manifest_path.clone(),
-            read_only: true,
+            storage_instance_id: args.storage_instance_id.clone(),
+            cleanup_storage_on_start: args.cleanup_storage_on_start,
             ..crate::cli::args::ManifestLoadArgs::default()
         };
         let config = build_manifest_load_config(&load_args).expect("config");

--- a/src/cli/audit_cmd.rs
+++ b/src/cli/audit_cmd.rs
@@ -1,0 +1,871 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+use std::fs;
+use std::path::Path;
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+use crate::cli::args::{MetadataAuditArgs, MetadataAuditSelectionModeArg};
+use crate::cli::manifest::{build_manifest_load_config, execute_manifest_load};
+use crate::cli::output::CliEnvelope;
+use crate::error::{DbtNovaError, Result};
+use crate::manifest::entity::ArchivedEntity;
+use crate::manifest::search::ManifestSearch;
+use crate::params::GetMetadataScoreParams;
+use crate::utils::SearchPersona;
+
+use super::{DispatchError, DispatchResult};
+
+const DEFAULT_RESOURCE_TYPES_JSON: &str = "[\"model\"]";
+const DEFAULT_PERSONAS_JSON: &str = "[\"engineer\"]";
+const DEFAULT_THRESHOLDS_JSON: &str = r#"{
+  "entity": {
+    "engineer": { "min_score": 70, "severity": "required" },
+    "analyst": { "min_score": 65, "severity": "advisory" },
+    "governance": { "min_score": 65, "severity": "advisory" }
+  }
+}"#;
+
+#[derive(Debug, Clone, Serialize)]
+struct MetadataAuditReport {
+    selection_mode: String,
+    manifest_hash: String,
+    manifest_version: String,
+    manifest_source: String,
+    resource_types: Vec<String>,
+    personas: Vec<String>,
+    changed_files: Vec<String>,
+    selected_entity_ids: Vec<String>,
+    target_count: usize,
+    scored_count: usize,
+    gate_status: &'static str,
+    summary: AuditSummary,
+    entities: Vec<EntityAuditReport>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AuditSummary {
+    required_fail_count: usize,
+    advisory_fail_count: usize,
+    pass_count: usize,
+    no_target: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct EntityAuditReport {
+    unique_id: String,
+    name: Option<String>,
+    resource_type: Option<String>,
+    original_file_path: Option<String>,
+    patch_path: Option<String>,
+    gate_status: &'static str,
+    personas: BTreeMap<String, PersonaAuditReport>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct PersonaAuditReport {
+    overall_score: u8,
+    grade: String,
+    categories: JsonValue,
+    breakdown: JsonValue,
+    recommendations: JsonValue,
+    threshold: Option<AppliedThreshold>,
+    gate_status: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AppliedThreshold {
+    min_score: Option<u8>,
+    min_grade: Option<String>,
+    severity: ThresholdSeverity,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+enum ThresholdSeverity {
+    #[default]
+    Required,
+    Advisory,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+struct ThresholdRule {
+    min_score: Option<u8>,
+    min_grade: Option<String>,
+    severity: ThresholdSeverity,
+}
+
+impl Default for ThresholdRule {
+    fn default() -> Self {
+        Self {
+            min_score: None,
+            min_grade: None,
+            severity: ThresholdSeverity::Required,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(default)]
+struct PersonaThresholdConfig {
+    default: Option<ThresholdRule>,
+    analyst: Option<ThresholdRule>,
+    engineer: Option<ThresholdRule>,
+    governance: Option<ThresholdRule>,
+}
+
+impl PersonaThresholdConfig {
+    fn rule_for(&self, persona: &str) -> Option<&ThresholdRule> {
+        match persona {
+            "analyst" => self.analyst.as_ref().or(self.default.as_ref()),
+            "engineer" => self.engineer.as_ref().or(self.default.as_ref()),
+            "governance" => self.governance.as_ref().or(self.default.as_ref()),
+            _ => self.default.as_ref(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(default)]
+struct AuditThresholdConfig {
+    entity: PersonaThresholdConfig,
+    project: PersonaThresholdConfig,
+}
+
+#[derive(Debug, Clone)]
+struct AuditInputs {
+    selection_mode: MetadataAuditSelectionModeArg,
+    resource_types: Vec<String>,
+    personas: Vec<String>,
+    changed_files: Vec<String>,
+    explicit_entities: Vec<String>,
+    thresholds: AuditThresholdConfig,
+}
+
+/// Runs the `audit metadata-score` CLI command.
+///
+/// # Errors
+/// Returns an error if input validation fails, manifest loading fails, or report serialization fails.
+pub async fn run_metadata_score_command(args: &MetadataAuditArgs) -> DispatchResult {
+    let started = Instant::now();
+    let audit_inputs = parse_audit_inputs(args).map_err(|error| DispatchError {
+        error,
+        rendered: false,
+    })?;
+    let load_args = crate::cli::args::ManifestLoadArgs {
+        manifest_path: args.manifest_path.clone(),
+        manifest_uri: args.manifest_uri.clone(),
+        storage_instance_id: args.storage_instance_id.clone(),
+        cleanup_storage_on_start: args.cleanup_storage_on_start,
+        read_only: args.read_only,
+        json: false,
+    };
+    let config = build_manifest_load_config(&load_args).map_err(Into::<DispatchError>::into)?;
+    let load_result = execute_manifest_load(config)
+        .await
+        .map_err(Into::<DispatchError>::into)?;
+
+    let report = build_metadata_audit_report(&load_result.search, &audit_inputs, args).await?;
+
+    if let Some(path) = args.report_json_path.as_deref() {
+        let serialized = serde_json::to_string_pretty(&report)
+            .map_err(|error| DbtNovaError::ServerError(error.to_string()))?;
+        write_report(path, &serialized)?;
+    }
+    let markdown = render_markdown_report(&report);
+    if let Some(path) = args.report_md_path.as_deref() {
+        write_report(path, &markdown)?;
+    }
+
+    if args.json {
+        let envelope = CliEnvelope::success(
+            "audit metadata-score",
+            &report,
+            started.elapsed().as_millis(),
+        );
+        let output = serde_json::to_string_pretty(&envelope).map_err(|error| DispatchError {
+            error: DbtNovaError::ServerError(error.to_string()),
+            rendered: false,
+        })?;
+        println!("{output}");
+    } else {
+        print_human_summary(&report);
+        println!();
+        println!("{markdown}");
+    }
+
+    if report.gate_status == "fail" {
+        return Err(DispatchError {
+            error: DbtNovaError::ServerError(format!(
+                "metadata audit gate failed ({} required failure(s))",
+                report.summary.required_fail_count
+            )),
+            rendered: true,
+        });
+    }
+
+    Ok(())
+}
+
+fn parse_audit_inputs(args: &MetadataAuditArgs) -> Result<AuditInputs> {
+    let resource_types: Vec<String> = parse_json_array_input(
+        args.resource_types_json.as_deref(),
+        None,
+        DEFAULT_RESOURCE_TYPES_JSON,
+    )?
+    .into_iter()
+    .map(|value| value.trim().to_lowercase())
+    .filter(|value| !value.is_empty())
+    .collect();
+    if resource_types.is_empty() {
+        return Err(DbtNovaError::InvalidParams(
+            "resource_types_json must contain at least one resource type".to_string(),
+        ));
+    }
+
+    let personas: Vec<String> =
+        parse_json_array_input(args.personas_json.as_deref(), None, DEFAULT_PERSONAS_JSON)?
+            .into_iter()
+            .map(|value| value.trim().to_lowercase())
+            .filter(|value| !value.is_empty())
+            .collect();
+    if personas.is_empty() {
+        return Err(DbtNovaError::InvalidParams(
+            "personas_json must contain at least one persona".to_string(),
+        ));
+    }
+    for persona in &personas {
+        if SearchPersona::parse(persona) == SearchPersona::Default && persona != "default" {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "unsupported persona '{persona}'; expected analyst, engineer, or governance"
+            )));
+        }
+    }
+
+    let changed_files = parse_json_array_input(
+        args.changed_files_json.as_deref(),
+        args.changed_files_file.as_deref(),
+        "[]",
+    )?
+    .into_iter()
+    .map(|path| normalize_path(&path))
+    .filter(|path| !path.is_empty())
+    .collect::<Vec<_>>();
+
+    let explicit_entities = parse_json_array_input(
+        args.entity_ids_json.as_deref(),
+        args.entity_ids_file.as_deref(),
+        "[]",
+    )?;
+
+    match args.selection_mode {
+        MetadataAuditSelectionModeArg::Changed if changed_files.is_empty() => {
+            return Err(DbtNovaError::InvalidParams(
+                "selection_mode=changed requires changed_files_json or changed_files_file"
+                    .to_string(),
+            ));
+        }
+        MetadataAuditSelectionModeArg::Entities if explicit_entities.is_empty() => {
+            return Err(DbtNovaError::InvalidParams(
+                "selection_mode=entities requires entity_ids_json or entity_ids_file".to_string(),
+            ));
+        }
+        _ => {}
+    }
+
+    let thresholds: AuditThresholdConfig = parse_json_input(
+        args.thresholds_json.as_deref(),
+        args.thresholds_file.as_deref(),
+        DEFAULT_THRESHOLDS_JSON,
+    )?;
+
+    Ok(AuditInputs {
+        selection_mode: args.selection_mode,
+        resource_types,
+        personas,
+        changed_files,
+        explicit_entities,
+        thresholds,
+    })
+}
+
+async fn build_metadata_audit_report(
+    search: &ManifestSearch,
+    inputs: &AuditInputs,
+    args: &MetadataAuditArgs,
+) -> Result<MetadataAuditReport> {
+    let selected_entity_ids = select_entity_ids(search, inputs)?;
+    if selected_entity_ids.is_empty() && args.fail_on_no_targets {
+        return Err(DbtNovaError::ServerError(
+            "metadata audit selected no entities".to_string(),
+        ));
+    }
+
+    let mut entities = Vec::with_capacity(selected_entity_ids.len());
+    let mut required_fail_count = 0usize;
+    let mut advisory_fail_count = 0usize;
+    let mut pass_count = 0usize;
+
+    for unique_id in &selected_entity_ids {
+        let entity = search
+            .get_entity_archived(unique_id)?
+            .ok_or_else(|| search.entity_not_found(unique_id, None))?;
+        let report = score_entity(search, entity, unique_id, inputs, args).await?;
+        match report.gate_status {
+            "fail" => required_fail_count += 1,
+            "advisory" => advisory_fail_count += 1,
+            _ => pass_count += 1,
+        }
+        entities.push(report);
+    }
+
+    let gate_status = if required_fail_count > 0 {
+        "fail"
+    } else if advisory_fail_count > 0 {
+        "advisory"
+    } else {
+        "pass"
+    };
+
+    Ok(MetadataAuditReport {
+        selection_mode: selection_mode_label(inputs.selection_mode).to_string(),
+        manifest_hash: search.manifest_hash.clone(),
+        manifest_version: search.manifest_version.clone(),
+        manifest_source: search.manifest_source_uri.clone(),
+        resource_types: inputs.resource_types.clone(),
+        personas: inputs.personas.clone(),
+        changed_files: inputs.changed_files.clone(),
+        selected_entity_ids: selected_entity_ids.clone(),
+        target_count: selected_entity_ids.len(),
+        scored_count: entities.len(),
+        gate_status,
+        summary: AuditSummary {
+            required_fail_count,
+            advisory_fail_count,
+            pass_count,
+            no_target: selected_entity_ids.is_empty(),
+        },
+        entities,
+    })
+}
+
+async fn score_entity(
+    search: &ManifestSearch,
+    entity: &ArchivedEntity,
+    unique_id: &str,
+    inputs: &AuditInputs,
+    args: &MetadataAuditArgs,
+) -> Result<EntityAuditReport> {
+    let mut personas = BTreeMap::new();
+    let mut required_fail = false;
+    let mut advisory_fail = false;
+    let resource_type = entity.resource_type_str().map(ToString::to_string);
+    let threshold_profile = inputs.threshold_profile();
+
+    for persona in &inputs.personas {
+        let params = GetMetadataScoreParams {
+            id_or_name: Some(unique_id.to_string()),
+            resource_type: resource_type.clone(),
+            persona: Some(persona.clone()),
+            scope: Some("entity".to_string()),
+            include_breakdown: args.include_breakdown.unwrap_or(true),
+            include_recommendations: args.include_recommendations.unwrap_or(true),
+            ..GetMetadataScoreParams::default()
+        };
+        let result = search.get_metadata_score(&params).await?;
+        let data = result.get("data").cloned().ok_or_else(|| {
+            DbtNovaError::ServerError("metadata score response missing data".to_string())
+        })?;
+        let overall_score = json_u8(&data, "overall_score")?;
+        let grade = json_string(&data, "grade")?;
+        let threshold = threshold_profile.rule_for(persona).cloned();
+        let persona_gate = evaluate_threshold(overall_score, &grade, threshold.as_ref());
+        match persona_gate {
+            "required_fail" => required_fail = true,
+            "advisory_fail" => advisory_fail = true,
+            _ => {}
+        }
+        personas.insert(
+            persona.clone(),
+            PersonaAuditReport {
+                overall_score,
+                grade,
+                categories: data.get("categories").cloned().unwrap_or(JsonValue::Null),
+                breakdown: data.get("breakdown").cloned().unwrap_or(JsonValue::Null),
+                recommendations: data
+                    .get("recommendations")
+                    .cloned()
+                    .unwrap_or(JsonValue::Array(Vec::new())),
+                threshold: threshold.map(|rule| AppliedThreshold {
+                    min_score: rule.min_score,
+                    min_grade: rule.min_grade,
+                    severity: rule.severity,
+                }),
+                gate_status: match persona_gate {
+                    "required_fail" | "advisory_fail" => persona_gate,
+                    _ => "pass",
+                },
+            },
+        );
+    }
+
+    let gate_status = if required_fail {
+        "fail"
+    } else if advisory_fail {
+        "advisory"
+    } else {
+        "pass"
+    };
+
+    Ok(EntityAuditReport {
+        unique_id: unique_id.to_string(),
+        name: entity.name_str().map(ToString::to_string),
+        resource_type,
+        original_file_path: entity.original_file_path_str().map(ToString::to_string),
+        patch_path: patch_path_from_entity(entity),
+        gate_status,
+        personas,
+    })
+}
+
+fn select_entity_ids(search: &ManifestSearch, inputs: &AuditInputs) -> Result<Vec<String>> {
+    let mut selected = BTreeSet::new();
+    match inputs.selection_mode {
+        MetadataAuditSelectionModeArg::Project => {
+            for resource_type in normalized_resource_types(search, &inputs.resource_types)? {
+                if let Some(ids) = search.by_resource_type.get(&resource_type) {
+                    for id in ids {
+                        selected.insert(id.clone());
+                    }
+                }
+            }
+        }
+        MetadataAuditSelectionModeArg::Changed => {
+            let changed: BTreeSet<String> = inputs.changed_files.iter().cloned().collect();
+            for resource_type in normalized_resource_types(search, &inputs.resource_types)? {
+                if let Some(ids) = search.by_resource_type.get(&resource_type) {
+                    for id in ids {
+                        if let Some(entity) = search.get_entity_archived(id)?
+                            && entity_matches_changed_files(entity, &changed)
+                        {
+                            selected.insert(id.clone());
+                        }
+                    }
+                }
+            }
+        }
+        MetadataAuditSelectionModeArg::Entities => {
+            for id_or_name in &inputs.explicit_entities {
+                selected.insert(search.resolve_single_id(id_or_name, None)?);
+            }
+        }
+    }
+    Ok(selected.into_iter().collect())
+}
+
+fn normalized_resource_types(
+    search: &ManifestSearch,
+    resource_types: &[String],
+) -> Result<Vec<String>> {
+    let mut normalized = Vec::new();
+    for resource_type in resource_types {
+        normalized.push(search.normalize_resource_type_key(resource_type)?);
+    }
+    normalized.sort();
+    normalized.dedup();
+    Ok(normalized)
+}
+
+fn entity_matches_changed_files(entity: &ArchivedEntity, changed_files: &BTreeSet<String>) -> bool {
+    entity
+        .original_file_path_str()
+        .map(normalize_path)
+        .is_some_and(|path| changed_files.contains(&path))
+        || patch_path_from_entity(entity)
+            .as_deref()
+            .map(normalize_path)
+            .is_some_and(|path| changed_files.contains(&path))
+}
+
+fn patch_path_from_entity(entity: &ArchivedEntity) -> Option<String> {
+    entity
+        .to_json_value()
+        .get("patch_path")
+        .and_then(JsonValue::as_str)
+        .map(ToString::to_string)
+}
+
+fn normalize_path(path: &str) -> String {
+    path.trim().trim_start_matches("./").replace('\\', "/")
+}
+
+fn selection_mode_label(mode: MetadataAuditSelectionModeArg) -> &'static str {
+    match mode {
+        MetadataAuditSelectionModeArg::Project => "project",
+        MetadataAuditSelectionModeArg::Changed => "changed",
+        MetadataAuditSelectionModeArg::Entities => "entities",
+    }
+}
+
+fn evaluate_threshold(
+    overall_score: u8,
+    grade: &str,
+    threshold: Option<&ThresholdRule>,
+) -> &'static str {
+    let Some(threshold) = threshold else {
+        return "pass";
+    };
+    let score_pass = threshold.min_score.is_none_or(|min| overall_score >= min);
+    let grade_pass = threshold
+        .min_grade
+        .as_deref()
+        .is_none_or(|min| grade_meets_threshold(grade, min));
+    if score_pass && grade_pass {
+        return "pass";
+    }
+    match threshold.severity {
+        ThresholdSeverity::Required => "required_fail",
+        ThresholdSeverity::Advisory => "advisory_fail",
+    }
+}
+
+fn grade_meets_threshold(actual: &str, minimum: &str) -> bool {
+    grade_rank(actual) >= grade_rank(minimum)
+}
+
+fn grade_rank(grade: &str) -> i8 {
+    match grade.trim().to_ascii_uppercase().as_str() {
+        "A" => 4,
+        "B" => 3,
+        "C" => 2,
+        "D" => 1,
+        _ => 0,
+    }
+}
+
+fn render_markdown_report(report: &MetadataAuditReport) -> String {
+    let mut out = String::new();
+    out.push_str("# Nova Metadata Audit\n\n");
+    let _ = write!(
+        out,
+        "- gate_status: `{}`\n- selection_mode: `{}`\n- target_count: `{}`\n- required_fail_count: `{}`\n- advisory_fail_count: `{}`\n\n",
+        report.gate_status,
+        report.selection_mode,
+        report.target_count,
+        report.summary.required_fail_count,
+        report.summary.advisory_fail_count
+    );
+
+    if report.summary.no_target {
+        out.push_str("No entities matched the selection.\n");
+        return out;
+    }
+
+    out.push_str("| Entity | Type | Gate |");
+    for persona in &report.personas {
+        let _ = write!(out, " {} |", title_case(persona));
+    }
+    out.push('\n');
+    out.push_str("|---|---|---|");
+    for _ in &report.personas {
+        out.push_str("---|");
+    }
+    out.push('\n');
+
+    for entity in &report.entities {
+        let _ = write!(
+            out,
+            "| `{}` | `{}` | `{}` |",
+            entity.unique_id,
+            entity.resource_type.clone().unwrap_or_default(),
+            entity.gate_status
+        );
+        for persona in &report.personas {
+            let cell = entity.personas.get(persona).map_or_else(
+                || "-".to_string(),
+                |score| format!("{} ({})", score.overall_score, score.grade),
+            );
+            let _ = write!(out, " {cell} |");
+        }
+        out.push('\n');
+    }
+
+    let failing = report
+        .entities
+        .iter()
+        .filter(|entity| entity.gate_status != "pass")
+        .collect::<Vec<_>>();
+    if !failing.is_empty() {
+        out.push_str("\n## Findings\n\n");
+        for entity in failing {
+            let _ = writeln!(out, "- `{}` `{}`", entity.unique_id, entity.gate_status);
+            for persona in &report.personas {
+                let Some(score) = entity.personas.get(persona) else {
+                    continue;
+                };
+                if score.gate_status == "pass" {
+                    continue;
+                }
+                let _ = writeln!(
+                    out,
+                    "  - {}: {} ({})",
+                    title_case(persona),
+                    score.overall_score,
+                    score.grade
+                );
+                if let Some(recommendations) = score.recommendations.as_array() {
+                    for recommendation in recommendations.iter().take(3) {
+                        if let Some(field) = recommendation.get("field").and_then(JsonValue::as_str)
+                        {
+                            let category = recommendation
+                                .get("category")
+                                .and_then(JsonValue::as_str)
+                                .unwrap_or("metadata");
+                            let _ = writeln!(out, "    - {category}: `{field}`");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    out
+}
+
+fn title_case(value: &str) -> String {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+fn print_human_summary(report: &MetadataAuditReport) {
+    println!("metadata audit complete");
+    println!("  gate_status: {}", report.gate_status);
+    println!("  selection_mode: {}", report.selection_mode);
+    println!("  target_count: {}", report.target_count);
+    println!(
+        "  required_fail_count: {}",
+        report.summary.required_fail_count
+    );
+    println!(
+        "  advisory_fail_count: {}",
+        report.summary.advisory_fail_count
+    );
+}
+
+fn write_report(path: &str, contents: &str) -> Result<()> {
+    let path = Path::new(path);
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, contents)?;
+    Ok(())
+}
+
+fn parse_json_input<T>(inline: Option<&str>, path: Option<&str>, default_inline: &str) -> Result<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let raw = if let Some(inline) = inline {
+        inline.to_string()
+    } else if let Some(path) = path {
+        fs::read_to_string(path).map_err(|error| {
+            DbtNovaError::InvalidParams(format!("failed to read {path}: {error}"))
+        })?
+    } else {
+        default_inline.to_string()
+    };
+
+    serde_json::from_str(&raw).map_err(|error| {
+        DbtNovaError::InvalidParams(format!("failed to parse JSON input: {error}"))
+    })
+}
+
+fn parse_json_array_input(
+    inline: Option<&str>,
+    path: Option<&str>,
+    default_inline: &str,
+) -> Result<Vec<String>> {
+    parse_json_input(inline, path, default_inline)
+}
+
+fn json_u8(data: &JsonValue, field: &str) -> Result<u8> {
+    let raw = data.get(field).and_then(JsonValue::as_u64).ok_or_else(|| {
+        DbtNovaError::ServerError(format!("metadata score response missing {field}"))
+    })?;
+    u8::try_from(raw).map_err(|_| {
+        DbtNovaError::ServerError(format!("metadata score field {field} out of range"))
+    })
+}
+
+fn json_string(data: &JsonValue, field: &str) -> Result<String> {
+    data.get(field)
+        .and_then(JsonValue::as_str)
+        .map(ToString::to_string)
+        .ok_or_else(|| {
+            DbtNovaError::ServerError(format!("metadata score response missing {field}"))
+        })
+}
+
+impl AuditInputs {
+    fn threshold_profile(&self) -> &PersonaThresholdConfig {
+        match self.selection_mode {
+            MetadataAuditSelectionModeArg::Project => &self.thresholds.project,
+            MetadataAuditSelectionModeArg::Changed | MetadataAuditSelectionModeArg::Entities => {
+                &self.thresholds.entity
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AuditThresholdConfig, MetadataAuditReport, ThresholdSeverity, entity_matches_changed_files,
+        evaluate_threshold, normalize_path, parse_json_input, render_markdown_report,
+    };
+    use crate::cli::args::{MetadataAuditArgs, MetadataAuditSelectionModeArg};
+    use crate::cli::manifest::{build_manifest_load_config, execute_manifest_load};
+    use crate::tests::common::fixture_manifest_path_string;
+    use serde_json::Value as JsonValue;
+    use serde_json::json;
+
+    #[test]
+    fn normalize_path_strips_dot_prefix_and_backslashes() {
+        assert_eq!(
+            normalize_path("./models\\staging\\orders.sql"),
+            "models/staging/orders.sql"
+        );
+    }
+
+    #[test]
+    fn parse_threshold_defaults_loads_expected_rule() {
+        let thresholds: AuditThresholdConfig =
+            parse_json_input(None, None, super::DEFAULT_THRESHOLDS_JSON).expect("thresholds");
+        let engineer = thresholds.entity.engineer.expect("engineer threshold");
+        assert_eq!(engineer.min_score, Some(70));
+        assert_eq!(engineer.severity, ThresholdSeverity::Required);
+    }
+
+    #[test]
+    fn evaluate_threshold_distinguishes_required_and_advisory_failures() {
+        let required = super::ThresholdRule {
+            min_score: Some(80),
+            min_grade: Some("B".to_string()),
+            severity: ThresholdSeverity::Required,
+        };
+        let advisory = super::ThresholdRule {
+            min_score: Some(80),
+            min_grade: None,
+            severity: ThresholdSeverity::Advisory,
+        };
+        assert_eq!(
+            evaluate_threshold(72, "C", Some(&required)),
+            "required_fail"
+        );
+        assert_eq!(
+            evaluate_threshold(72, "C", Some(&advisory)),
+            "advisory_fail"
+        );
+        assert_eq!(evaluate_threshold(90, "A", Some(&required)), "pass");
+    }
+
+    #[tokio::test]
+    async fn changed_selection_matches_original_file_path() {
+        let args = MetadataAuditArgs {
+            selection_mode: MetadataAuditSelectionModeArg::Changed,
+            changed_files_json: Some(
+                "[\"models/staging/traffic/stg__traffic_sessions.sql\"]".to_string(),
+            ),
+            manifest_path: Some(fixture_manifest_path_string()),
+            read_only: true,
+            ..MetadataAuditArgs::default()
+        };
+        let inputs = super::parse_audit_inputs(&args).expect("audit inputs");
+        let load_args = crate::cli::args::ManifestLoadArgs {
+            manifest_path: args.manifest_path.clone(),
+            read_only: true,
+            ..crate::cli::args::ManifestLoadArgs::default()
+        };
+        let config = build_manifest_load_config(&load_args).expect("config");
+        let loaded = execute_manifest_load(config).await.expect("load");
+        let selected = super::select_entity_ids(&loaded.search, &inputs).expect("selected");
+        assert!(
+            selected
+                .iter()
+                .any(|id| id == "model.nova_test.stg__traffic_sessions")
+        );
+    }
+
+    #[tokio::test]
+    async fn entity_matches_changed_files_uses_patch_path_when_present() {
+        let entity = crate::manifest::entity::Entity::from_json(
+            "model.pkg.orders",
+            &json!({
+                "resource_type": "model",
+                "name": "orders",
+                "original_file_path": "models/marts/orders.sql",
+                "patch_path": "models/marts/orders.yml"
+            }),
+        );
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&entity).expect("serialize");
+        let archived =
+            rkyv::access::<crate::manifest::entity::ArchivedEntity, rkyv::rancor::Error>(&bytes)
+                .expect("archive");
+        let changed = std::collections::BTreeSet::from(["models/marts/orders.yml".to_string()]);
+        assert!(entity_matches_changed_files(archived, &changed));
+    }
+
+    #[test]
+    fn markdown_report_includes_gate_status() {
+        let report = MetadataAuditReport {
+            selection_mode: "changed".to_string(),
+            manifest_hash: "abc".to_string(),
+            manifest_version: "abc".to_string(),
+            manifest_source: "file:///tmp/manifest.json".to_string(),
+            resource_types: vec!["model".to_string()],
+            personas: vec!["engineer".to_string()],
+            changed_files: vec!["models/marts/orders.sql".to_string()],
+            selected_entity_ids: vec!["model.pkg.orders".to_string()],
+            target_count: 1,
+            scored_count: 1,
+            gate_status: "fail",
+            summary: super::AuditSummary {
+                required_fail_count: 1,
+                advisory_fail_count: 0,
+                pass_count: 0,
+                no_target: false,
+            },
+            entities: vec![super::EntityAuditReport {
+                unique_id: "model.pkg.orders".to_string(),
+                name: Some("orders".to_string()),
+                resource_type: Some("model".to_string()),
+                original_file_path: Some("models/marts/orders.sql".to_string()),
+                patch_path: None,
+                gate_status: "fail",
+                personas: std::collections::BTreeMap::from([(
+                    "engineer".to_string(),
+                    super::PersonaAuditReport {
+                        overall_score: 60,
+                        grade: "D".to_string(),
+                        categories: JsonValue::Null,
+                        breakdown: JsonValue::Null,
+                        recommendations: JsonValue::Array(Vec::new()),
+                        threshold: None,
+                        gate_status: "required_fail",
+                    },
+                )]),
+            }],
+        };
+        let markdown = render_markdown_report(&report);
+        assert!(markdown.contains("gate_status: `fail`"));
+        assert!(markdown.contains("model.pkg.orders"));
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,6 +5,7 @@ use crate::error::{DbtNovaError, Result};
 use crate::utils::{dir_in_use, prune_dirs};
 
 pub mod args;
+pub mod audit_cmd;
 pub mod config_cmd;
 pub mod health_cmd;
 pub mod manifest;
@@ -48,6 +49,11 @@ pub async fn dispatch(command: args::Command) -> DispatchResult {
         },
         args::Command::Tool(tool_args) => match tool_args.command {
             args::ToolCommand::Call(call_args) => tool::run_call_command(&call_args).await,
+        },
+        args::Command::Audit(audit_args) => match audit_args.command {
+            args::AuditCommand::MetadataScore(metadata_args) => {
+                audit_cmd::run_metadata_score_command(&metadata_args).await
+            }
         },
         args::Command::Config(config_args) => match config_args.command {
             args::ConfigCommand::Show(show_args) => config_cmd::run_show_command(&show_args),

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use tracing::error;
 use tracing_subscriber::fmt::format::FmtSpan;
 
 enum LaunchTarget {
-    Command(Command),
+    Command(Box<Command>),
     Server,
 }
 
@@ -16,7 +16,7 @@ async fn main() -> Result<()> {
 
     match launch_target(Cli::parse()) {
         LaunchTarget::Command(command) => {
-            if let Err(dispatch_error) = dbt_nova::cli::dispatch(command).await {
+            if let Err(dispatch_error) = dbt_nova::cli::dispatch(*command).await {
                 error!(error = %dispatch_error.error, "cli command failed");
                 if !dispatch_error.rendered {
                     eprintln!("dbt-nova CLI error: {}", dispatch_error.error);
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
 
 fn launch_target(cli: Cli) -> LaunchTarget {
     if let Some(command) = cli.command {
-        LaunchTarget::Command(command)
+        LaunchTarget::Command(Box::new(command))
     } else {
         LaunchTarget::Server
     }


### PR DESCRIPTION
## Summary
- add `dbt-nova audit metadata-score` for manifest-backed metadata scoring, report generation, and CI gating
- add `.github/workflows/nova-metadata-audit.yml` following the same installer and dbt invocation contract as the reusable asset workflow
- add CI smoke coverage and docs for reusable metadata audit usage

## Validation
- cargo test --locked
- cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
- uv run mkdocs build --strict
- ./scripts/check_config_reference.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nova-metadata-audit.yml"); puts "ok"'
