### PR TITLE
Fix GCS bootstrap fetch inside async runtime

### DIFF
--- a/src/manifest/source/mod.rs
+++ b/src/manifest/source/mod.rs
@@ -946,11 +946,34 @@ where
 
 fn run_async_fetch_blocking<F, Fut, T>(factory: F) -> Result<T>
 where
-    F: FnOnce() -> Fut,
-    Fut: std::future::Future<Output = Result<T>>,
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = Result<T>> + Send + 'static,
+    T: Send + 'static,
 {
     if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        return tokio::task::block_in_place(|| handle.block_on(factory()));
+        return match handle.runtime_flavor() {
+            tokio::runtime::RuntimeFlavor::CurrentThread => {
+                let (tx, rx) = std::sync::mpsc::sync_channel(1);
+                std::thread::spawn(move || {
+                    let result = tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .map_err(|e| {
+                            DbtNovaError::ServerError(format!("Failed to init runtime: {e}"))
+                        })
+                        .and_then(|rt| rt.block_on(factory()));
+                    let _ = tx.send(result);
+                });
+                rx.recv().map_err(|e| {
+                    DbtNovaError::ServerError(format!(
+                        "Failed to receive async fetch result from worker thread: {e}"
+                    ))
+                })?
+            }
+            tokio::runtime::RuntimeFlavor::MultiThread | _ => {
+                tokio::task::block_in_place(|| handle.block_on(factory()))
+            }
+        };
     }
 
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -967,6 +990,7 @@ fn fetch_s3_manifest_sdk(
     config: &DbtNovaConfig,
 ) -> Result<ManifestResolution> {
     let (bucket, key) = split_bucket_key(rest)?;
+    let timeout_secs = config.manifest_http_timeout_secs;
     fetch_sdk_manifest_with_cache("S3", uri, config, || {
         let bucket = bucket.clone();
         let key = key.clone();
@@ -991,13 +1015,10 @@ fn fetch_s3_manifest_sdk(
                     .into_bytes();
                 Ok::<_, DbtNovaError>(data.to_vec())
             };
-            if config.manifest_http_timeout_secs > 0 {
-                tokio::time::timeout(
-                    Duration::from_secs(config.manifest_http_timeout_secs),
-                    fetch,
-                )
-                .await
-                .map_err(|_| DbtNovaError::ServerError("S3 download timed out".to_string()))?
+            if timeout_secs > 0 {
+                tokio::time::timeout(Duration::from_secs(timeout_secs), fetch)
+                    .await
+                    .map_err(|_| DbtNovaError::ServerError("S3 download timed out".to_string()))?
             } else {
                 fetch.await
             }
@@ -1012,6 +1033,7 @@ fn fetch_gcs_manifest_sdk(
     config: &DbtNovaConfig,
 ) -> Result<ManifestResolution> {
     let (bucket, object) = split_bucket_key(rest)?;
+    let timeout_secs = config.manifest_http_timeout_secs;
     fetch_sdk_manifest_with_cache("GCS", uri, config, || {
         let bucket = bucket.clone();
         let object = object.clone();
@@ -1035,13 +1057,10 @@ fn fetch_gcs_manifest_sdk(
                     .await
                     .map_err(|e| DbtNovaError::ServerError(format!("GCS download failed: {e}")))
             };
-            if config.manifest_http_timeout_secs > 0 {
-                tokio::time::timeout(
-                    Duration::from_secs(config.manifest_http_timeout_secs),
-                    fetch,
-                )
-                .await
-                .map_err(|_| DbtNovaError::ServerError("GCS download timed out".to_string()))?
+            if timeout_secs > 0 {
+                tokio::time::timeout(Duration::from_secs(timeout_secs), fetch)
+                    .await
+                    .map_err(|_| DbtNovaError::ServerError("GCS download timed out".to_string()))?
             } else {
                 fetch.await
             }

--- a/src/manifest/source/mod.rs
+++ b/src/manifest/source/mod.rs
@@ -944,6 +944,22 @@ where
     })
 }
 
+fn run_async_fetch_blocking<F, Fut, T>(factory: F) -> Result<T>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        return tokio::task::block_in_place(|| handle.block_on(factory()));
+    }
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| DbtNovaError::ServerError(format!("Failed to init runtime: {e}")))?;
+    rt.block_on(factory())
+}
+
 #[cfg(feature = "s3")]
 fn fetch_s3_manifest_sdk(
     rest: &str,
@@ -951,21 +967,10 @@ fn fetch_s3_manifest_sdk(
     config: &DbtNovaConfig,
 ) -> Result<ManifestResolution> {
     let (bucket, key) = split_bucket_key(rest)?;
-    let runtime: std::sync::OnceLock<std::result::Result<tokio::runtime::Runtime, String>> =
-        std::sync::OnceLock::new();
-
     fetch_sdk_manifest_with_cache("S3", uri, config, || {
-        let rt = runtime
-            .get_or_init(|| {
-                tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .map_err(|e| format!("Failed to init runtime: {e}"))
-            })
-            .as_ref()
-            .map_err(|e| DbtNovaError::ServerError(e.clone()))?;
-
-        rt.block_on(async {
+        let bucket = bucket.clone();
+        let key = key.clone();
+        run_async_fetch_blocking(move || async move {
             let fetch = async {
                 let shared = aws_config::defaults(aws_config::BehaviorVersion::latest())
                     .load()
@@ -1007,21 +1012,10 @@ fn fetch_gcs_manifest_sdk(
     config: &DbtNovaConfig,
 ) -> Result<ManifestResolution> {
     let (bucket, object) = split_bucket_key(rest)?;
-    let runtime: std::sync::OnceLock<std::result::Result<tokio::runtime::Runtime, String>> =
-        std::sync::OnceLock::new();
-
     fetch_sdk_manifest_with_cache("GCS", uri, config, || {
-        let rt = runtime
-            .get_or_init(|| {
-                tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .map_err(|e| format!("Failed to init runtime: {e}"))
-            })
-            .as_ref()
-            .map_err(|e| DbtNovaError::ServerError(e.clone()))?;
-
-        rt.block_on(async {
+        let bucket = bucket.clone();
+        let object = object.clone();
+        run_async_fetch_blocking(move || async move {
             let fetch = async {
                 let gcs_config = google_cloud_storage::client::ClientConfig::default()
                     .with_auth()

--- a/src/manifest/source/tests.rs
+++ b/src/manifest/source/tests.rs
@@ -138,3 +138,23 @@ fn async_fetch_blocking_runs_inside_existing_runtime() {
 
     assert_eq!(value, 41);
 }
+
+#[cfg(any(feature = "s3", feature = "gcs"))]
+#[test]
+fn async_fetch_blocking_runs_inside_current_thread_runtime() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    let value = runtime
+        .block_on(async {
+            run_async_fetch_blocking(|| async {
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                Ok::<_, DbtNovaError>(73usize)
+            })
+        })
+        .expect("nested current-thread runtime-safe fetch");
+
+    assert_eq!(value, 73);
+}

--- a/src/manifest/source/tests.rs
+++ b/src/manifest/source/tests.rs
@@ -118,3 +118,23 @@ fn sdk_fetch_pipeline_falls_back_to_cache_on_size_limit() {
     let stored = fs::read_to_string(&resolution.local_path).expect("read cache");
     assert_eq!(stored, "{}");
 }
+
+#[cfg(any(feature = "s3", feature = "gcs"))]
+#[test]
+fn async_fetch_blocking_runs_inside_existing_runtime() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    let value = runtime
+        .block_on(async {
+            run_async_fetch_blocking(|| async {
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                Ok::<_, DbtNovaError>(41usize)
+            })
+        })
+        .expect("nested runtime-safe fetch");
+
+    assert_eq!(value, 41);
+}


### PR DESCRIPTION
## Summary
- avoid nested Tokio runtime panics when fetching bootstrap/artifacts from GCS or S3
- use a blocking bridge that works both inside and outside an existing runtime
- add a regression test for the runtime-safe async fetch path

## Validation
- cargo test --manifest-path /tmp/dbt-nova-gcs-bootstrap-fix/Cargo.toml async_fetch_blocking_runs_inside_existing_runtime --lib
- cargo fmt --check
