### PR TITLE
Harden manifest metadata reads for config.meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reusable metadata audit workflows now resolve `selection_mode=changed` from
   immutable pull-request SHAs when available, so reruns stay stable after the
   base branch has advanced.
+- Manifest metadata readers now fall back from legacy `meta` to dbt 1.11+
+  `config.meta` for Nova entity/column metadata, primary-key detection, search
+  indexing, and metadata scoring, while preserving legacy-field precedence when
+  both shapes are present.
 - Public docs, examples, and fixtures were sanitized to remove private
   manifest-specific vocabulary from the public repository.
 - Hosted HTTP startup/bind fallback handling is more robust: invalid `PORT` fallback is ignored, MCP paths are normalized/validated, and reserved probe paths are rejected.

--- a/src/manifest/embeddings/text.rs
+++ b/src/manifest/embeddings/text.rs
@@ -304,6 +304,7 @@ impl EmbeddingSource for JsonValue {
         let Some(nova) = entity_nova_meta_json(self) else {
             return;
         };
+        let nova = nova.as_ref();
         visit_string_array(nova, "synonyms", f);
         visit_string_array(nova, "domains", f);
         visit_string_array(nova, "use_cases", f);

--- a/src/manifest/embeddings/text.rs
+++ b/src/manifest/embeddings/text.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use serde_json::Value as JsonValue;
 
 use crate::config::SearchConfig;
-use crate::manifest::entity::{ArchivedEntity, Entity};
+use crate::manifest::entity::{ArchivedEntity, Entity, entity_nova_meta_json};
 
 #[must_use]
 pub fn embedding_text(entity: &Entity, config: &SearchConfig) -> String {
@@ -301,7 +301,7 @@ impl EmbeddingSource for JsonValue {
     }
 
     fn visit_nova_meta(&self, f: &mut dyn FnMut(&str)) {
-        let Some(nova) = self.get("meta").and_then(|v| v.get("nova")) else {
+        let Some(nova) = entity_nova_meta_json(self) else {
             return;
         };
         visit_string_array(nova, "synonyms", f);

--- a/src/manifest/entity.rs
+++ b/src/manifest/entity.rs
@@ -293,6 +293,59 @@ fn get_string(value: &serde_json::Value, key: &str) -> Option<String> {
     value.get(key).and_then(|v| v.as_str()).map(str::to_string)
 }
 
+#[must_use]
+pub fn entity_meta_field_json<'a>(value: &'a JsonValue, field: &str) -> Option<&'a JsonValue> {
+    value
+        .get("meta")
+        .and_then(|meta| meta.get(field))
+        .or_else(|| {
+            value
+                .get("config")
+                .and_then(|config| config.get("meta"))
+                .and_then(|meta| meta.get(field))
+        })
+}
+
+#[must_use]
+pub fn entity_nova_meta_json(value: &JsonValue) -> Option<&JsonValue> {
+    entity_meta_field_json(value, "nova")
+}
+
+#[must_use]
+pub fn column_meta_json(column: &JsonValue) -> Option<&JsonValue> {
+    column
+        .get("meta")
+        .or_else(|| column.get("config").and_then(|config| config.get("meta")))
+}
+
+#[must_use]
+pub fn column_meta_field_json<'a>(column: &'a JsonValue, field: &str) -> Option<&'a JsonValue> {
+    column
+        .get("meta")
+        .and_then(|meta| meta.get(field))
+        .or_else(|| {
+            column
+                .get("config")
+                .and_then(|config| config.get("meta"))
+                .and_then(|meta| meta.get(field))
+        })
+}
+
+#[must_use]
+pub fn column_nova_meta_json(column: &JsonValue) -> Option<&JsonValue> {
+    column_meta_field_json(column, "nova")
+}
+
+#[must_use]
+pub fn column_primary_key_json(column: &JsonValue) -> Option<&JsonValue> {
+    column_meta_field_json(column, "primary_key")
+}
+
+#[must_use]
+pub fn column_primary_key_bool(column: &JsonValue) -> bool {
+    parse_bool_like(column_primary_key_json(column)).unwrap_or(false)
+}
+
 fn get_tags(value: &serde_json::Value) -> Vec<String> {
     let Some(tags) = value.get("tags") else {
         return Vec::new();
@@ -362,10 +415,7 @@ fn get_column_meta(value: &serde_json::Value, column_names: &[String]) -> Vec<Co
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .map(str::to_string);
-        let nova = column
-            .get("meta")
-            .and_then(|m| m.get("nova"))
-            .and_then(|v| v.as_object());
+        let nova = column_nova_meta_json(column).and_then(JsonValue::as_object);
         let role = nova
             .and_then(|n| n.get("role"))
             .and_then(|v| v.as_str())
@@ -394,14 +444,7 @@ fn get_column_meta(value: &serde_json::Value, column_names: &[String]) -> Vec<Co
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
-        let primary_key = column
-            .get("meta")
-            .and_then(|m| m.get("primary_key"))
-            .and_then(|v| {
-                v.as_bool()
-                    .or_else(|| v.as_str().map(|s| s.eq_ignore_ascii_case("true")))
-            })
-            .unwrap_or(false);
+        let primary_key = column_primary_key_bool(column);
 
         if description.is_none()
             && role.is_none()
@@ -462,10 +505,7 @@ fn has_compiled_sql(value: &serde_json::Value) -> bool {
 
 #[allow(clippy::too_many_lines)]
 fn get_nova_meta(value: &serde_json::Value) -> Option<NovaMeta> {
-    let nova = value
-        .get("meta")
-        .and_then(|m| m.get("nova"))
-        .and_then(|v| v.as_object())?;
+    let nova = entity_nova_meta_json(value).and_then(JsonValue::as_object)?;
 
     let role = nova
         .get("role")
@@ -796,5 +836,53 @@ mod tests {
         assert!(meta.measures[0].canonical);
         assert_eq!(meta.metrics.len(), 1);
         assert!(meta.metrics[0].canonical);
+    }
+
+    #[test]
+    fn entity_nova_meta_prefers_legacy_meta_over_config_meta() {
+        let entity = serde_json::json!({
+            "meta": {
+                "nova": {
+                    "role": "dimension"
+                }
+            },
+            "config": {
+                "meta": {
+                    "nova": {
+                        "role": "measure"
+                    }
+                }
+            }
+        });
+
+        let nova = entity_nova_meta_json(&entity).expect("expected nova metadata");
+        assert_eq!(
+            nova.get("role").and_then(JsonValue::as_str),
+            Some("dimension")
+        );
+    }
+
+    #[test]
+    fn column_meta_helpers_fallback_to_config_meta() {
+        let column = serde_json::json!({
+            "name": "order_id",
+            "config": {
+                "meta": {
+                    "primary_key": true,
+                    "nova": {
+                        "role": "identifier"
+                    }
+                }
+            }
+        });
+
+        assert!(column_meta_json(&column).is_some());
+        assert!(column_primary_key_bool(&column));
+        assert_eq!(
+            column_nova_meta_json(&column)
+                .and_then(|nova| nova.get("role"))
+                .and_then(JsonValue::as_str),
+            Some("identifier")
+        );
     }
 }

--- a/src/manifest/entity.rs
+++ b/src/manifest/entity.rs
@@ -325,6 +325,7 @@ pub fn entity_nova_meta_json(value: &JsonValue) -> Option<Cow<'_, JsonValue>> {
 pub fn column_meta_json(column: &JsonValue) -> Option<&JsonValue> {
     column
         .get("meta")
+        .filter(|meta| !meta.is_null())
         .or_else(|| column.get("config").and_then(|config| config.get("meta")))
 }
 
@@ -988,6 +989,22 @@ mod tests {
                 .and_then(JsonValue::as_str),
             Some("identifier")
         );
+    }
+
+    #[test]
+    fn column_meta_json_falls_back_when_legacy_meta_is_null() {
+        let column = serde_json::json!({
+            "name": "order_id",
+            "meta": null,
+            "config": {
+                "meta": {
+                    "primary_key": true
+                }
+            }
+        });
+
+        let meta = column_meta_json(&column).expect("expected config meta fallback");
+        assert_eq!(meta["primary_key"].as_bool(), Some(true));
     }
 
     #[test]

--- a/src/manifest/entity.rs
+++ b/src/manifest/entity.rs
@@ -330,8 +330,11 @@ pub fn column_meta_json(column: &JsonValue) -> Option<&JsonValue> {
 
 #[must_use]
 pub fn normalized_column_meta_json(column: &JsonValue) -> Option<JsonValue> {
-    let legacy = column.get("meta");
-    let config = column.get("config").and_then(|config| config.get("meta"));
+    let legacy = column.get("meta").filter(|meta| !meta.is_null());
+    let config = column
+        .get("config")
+        .and_then(|config| config.get("meta"))
+        .filter(|meta| !meta.is_null());
 
     match (legacy, config) {
         (Some(JsonValue::Object(legacy_obj)), Some(JsonValue::Object(config_obj))) => {
@@ -1095,5 +1098,26 @@ mod tests {
                 .and_then(|values| values.first()),
             Some(&JsonValue::String("purchase_id".to_string()))
         );
+    }
+
+    #[test]
+    fn normalized_column_meta_falls_back_when_legacy_meta_is_null() {
+        let column = serde_json::json!({
+            "meta": null,
+            "config": {
+                "meta": {
+                    "primary_key": true,
+                    "nova": {
+                        "role": "identifier",
+                        "semantic_type": "order_id"
+                    }
+                }
+            }
+        });
+
+        let meta = normalized_column_meta_json(&column).expect("expected config meta fallback");
+        assert_eq!(meta["primary_key"].as_bool(), Some(true));
+        assert_eq!(meta["nova"]["role"].as_str(), Some("identifier"));
+        assert_eq!(meta["nova"]["semantic_type"].as_str(), Some("order_id"));
     }
 }

--- a/src/manifest/entity.rs
+++ b/src/manifest/entity.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use rkyv::option::ArchivedOption;
 use rkyv::string::ArchivedString;
 use rkyv_derive::{Archive, Deserialize, Serialize};
@@ -307,8 +309,14 @@ pub fn entity_meta_field_json<'a>(value: &'a JsonValue, field: &str) -> Option<&
 }
 
 #[must_use]
-pub fn entity_nova_meta_json(value: &JsonValue) -> Option<&JsonValue> {
-    entity_meta_field_json(value, "nova")
+pub fn entity_nova_meta_json(value: &JsonValue) -> Option<Cow<'_, JsonValue>> {
+    merged_meta_value_json(
+        value.get("meta").and_then(|meta| meta.get("nova")),
+        value
+            .get("config")
+            .and_then(|config| config.get("meta"))
+            .and_then(|meta| meta.get("nova")),
+    )
 }
 
 #[must_use]
@@ -348,8 +356,14 @@ pub fn column_meta_field_json<'a>(column: &'a JsonValue, field: &str) -> Option<
 }
 
 #[must_use]
