### PR TITLE
Fix manifest fixture isolation in parallel tests

### DIFF
--- a/src/cli/audit_cmd.rs
+++ b/src/cli/audit_cmd.rs
@@ -835,6 +835,7 @@ mod tests {
     use crate::tests::common::fixture_manifest_path_string;
     use serde_json::Value as JsonValue;
     use serde_json::json;
+    use tempfile::TempDir;
 
     #[test]
     fn normalize_path_strips_dot_prefix_and_backslashes() {
@@ -878,6 +879,7 @@ mod tests {
 
     #[tokio::test]
     async fn changed_selection_matches_original_file_path() {
+        let temp_dir = TempDir::new().expect("temp dir");
         let args = MetadataAuditArgs {
             selection_mode: MetadataAuditSelectionModeArg::Changed,
             changed_files_json: Some(
@@ -895,7 +897,8 @@ mod tests {
             cleanup_storage_on_start: args.cleanup_storage_on_start,
             ..crate::cli::args::ManifestLoadArgs::default()
         };
-        let config = build_manifest_load_config(&load_args).expect("config");
+        let mut config = build_manifest_load_config(&load_args).expect("config");
+        config.storage_dir = temp_dir.path().to_string_lossy().to_string();
         let loaded = execute_manifest_load(config).await.expect("load");
         let selected = super::select_entity_ids(&loaded.search, &inputs).expect("selected");
         assert!(
@@ -973,6 +976,7 @@ mod tests {
 
     #[tokio::test]
     async fn project_selection_uses_project_thresholds_for_gate_status() {
+        let temp_dir = TempDir::new().expect("temp dir");
         let args = MetadataAuditArgs {
             selection_mode: MetadataAuditSelectionModeArg::Project,
             resource_types_json: Some("[\"model\"]".to_string()),
@@ -993,7 +997,8 @@ mod tests {
             cleanup_storage_on_start: args.cleanup_storage_on_start,
             ..crate::cli::args::ManifestLoadArgs::default()
         };
-        let config = build_manifest_load_config(&load_args).expect("config");
+        let mut config = build_manifest_load_config(&load_args).expect("config");
+        config.storage_dir = temp_dir.path().to_string_lossy().to_string();
         let loaded = execute_manifest_load(config).await.expect("load");
         let report = super::build_metadata_audit_report(&loaded.search, &inputs, &args)
             .await

--- a/src/cli/manifest.rs
+++ b/src/cli/manifest.rs
@@ -441,11 +441,15 @@ mod tests {
 
     #[tokio::test]
     async fn execute_manifest_load_invalid_path_fails() {
+        let temp_dir = TempDir::new().expect("temp dir");
         let args = ManifestLoadArgs {
             manifest_path: Some("tests/fixtures/missing-manifest.json".to_string()),
+            storage_instance_id: Some("missing-manifest-test".to_string()),
+            cleanup_storage_on_start: true,
             ..ManifestLoadArgs::default()
         };
         let mut config = build_manifest_load_config(&args).expect("config");
+        config.storage_dir = temp_dir.path().to_string_lossy().to_string();
         config.search.enable_vector_search = false;
         config.search.enable_sparse_search = false;
         config.search.enable_reranker = false;
@@ -453,7 +457,7 @@ mod tests {
             panic!("load should fail");
         };
 
-        assert!(err.to_string().contains("Manifest error"));
+        assert!(matches!(err, crate::error::DbtNovaError::ManifestError(_)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- isolate metadata audit fixture loads with per-test temp storage roots
- isolate missing-manifest load test from shared storage state
- assert on the typed manifest error instead of a fragile string

## Validation
- cargo test --locked cli::manifest::tests::execute_manifest_load_invalid_path_fails -- --exact
- cargo test --locked cli::audit_cmd::tests::project_selection_uses_project_thresholds_for_gate_status -- --exact
- cargo test --locked cli::audit_cmd::tests::changed_selection_matches_original_file_path -- --exact
- cargo test --locked