-pub fn column_nova_meta_json(column: &JsonValue) -> Option<&JsonValue> {
-    column_meta_field_json(column, "nova")
+pub fn column_nova_meta_json(column: &JsonValue) -> Option<Cow<'_, JsonValue>> {
+    merged_meta_value_json(
+        column.get("meta").and_then(|meta| meta.get("nova")),
+        column
+            .get("config")
+            .and_then(|config| config.get("meta"))
+            .and_then(|meta| meta.get("nova")),
+    )
 }
 
 #[must_use]
@@ -375,6 +389,21 @@ fn merge_json_value(target: &mut JsonValue, overlay: &JsonValue) {
             }
         }
         (target_value, overlay_value) => *target_value = overlay_value.clone(),
+    }
+}
+
+fn merged_meta_value_json<'a>(
+    legacy: Option<&'a JsonValue>,
+    config: Option<&'a JsonValue>,
+) -> Option<Cow<'a, JsonValue>> {
+    match (legacy, config) {
+        (Some(JsonValue::Object(legacy_obj)), Some(JsonValue::Object(config_obj))) => {
+            let mut merged = JsonValue::Object(config_obj.clone());
+            merge_json_value(&mut merged, &JsonValue::Object(legacy_obj.clone()));
+            Some(Cow::Owned(merged))
+        }
+        (Some(value), _) | (None, Some(value)) => Some(Cow::Borrowed(value)),
+        (None, None) => None,
     }
 }
 
@@ -447,7 +476,8 @@ fn get_column_meta(value: &serde_json::Value, column_names: &[String]) -> Vec<Co
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .map(str::to_string);
-        let nova = column_nova_meta_json(column).and_then(JsonValue::as_object);
+        let nova_json = column_nova_meta_json(column);
+        let nova = nova_json.as_deref().and_then(JsonValue::as_object);
         let role = nova
             .and_then(|n| n.get("role"))
             .and_then(|v| v.as_str())
@@ -537,7 +567,8 @@ fn has_compiled_sql(value: &serde_json::Value) -> bool {
 
 #[allow(clippy::too_many_lines)]
 fn get_nova_meta(value: &serde_json::Value) -> Option<NovaMeta> {
-    let nova = entity_nova_meta_json(value).and_then(JsonValue::as_object)?;
+    let nova_json = entity_nova_meta_json(value);
+    let nova = nova_json.as_deref().and_then(JsonValue::as_object)?;
 
     let role = nova
         .get("role")
@@ -889,7 +920,7 @@ mod tests {
 
         let nova = entity_nova_meta_json(&entity).expect("expected nova metadata");
         assert_eq!(
-            nova.get("role").and_then(JsonValue::as_str),
+            nova.as_ref().get("role").and_then(JsonValue::as_str),
             Some("dimension")
         );
     }
@@ -912,9 +943,68 @@ mod tests {
         assert!(column_primary_key_bool(&column));
         assert_eq!(
             column_nova_meta_json(&column)
+                .as_deref()
                 .and_then(|nova| nova.get("role"))
                 .and_then(JsonValue::as_str),
             Some("identifier")
+        );
+    }
+
+    #[test]
+    fn entity_nova_meta_merges_partial_legacy_and_config_objects() {
+        let entity = serde_json::json!({
+            "meta": {
+                "nova": {
+                    "role": "dimension"
+                }
+            },
+            "config": {
+                "meta": {
+                    "nova": {
+                        "semantic_type": "market",
+                        "synonyms": ["country"]
+                    }
+                }
+            }
+        });
+
+        let nova = entity_nova_meta_json(&entity).expect("expected nova metadata");
+        assert_eq!(nova["role"].as_str(), Some("dimension"));
+        assert_eq!(nova["semantic_type"].as_str(), Some("market"));
+        assert_eq!(
+            nova["synonyms"]
+                .as_array()
+                .and_then(|values| values.first()),
+            Some(&JsonValue::String("country".to_string()))
+        );
+    }
+
+    #[test]
+    fn column_nova_meta_merges_partial_legacy_and_config_objects() {
+        let column = serde_json::json!({
+            "meta": {
+                "nova": {
+                    "role": "identifier"
+                }
+            },
+            "config": {
+                "meta": {
+                    "nova": {
+                        "semantic_type": "order_id",
+                        "synonyms": ["purchase_id"]
+                    }
+                }
+            }
+        });
+
+        let nova = column_nova_meta_json(&column).expect("expected nova metadata");
+        assert_eq!(nova["role"].as_str(), Some("identifier"));
+        assert_eq!(nova["semantic_type"].as_str(), Some("order_id"));
+        assert_eq!(
+            nova["synonyms"]
+                .as_array()
+                .and_then(|values| values.first()),
+            Some(&JsonValue::String("purchase_id".to_string()))
         );
     }
 }

--- a/src/manifest/entity.rs
+++ b/src/manifest/entity.rs
@@ -300,11 +300,13 @@ pub fn entity_meta_field_json<'a>(value: &'a JsonValue, field: &str) -> Option<&
     value
         .get("meta")
         .and_then(|meta| meta.get(field))
+        .filter(|meta| !meta.is_null())
         .or_else(|| {
             value
                 .get("config")
                 .and_then(|config| config.get("meta"))
                 .and_then(|meta| meta.get(field))
+                .filter(|meta| !meta.is_null())
         })
 }
 
@@ -347,11 +349,13 @@ pub fn column_meta_field_json<'a>(column: &'a JsonValue, field: &str) -> Option<
     column
         .get("meta")
         .and_then(|meta| meta.get(field))
+        .filter(|meta| !meta.is_null())
         .or_else(|| {
             column
                 .get("config")
                 .and_then(|config| config.get("meta"))
                 .and_then(|meta| meta.get(field))
+                .filter(|meta| !meta.is_null())
         })
 }
 
@@ -377,6 +381,9 @@ pub fn column_primary_key_bool(column: &JsonValue) -> bool {
 }
 
 fn merge_json_value(target: &mut JsonValue, overlay: &JsonValue) {
+    if overlay.is_null() {
+        return;
+    }
     match (target, overlay) {
         (JsonValue::Object(target_obj), JsonValue::Object(overlay_obj)) => {
             for (key, overlay_value) in overlay_obj {
@@ -396,6 +403,8 @@ fn merged_meta_value_json<'a>(
     legacy: Option<&'a JsonValue>,
     config: Option<&'a JsonValue>,
 ) -> Option<Cow<'a, JsonValue>> {
+    let legacy = legacy.filter(|value| !value.is_null());
+    let config = config.filter(|value| !value.is_null());
     match (legacy, config) {
         (Some(JsonValue::Object(legacy_obj)), Some(JsonValue::Object(config_obj))) => {
             let mut merged = JsonValue::Object(config_obj.clone());
@@ -951,6 +960,34 @@ mod tests {
     }
 
     #[test]
+    fn column_meta_helpers_ignore_null_legacy_fields() {
+        let column = serde_json::json!({
+            "name": "order_id",
+            "meta": {
+                "primary_key": null,
+                "nova": null
+            },
+            "config": {
+                "meta": {
+                    "primary_key": true,
+                    "nova": {
+                        "role": "identifier"
+                    }
+                }
+            }
+        });
+
+        assert!(column_primary_key_bool(&column));
+        assert_eq!(
+            column_nova_meta_json(&column)
+                .as_deref()
+                .and_then(|nova| nova.get("role"))
+                .and_then(JsonValue::as_str),
+            Some("identifier")
+        );
+    }
+
+    #[test]
     fn entity_nova_meta_merges_partial_legacy_and_config_objects() {
         let entity = serde_json::json!({
             "meta": {
@@ -980,6 +1017,25 @@ mod tests {
     }
 
     #[test]
+    fn entity_nova_meta_falls_back_when_legacy_nova_is_null() {
+        let entity = serde_json::json!({
+            "meta": {
+                "nova": null
+            },
+            "config": {
+                "meta": {
+                    "nova": {
+                        "role": "dimension"
+                    }
+                }
+            }
+        });
+
+        let nova = entity_nova_meta_json(&entity).expect("expected nova metadata");
+        assert_eq!(nova["role"].as_str(), Some("dimension"));
+    }
+
+    #[test]
     fn column_nova_meta_merges_partial_legacy_and_config_objects() {
         let column = serde_json::json!({
             "meta": {
@@ -1002,6 +1058,39 @@ mod tests {
         assert_eq!(nova["semantic_type"].as_str(), Some("order_id"));
         assert_eq!(
             nova["synonyms"]
+                .as_array()
+                .and_then(|values| values.first()),
+            Some(&JsonValue::String("purchase_id".to_string()))
+        );
+    }
+
+    #[test]
+    fn normalized_column_meta_ignores_null_legacy_values() {
+        let column = serde_json::json!({
+            "meta": {
+                "primary_key": null,
+                "nova": {
+                    "role": "identifier",
+                    "semantic_type": null
+                }
+            },
+            "config": {
+                "meta": {
+                    "primary_key": true,
+                    "nova": {
+                        "semantic_type": "order_id",
+                        "synonyms": ["purchase_id"]
+                    }
+                }
+            }
+        });
+
+        let meta = normalized_column_meta_json(&column).expect("expected merged meta");
+        assert_eq!(meta["primary_key"].as_bool(), Some(true));
+        assert_eq!(meta["nova"]["role"].as_str(), Some("identifier"));
+        assert_eq!(meta["nova"]["semantic_type"].as_str(), Some("order_id"));
+        assert_eq!(
+            meta["nova"]["synonyms"]
                 .as_array()
                 .and_then(|values| values.first()),
             Some(&JsonValue::String("purchase_id".to_string()))

--- a/src/manifest/entity.rs
+++ b/src/manifest/entity.rs
@@ -319,6 +319,22 @@ pub fn column_meta_json(column: &JsonValue) -> Option<&JsonValue> {
 }
 
 #[must_use]
+pub fn normalized_column_meta_json(column: &JsonValue) -> Option<JsonValue> {
+    let legacy = column.get("meta");
+    let config = column.get("config").and_then(|config| config.get("meta"));
+
+    match (legacy, config) {
+        (Some(JsonValue::Object(legacy_obj)), Some(JsonValue::Object(config_obj))) => {
+            let mut merged = JsonValue::Object(config_obj.clone());
+            merge_json_value(&mut merged, &JsonValue::Object(legacy_obj.clone()));
+            Some(merged)
+        }
+        (Some(value), _) | (None, Some(value)) => Some(value.clone()),
+        (None, None) => None,
+    }
+}
+
+#[must_use]
 pub fn column_meta_field_json<'a>(column: &'a JsonValue, field: &str) -> Option<&'a JsonValue> {
     column
         .get("meta")
@@ -344,6 +360,22 @@ pub fn column_primary_key_json(column: &JsonValue) -> Option<&JsonValue> {
 #[must_use]
 pub fn column_primary_key_bool(column: &JsonValue) -> bool {
     parse_bool_like(column_primary_key_json(column)).unwrap_or(false)
+}
+
+fn merge_json_value(target: &mut JsonValue, overlay: &JsonValue) {
+    match (target, overlay) {
+        (JsonValue::Object(target_obj), JsonValue::Object(overlay_obj)) => {
+            for (key, overlay_value) in overlay_obj {
+                match target_obj.get_mut(key) {
+                    Some(target_value) => merge_json_value(target_value, overlay_value),
+                    None => {
+                        target_obj.insert(key.clone(), overlay_value.clone());
+                    }
+                }
+            }
+        }
+        (target_value, overlay_value) => *target_value = overlay_value.clone(),
+    }
 }
 
 fn get_tags(value: &serde_json::Value) -> Vec<String> {

--- a/src/manifest/search/summary/nova.rs
+++ b/src/manifest/search/summary/nova.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use serde_json::Value as JsonValue;
 
+use crate::manifest::entity::entity_nova_meta_json;
 use crate::manifest::entity::{ArchivedNovaGrain, ArchivedNovaMeta};
 use crate::manifest::search::{SemanticPreviewItem, match_nova_semantics};
 
@@ -29,9 +30,7 @@ impl ManifestSearch {
         required_fields.sort();
         required_fields.dedup();
 
-        let nova_json = entity_json
-            .get("meta")
-            .and_then(|m| m.get("nova"))
+        let nova_json = entity_nova_meta_json(entity_json)
             .cloned()
             .unwrap_or(JsonValue::Null);
         if nova_json.is_null() {

--- a/src/manifest/search/summary/nova.rs
+++ b/src/manifest/search/summary/nova.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashSet;
 
 use serde_json::Value as JsonValue;
@@ -30,9 +31,7 @@ impl ManifestSearch {
         required_fields.sort();
         required_fields.dedup();
 
-        let nova_json = entity_nova_meta_json(entity_json)
-            .cloned()
-            .unwrap_or(JsonValue::Null);
+        let nova_json = entity_nova_meta_json(entity_json).map_or(JsonValue::Null, Cow::into_owned);
         if nova_json.is_null() {
             return required_fields;
         }

--- a/src/manifest/tantivy_search.rs
+++ b/src/manifest/tantivy_search.rs
@@ -19,6 +19,7 @@ use tantivy::{Index, IndexReader, IndexWriter, Term};
 
 use crate::config::SearchConfig;
 use crate::error::{DbtNovaError, Result};
+use crate::manifest::entity::{column_nova_meta_json, entity_nova_meta_json};
 use crate::manifest::store::EntityStore;
 use crate::utils::{SearchPersona, has_query_syntax, tokenize_alnum_lowercase};
 use tracing::{debug, info, instrument, warn};
@@ -196,11 +197,7 @@ impl TantivySearcher {
                 let mut tokens: Vec<String> = Vec::new();
                 for (name, col) in cols {
                     tokens.push(name.clone());
-                    if let Some(nova) = col
-                        .get("meta")
-                        .and_then(|m| m.get("nova"))
-                        .and_then(|v| v.as_object())
-                    {
+                    if let Some(nova) = column_nova_meta_json(col).and_then(JsonValue::as_object) {
                         if let Some(semantic) = nova.get("semantic_type").and_then(|v| v.as_str()) {
                             tokens.push(semantic.to_string());
                         }
@@ -274,11 +271,7 @@ impl TantivySearcher {
                 doc.add_text(fields.package_name, pkg);
             }
 
-            if let Some(nova) = entity_json
-                .get("meta")
-                .and_then(|m| m.get("nova"))
-                .and_then(|v| v.as_object())
-            {
+            if let Some(nova) = entity_nova_meta_json(&entity_json).and_then(JsonValue::as_object) {
                 if let Some(syns) = nova.get("synonyms").and_then(|v| v.as_array()) {
                     for syn in syns {
                         if let Some(s) = syn.as_str().filter(|s| !s.is_empty()) {

--- a/src/manifest/tantivy_search.rs
+++ b/src/manifest/tantivy_search.rs
@@ -197,7 +197,10 @@ impl TantivySearcher {
                 let mut tokens: Vec<String> = Vec::new();
                 for (name, col) in cols {
                     tokens.push(name.clone());
-                    if let Some(nova) = column_nova_meta_json(col).and_then(JsonValue::as_object) {
+                    if let Some(nova) = column_nova_meta_json(col)
+                        .as_deref()
+                        .and_then(JsonValue::as_object)
+                    {
                         if let Some(semantic) = nova.get("semantic_type").and_then(|v| v.as_str()) {
                             tokens.push(semantic.to_string());
                         }
@@ -271,7 +274,10 @@ impl TantivySearcher {
                 doc.add_text(fields.package_name, pkg);
             }
 
-            if let Some(nova) = entity_nova_meta_json(&entity_json).and_then(JsonValue::as_object) {
+            if let Some(nova) = entity_nova_meta_json(&entity_json)
+                .as_deref()
+                .and_then(JsonValue::as_object)
+            {
                 if let Some(syns) = nova.get("synonyms").and_then(|v| v.as_array()) {
                     for syn in syns {
                         if let Some(s) = syn.as_str().filter(|s| !s.is_empty()) {

--- a/src/tests/config_meta.rs
+++ b/src/tests/config_meta.rs
@@ -32,6 +32,7 @@ async fn test_get_columns_supports_config_meta_primary_key() {
         order_id["meta"]["nova"]["role"].as_str(),
         Some("identifier")
     );
+    assert_eq!(order_id["meta"]["primary_key"].as_bool(), Some(true));
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -92,5 +93,44 @@ async fn test_search_supports_config_meta_only_nova_metadata() {
     assert_eq!(
         rows.first().and_then(|row| row["unique_id"].as_str()),
         Some("model.pkg.config_meta_model")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_context_merges_legacy_and_config_column_meta() {
+    let searcher = config_meta_searcher();
+    let result = searcher
+        .get_context(&GetContextParams {
+            id_or_name: "config_meta_model".to_string(),
+            resource_type: None,
+            include_columns: true,
+            include_tests: false,
+            include_upstream: false,
+            include_downstream: false,
+            include_docs: false,
+            include_sql: false,
+            context_mode: ContextMode::Standard,
+            limits: ContextLimits {
+                lineage_depth: 1,
+                upstream_limit: 5,
+                downstream_limit: 5,
+            },
+        })
+        .await
+        .json();
+
+    assert_eq!(result["success"].as_bool(), Some(true));
+    let columns = result["data"]["entity"]["columns"]
+        .as_array()
+        .expect("expected columns array");
+    let order_id = columns
+        .iter()
+        .find(|column| column["name"].as_str() == Some("order_id"))
+        .expect("missing order_id column");
+
+    assert_eq!(order_id["meta"]["primary_key"].as_bool(), Some(true));
+    assert_eq!(
+        order_id["meta"]["nova"]["role"].as_str(),
+        Some("identifier")
     );
 }

--- a/src/tests/config_meta.rs
+++ b/src/tests/config_meta.rs
@@ -1,0 +1,96 @@
+//! Regression tests for dbt 1.11+ `config.meta` fallback behavior.
+use super::common::*;
+
+fn config_meta_searcher() -> TestSearchEnv {
+    get_searcher_with_fixture("config_meta_only.json")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_columns_supports_config_meta_primary_key() {
+    let searcher = config_meta_searcher();
+    let result = searcher
+        .get_columns(&GetColumnsParams {
+            id_or_name: "config_meta_model".to_string(),
+        })
+        .await
+        .json();
+
+    assert_eq!(result["success"].as_bool(), Some(true));
+    assert_eq!(
+        result["data"]["primary_key_columns"].as_array(),
+        Some(&vec![JsonValue::String("order_id".to_string())])
+    );
+
+    let columns = result["data"]["columns"]
+        .as_array()
+        .expect("expected columns array");
+    let order_id = columns
+        .iter()
+        .find(|column| column["name"].as_str() == Some("order_id"))
+        .expect("missing order_id column");
+    assert_eq!(
+        order_id["meta"]["nova"]["role"].as_str(),
+        Some("identifier")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_metadata_score_supports_config_meta_only() {
+    let searcher = config_meta_searcher();
+    let result = searcher
+        .get_metadata_score(&GetMetadataScoreParams {
+            id_or_name: Some("config_meta_model".to_string()),
+            scope: Some("entity".to_string()),
+            include_breakdown: true,
+            include_recommendations: false,
+            ..Default::default()
+        })
+        .await
+        .json();
+
+    assert_eq!(result["success"].as_bool(), Some(true));
+    assert!(
+        result["data"]["categories"]["semantic"]["score"]
+            .as_u64()
+            .is_some_and(|score| score > 0)
+    );
+    assert!(
+        result["data"]["categories"]["governance"]["score"]
+            .as_u64()
+            .is_some_and(|score| score > 0)
+    );
+    assert_eq!(
+        result["data"]["breakdown"]["quality"]["primary_key"]["present"].as_bool(),
+        Some(true)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_search_supports_config_meta_only_nova_metadata() {
+    let searcher = config_meta_searcher();
+    let result = searcher
+        .search(&SearchParams {
+            query: "revenue".to_string(),
+            resource_types: vec!["model".to_string()],
+            persona: None,
+            detail: DetailLevel::Standard,
+            min_score: None,
+            fuzzy: false,
+            include_highlights: false,
+            include_sql: false,
+            explain: false,
+            pagination: PaginationParams {
+                limit: 5,
+                offset: 0,
+            },
+        })
+        .await
+        .json();
+
+    assert_eq!(result["success"].as_bool(), Some(true));
+    let rows = result["data"].as_array().expect("expected data array");
+    assert_eq!(
+        rows.first().and_then(|row| row["unique_id"].as_str()),
+        Some("model.pkg.config_meta_model")
+    );
+}

--- a/src/tests/config_meta.rs
+++ b/src/tests/config_meta.rs
@@ -33,6 +33,14 @@ async fn test_get_columns_supports_config_meta_primary_key() {
         Some("identifier")
     );
     assert_eq!(order_id["meta"]["primary_key"].as_bool(), Some(true));
+    assert_eq!(
+        order_id["meta"]["nova"]["semantic_type"].as_str(),
+        Some("order_id")
+    );
+    assert_eq!(
+        order_id["meta"]["nova"]["synonyms"].as_array(),
+        Some(&vec![JsonValue::String("purchase_id".to_string())])
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -97,6 +105,36 @@ async fn test_search_supports_config_meta_only_nova_metadata() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_search_supports_mixed_legacy_and_config_column_nova_metadata() {
+    let searcher = config_meta_searcher();
+    let result = searcher
+        .search(&SearchParams {
+            query: "purchase_id".to_string(),
+            resource_types: vec!["model".to_string()],
+            persona: None,
+            detail: DetailLevel::Standard,
+            min_score: None,
+            fuzzy: false,
+            include_highlights: false,
+            include_sql: false,
+            explain: false,
+            pagination: PaginationParams {
+                limit: 5,
+                offset: 0,
+            },
+        })
+        .await
+        .json();
+
+    assert_eq!(result["success"].as_bool(), Some(true));
+    let rows = result["data"].as_array().expect("expected data array");
+    assert_eq!(
+        rows.first().and_then(|row| row["unique_id"].as_str()),
+        Some("model.pkg.config_meta_model")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_get_context_merges_legacy_and_config_column_meta() {
     let searcher = config_meta_searcher();
     let result = searcher
@@ -132,5 +170,13 @@ async fn test_get_context_merges_legacy_and_config_column_meta() {
     assert_eq!(
         order_id["meta"]["nova"]["role"].as_str(),
         Some("identifier")
+    );
+    assert_eq!(
+        order_id["meta"]["nova"]["semantic_type"].as_str(),
+        Some("order_id")
+    );
+    assert_eq!(
+        order_id["meta"]["nova"]["synonyms"].as_array(),
+        Some(&vec![JsonValue::String("purchase_id".to_string())])
     );
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -8,6 +8,7 @@ mod batch_get;
 mod column_lineage;
 mod columns;
 pub(crate) mod common;
+mod config_meta;
 mod context;
 mod coverage;
 mod deep_metadata;

--- a/src/tools/context.rs
+++ b/src/tools/context.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use serde_json::Value as JsonValue;
 
 use crate::error::{DbtNovaError, Result};
-use crate::manifest::entity::{Entity, NovaMeta};
+use crate::manifest::entity::{Entity, NovaMeta, column_meta_json, column_primary_key_bool};
 use crate::manifest::search::ManifestSearch;
 use crate::params::{ContextMode, GetContextParams};
 use crate::responses::SuccessResponse;
@@ -339,7 +339,7 @@ impl ManifestSearch {
                     .get("data_type")
                     .and_then(|v| v.as_str())
                     .map(String::from),
-                meta: col_info.get("meta").cloned(),
+                meta: column_meta_json(col_info).cloned(),
                 tests: col_tests,
             });
         }
@@ -525,11 +525,7 @@ impl ManifestSearch {
             let entity_json = entity.to_json_value();
             if let Some(cols) = entity_json.get("columns").and_then(|c| c.as_object()) {
                 for (col_name, col_info) in cols {
-                    let is_pk = col_info
-                        .get("meta")
-                        .and_then(|m| m.get("primary_key"))
-                        .and_then(JsonValue::as_bool)
-                        .unwrap_or(false);
+                    let is_pk = column_primary_key_bool(col_info);
 
                     if is_pk {
                         pk_columns.insert(col_name.clone());

--- a/src/tools/context.rs
+++ b/src/tools/context.rs
@@ -4,7 +4,9 @@ use serde::Serialize;
 use serde_json::Value as JsonValue;
 
 use crate::error::{DbtNovaError, Result};
-use crate::manifest::entity::{Entity, NovaMeta, column_meta_json, column_primary_key_bool};
+use crate::manifest::entity::{
+    Entity, NovaMeta, column_primary_key_bool, normalized_column_meta_json,
+};
 use crate::manifest::search::ManifestSearch;
 use crate::params::{ContextMode, GetContextParams};
 use crate::responses::SuccessResponse;
@@ -339,7 +341,7 @@ impl ManifestSearch {
                     .get("data_type")
                     .and_then(|v| v.as_str())
                     .map(String::from),
-                meta: column_meta_json(col_info).cloned(),
+                meta: normalized_column_meta_json(col_info),
                 tests: col_tests,
             });
         }

--- a/src/tools/coverage.rs
+++ b/src/tools/coverage.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use serde_json::Value as JsonValue;
 
 use crate::error::Result;
+use crate::manifest::entity::column_primary_key_bool;
 use crate::manifest::search::ManifestSearch;
 use crate::params::{DEFAULT_TEST_COVERAGE_COLUMNS_LIMIT, GetTestCoverageParams};
 use crate::responses::SuccessResponse;
@@ -95,11 +96,7 @@ impl ManifestSearch {
 
         if let Some(cols) = entity_json.get("columns").and_then(|c| c.as_object()) {
             for (col_name, col_info) in cols {
-                let is_pk = col_info
-                    .get("meta")
-                    .and_then(|m| m.get("primary_key"))
-                    .and_then(JsonValue::as_bool)
-                    .unwrap_or(false);
+                let is_pk = column_primary_key_bool(col_info);
 
                 if is_pk {
                     let key = format!("{}:{col_name}", &entity_id);

--- a/src/tools/entity.rs
+++ b/src/tools/entity.rs
@@ -1,7 +1,7 @@
 use serde_json::Value as JsonValue;
 
 use crate::error::{DbtNovaError, Result};
-use crate::manifest::entity::column_meta_json;
+use crate::manifest::entity::normalized_column_meta_json;
 use crate::manifest::search::ManifestSearch;
 use crate::params::{BatchGetParams, DetailLevel, GetColumnsParams, GetEntityParams, GetSqlParams};
 use crate::responses::SuccessResponse;
@@ -218,8 +218,7 @@ fn sql_contains_templating(sql: &str) -> bool {
 fn normalized_column_json(column: &JsonValue) -> JsonValue {
     let mut normalized = column.clone();
     if let Some(obj) = normalized.as_object_mut()
-        && !obj.contains_key("meta")
-        && let Some(meta) = column_meta_json(column).cloned()
+        && let Some(meta) = normalized_column_meta_json(column)
     {
         obj.insert("meta".to_string(), meta);
     }

--- a/src/tools/entity.rs
+++ b/src/tools/entity.rs
@@ -1,6 +1,7 @@
 use serde_json::Value as JsonValue;
 
 use crate::error::{DbtNovaError, Result};
+use crate::manifest::entity::column_meta_json;
 use crate::manifest::search::ManifestSearch;
 use crate::params::{BatchGetParams, DetailLevel, GetColumnsParams, GetEntityParams, GetSqlParams};
 use crate::responses::SuccessResponse;
@@ -114,7 +115,7 @@ impl ManifestSearch {
             ordered.sort_by_key(|(name, _)| *name);
             ordered
                 .into_iter()
-                .map(|(_, value)| value.clone())
+                .map(|(_, value)| normalized_column_json(value))
                 .collect()
         } else {
             vec![]
@@ -212,4 +213,15 @@ fn sql_contains_templating(sql: &str) -> bool {
         || sql.contains("{#")
         || sql.contains("{ ref(")
         || sql.contains("{{ ref(")
+}
+
+fn normalized_column_json(column: &JsonValue) -> JsonValue {
+    let mut normalized = column.clone();
+    if let Some(obj) = normalized.as_object_mut()
+        && !obj.contains_key("meta")
+        && let Some(meta) = column_meta_json(column).cloned()
+    {
+        obj.insert("meta".to_string(), meta);
+    }
+    normalized
 }

--- a/src/tools/helpers.rs
+++ b/src/tools/helpers.rs
@@ -1,5 +1,7 @@
 use serde_json::Value as JsonValue;
 
+use crate::manifest::entity::column_primary_key_bool;
+
 pub fn dependency_hints_from_json(entity_json: &JsonValue) -> (JsonValue, usize) {
     let depends_on_nodes = entity_json
         .get("depends_on")
@@ -25,17 +27,14 @@ pub fn dependency_hints_from_json(entity_json: &JsonValue) -> (JsonValue, usize)
     )
 }
 
+#[must_use]
 pub fn primary_key_columns_from_columns(columns: &JsonValue) -> Vec<String> {
     let mut primary_keys = Vec::new();
     let Some(obj) = columns.as_object() else {
         return primary_keys;
     };
     for (name, column) in obj {
-        let is_primary = column
-            .get("meta")
-            .and_then(|meta| meta.get("primary_key"))
-            .and_then(JsonValue::as_bool)
-            .unwrap_or(false);
+        let is_primary = column_primary_key_bool(column);
         if is_primary {
             primary_keys.push(name.clone());
         }
@@ -43,6 +42,7 @@ pub fn primary_key_columns_from_columns(columns: &JsonValue) -> Vec<String> {
     primary_keys
 }
 
+#[must_use]
 pub fn primary_key_columns_from_entity(entity_json: &JsonValue) -> Vec<String> {
     entity_json
         .get("columns")

--- a/src/tools/metadata_score/governance/column.rs
+++ b/src/tools/metadata_score/governance/column.rs
@@ -1,5 +1,6 @@
 use serde_json::Value as JsonValue;
 
+use crate::manifest::entity::column_nova_meta_json;
 use crate::manifest::search::ManifestSearch;
 
 use crate::tools::metadata_score::CategoryBreakdown;
@@ -14,10 +15,7 @@ impl ManifestSearch {
         include_recommendations: bool,
         recommendations: &mut Vec<JsonValue>,
     ) -> CategoryBreakdown {
-        let governance = column_info
-            .get("meta")
-            .and_then(|m| m.get("nova"))
-            .and_then(|n| n.get("governance"));
+        let governance = column_nova_meta_json(column_info).and_then(|n| n.get("governance"));
 
         let sensitivity = governance
             .and_then(|g| g.get("sensitivity"))

--- a/src/tools/metadata_score/governance/column.rs
+++ b/src/tools/metadata_score/governance/column.rs
@@ -15,7 +15,8 @@ impl ManifestSearch {
         include_recommendations: bool,
         recommendations: &mut Vec<JsonValue>,
     ) -> CategoryBreakdown {
-        let governance = column_nova_meta_json(column_info).and_then(|n| n.get("governance"));
+        let nova_json = column_nova_meta_json(column_info);
+        let governance = nova_json.as_deref().and_then(|n| n.get("governance"));
 
         let sensitivity = governance
             .and_then(|g| g.get("sensitivity"))

--- a/src/tools/metadata_score/governance/entity.rs
+++ b/src/tools/metadata_score/governance/entity.rs
@@ -18,6 +18,7 @@ impl ManifestSearch {
         let nova = entity_nova_meta_json(entity_json);
 
         let sensitivity = nova
+            .as_deref()
             .and_then(|n| n.get("governance"))
             .and_then(|g| g.get("sensitivity"))
             .and_then(|s| s.as_str());
@@ -33,6 +34,7 @@ impl ManifestSearch {
         }
 
         let pii = nova
+            .as_deref()
             .and_then(|n| n.get("governance"))
             .and_then(|g| g.get("pii"));
         let pii_score = if pii.is_some() { 30 } else { 0 };
@@ -47,6 +49,7 @@ impl ManifestSearch {
         }
 
         let compliance_count = nova
+            .as_deref()
             .and_then(|n| n.get("governance"))
             .and_then(|g| g.get("compliance"))
             .and_then(JsonValue::as_array)

--- a/src/tools/metadata_score/governance/entity.rs
+++ b/src/tools/metadata_score/governance/entity.rs
@@ -1,5 +1,6 @@
 use serde_json::Value as JsonValue;
 
+use crate::manifest::entity::entity_nova_meta_json;
 use crate::manifest::search::ManifestSearch;
 
 use crate::tools::metadata_score::CategoryBreakdown;
@@ -14,7 +15,7 @@ impl ManifestSearch {
         include_recommendations: bool,
         recommendations: &mut Vec<JsonValue>,
     ) -> CategoryBreakdown {
-        let nova = entity_json.get("meta").and_then(|m| m.get("nova"));
+        let nova = entity_nova_meta_json(entity_json);
 
         let sensitivity = nova
             .and_then(|n| n.get("governance"))

--- a/src/tools/metadata_score/helpers.rs
+++ b/src/tools/metadata_score/helpers.rs
@@ -1,5 +1,7 @@
 use serde_json::Value as JsonValue;
 
+use crate::manifest::entity::entity_meta_field_json;
+
 #[must_use]
 #[allow(clippy::cast_precision_loss)]
 pub(crate) fn average_score<I>(scores: I) -> u8
@@ -105,7 +107,7 @@ pub(crate) fn array_len(nova: Option<&JsonValue>, key: &str) -> usize {
 
 #[must_use]
 pub(crate) fn has_owner(entity_json: &JsonValue) -> bool {
-    let meta_owner = entity_json.get("meta").and_then(|m| m.get("owner"));
+    let meta_owner = entity_meta_field_json(entity_json, "owner");
 
     if let Some(owner) = meta_owner {
         match owner {

--- a/src/tools/metadata_score/quality/entity.rs
+++ b/src/tools/metadata_score/quality/entity.rs
@@ -1,5 +1,6 @@
 use serde_json::Value as JsonValue;
 
+use crate::manifest::entity::{column_nova_meta_json, column_primary_key_bool};
 use crate::manifest::search::ManifestSearch;
 
 use crate::tools::metadata_score::CategoryBreakdown;
@@ -387,13 +388,8 @@ fn column_has_tests(search: &ManifestSearch, unique_id: &str, column_name: &str)
 }
 
 fn column_role(col: &JsonValue) -> Option<String> {
-    let meta = col.get("meta").and_then(|m| m.as_object());
-    let is_pk = meta
-        .and_then(|m| m.get("primary_key"))
-        .and_then(JsonValue::as_bool)
-        .unwrap_or(false);
-    let role = meta
-        .and_then(|m| m.get("nova"))
+    let is_pk = column_primary_key_bool(col);
+    let role = column_nova_meta_json(col)
         .and_then(|n| n.get("role"))
         .and_then(JsonValue::as_str)
         .map(str::to_string);
@@ -435,11 +431,7 @@ fn summarize_constraints(columns: &serde_json::Map<String, JsonValue>) -> Constr
 fn primary_keys(columns: &serde_json::Map<String, JsonValue>) -> (Vec<String>, bool) {
     let mut pk_cols = Vec::new();
     for (name, col) in columns {
-        let is_pk = col
-            .get("meta")
-            .and_then(|m| m.get("primary_key"))
-            .and_then(JsonValue::as_bool)
-            .unwrap_or(false);
+        let is_pk = column_primary_key_bool(col);
         if is_pk {
             pk_cols.push(name.clone());
         }

--- a/src/tools/metadata_score/quality/entity.rs
+++ b/src/tools/metadata_score/quality/entity.rs
@@ -390,6 +390,7 @@ fn column_has_tests(search: &ManifestSearch, unique_id: &str, column_name: &str)
 fn column_role(col: &JsonValue) -> Option<String> {
     let is_pk = column_primary_key_bool(col);
     let role = column_nova_meta_json(col)
+        .as_deref()
         .and_then(|n| n.get("role"))
         .and_then(JsonValue::as_str)
         .map(str::to_string);

--- a/src/tools/metadata_score/semantic/column.rs
+++ b/src/tools/metadata_score/semantic/column.rs
@@ -17,9 +17,12 @@ impl ManifestSearch {
     ) -> CategoryBreakdown {
         let nova = column_nova_meta_json(column_info);
 
-        let role_present = nova.and_then(|n| n.get("role")).is_some();
-        let semantic_present = nova.and_then(|n| n.get("semantic_type")).is_some();
-        let synonyms_count = array_len(nova, "synonyms");
+        let role_present = nova.as_deref().and_then(|n| n.get("role")).is_some();
+        let semantic_present = nova
+            .as_deref()
+            .and_then(|n| n.get("semantic_type"))
+            .is_some();
+        let synonyms_count = array_len(nova.as_deref(), "synonyms");
 
         let role_score = if role_present { 30 } else { 0 };
         if include_recommendations && role_score == 0 {

--- a/src/tools/metadata_score/semantic/column.rs
+++ b/src/tools/metadata_score/semantic/column.rs
@@ -1,5 +1,6 @@
 use serde_json::Value as JsonValue;
 
+use crate::manifest::entity::column_nova_meta_json;
 use crate::manifest::search::ManifestSearch;
 
 use crate::tools::metadata_score::CategoryBreakdown;
@@ -14,7 +15,7 @@ impl ManifestSearch {
         include_recommendations: bool,
         recommendations: &mut Vec<JsonValue>,
     ) -> CategoryBreakdown {
-        let nova = column_info.get("meta").and_then(|m| m.get("nova"));
+        let nova = column_nova_meta_json(column_info);
 
         let role_present = nova.and_then(|n| n.get("role")).is_some();
         let semantic_present = nova.and_then(|n| n.get("semantic_type")).is_some();

--- a/src/tools/metadata_score/semantic/entity.rs
+++ b/src/tools/metadata_score/semantic/entity.rs
@@ -1,5 +1,6 @@
 use serde_json::Value as JsonValue;
 
+use crate::manifest::entity::{column_nova_meta_json, entity_nova_meta_json};
 use crate::manifest::search::ManifestSearch;
 
 use crate::tools::metadata_score::CategoryBreakdown;
@@ -18,7 +19,7 @@ impl ManifestSearch {
         include_recommendations: bool,
         recommendations: &mut Vec<JsonValue>,
     ) -> CategoryBreakdown {
-        let nova = entity_json.get("meta").and_then(|m| m.get("nova"));
+        let nova = entity_nova_meta_json(entity_json);
         let columns = entity_json
             .get("columns")
             .and_then(|c| c.as_object())
@@ -298,7 +299,7 @@ fn column_semantic_coverage(
     }
     let mut with_semantic = 0usize;
     for column in columns.values() {
-        let nova = column.get("meta").and_then(|m| m.get("nova"));
+        let nova = column_nova_meta_json(column);
         if nova.and_then(|n| n.get("role")).is_some()
             || nova.and_then(|n| n.get("semantic_type")).is_some()
         {

--- a/src/tools/metadata_score/semantic/entity.rs
+++ b/src/tools/metadata_score/semantic/entity.rs
@@ -27,7 +27,7 @@ impl ManifestSearch {
             .unwrap_or_default();
         let expects_columns = expects_columns(resource_type);
         let scores = collect_semantic_scores(
-            nova,
+            nova.as_deref(),
             &columns,
             expects_columns,
             include_recommendations,
@@ -300,8 +300,11 @@ fn column_semantic_coverage(
     let mut with_semantic = 0usize;
     for column in columns.values() {
         let nova = column_nova_meta_json(column);
-        if nova.and_then(|n| n.get("role")).is_some()
-            || nova.and_then(|n| n.get("semantic_type")).is_some()
+        if nova.as_deref().and_then(|n| n.get("role")).is_some()
+            || nova
+                .as_deref()
+                .and_then(|n| n.get("semantic_type"))
+                .is_some()
         {
             with_semantic += 1;
         }

--- a/tests/fixtures/config_meta_only.json
+++ b/tests/fixtures/config_meta_only.json
@@ -1,0 +1,101 @@
+{
+  "metadata": {
+    "dbt_version": "1.11.6",
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json"
+  },
+  "nodes": {
+    "model.pkg.config_meta_model": {
+      "name": "config_meta_model",
+      "resource_type": "model",
+      "package_name": "pkg",
+      "database": "db",
+      "schema": "sch",
+      "description": "Order summary model backed only by config.meta metadata.",
+      "raw_code": "select order_id, market_code, order_amount from source_table",
+      "config": {
+        "meta": {
+          "owner": "analytics",
+          "nova": {
+            "canonical": true,
+            "synonyms": ["orders rollup"],
+            "domains": ["commerce"],
+            "use_cases": ["weekly reporting"],
+            "grain": {
+              "primary_key": ["order_id"],
+              "dimensions": ["market_code"]
+            },
+            "measures": [
+              {
+                "name": "gross_sales",
+                "field": "order_amount",
+                "synonyms": ["revenue"],
+                "canonical": true
+              }
+            ],
+            "governance": {
+              "sensitivity": "internal",
+              "compliance": ["gdpr"]
+            }
+          }
+        }
+      },
+      "columns": {
+        "market_code": {
+          "name": "market_code",
+          "data_type": "string",
+          "description": "Market code",
+          "config": {
+            "meta": {
+              "nova": {
+                "role": "dimension",
+                "semantic_type": "market",
+                "example_values": ["ES", "FR"]
+              }
+            }
+          }
+        },
+        "order_amount": {
+          "name": "order_amount",
+          "data_type": "numeric",
+          "description": "Gross sales amount",
+          "config": {
+            "meta": {
+              "nova": {
+                "role": "measure",
+                "semantic_type": "currency_amount"
+              }
+            }
+          }
+        },
+        "order_id": {
+          "name": "order_id",
+          "data_type": "string",
+          "description": "Order identifier",
+          "config": {
+            "meta": {
+              "primary_key": true,
+              "nova": {
+                "role": "identifier",
+                "semantic_type": "order_id",
+                "synonyms": ["purchase_id"]
+              }
+            }
+          }
+        }
+      },
+      "tags": ["finance"],
+      "original_file_path": "models/config_meta_model.sql",
+      "path": "models/config_meta_model.sql"
+    }
+  },
+  "sources": {},
+  "macros": {},
+  "docs": {},
+  "groups": {},
+  "exposures": {},
+  "metrics": {},
+  "parent_map": {
+    "model.pkg.config_meta_model": []
+  },
+  "child_map": {}
+}

--- a/tests/fixtures/config_meta_only.json
+++ b/tests/fixtures/config_meta_only.json
@@ -72,12 +72,14 @@
           "data_type": "string",
           "description": "Order identifier",
           "meta": {
-            "primary_key": true
+            "nova": {
+              "role": "identifier"
+            }
           },
           "config": {
             "meta": {
+              "primary_key": true,
               "nova": {
-                "role": "identifier",
                 "semantic_type": "order_id",
                 "synonyms": ["purchase_id"]
               }

--- a/tests/fixtures/config_meta_only.json
+++ b/tests/fixtures/config_meta_only.json
@@ -71,9 +71,11 @@
           "name": "order_id",
           "data_type": "string",
           "description": "Order identifier",
+          "meta": {
+            "primary_key": true
+          },
           "config": {
             "meta": {
-              "primary_key": true,
               "nova": {
                 "role": "identifier",
                 "semantic_type": "order_id",


### PR DESCRIPTION
## Summary
- harden Nova metadata readers to fall back from legacy meta to dbt 1.11+ config.meta
- apply the shared fallback logic across entity extraction, search/indexing, PK detection, and metadata scoring
- add config-meta-only fixture coverage and update the changelog

## Validation
- cargo fmt --check
- cargo clippy --offline --lib --tests -- -D warnings
- cargo test --offline

Closes #162