### PR TITLE
Add manifest lineage pruning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /site
+/local
 *.log
 
 .dbt-nova

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reusable asset builds now expose `search_warm_strategy` (`staged` or `full`) and
   `build_timeout_minutes` inputs so large manifests can warm semantic assets in
   bounded stages and choose an explicit job timeout.
+- Manifest unique_id pruning via `DBT_NOVA_PRUNE_ALLOW_IDS` and
+  `DBT_NOVA_PRUNE_DENY_IDS`, with cache identity isolation and fail-fast
+  validation for malformed prune JSON.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Minimal MCP client config:
       "args": [],
       "env": {
         "DBT_MANIFEST_PATH": "/path/to/manifest.json",
+        "DBT_NOVA_PRUNE_ALLOW_IDS": "[\"model.my_proj.fct_orders\",\"model.my_proj.dim_*\"]",
+        "DBT_NOVA_PRUNE_DENY_IDS": "[\"model.my_proj.dim_legacy_*\"]",
         "DBT_NOVA_EMBEDDINGS_CACHE_DIR": "/Users/<you>/.dbt-nova/.fastembed_cache"
       }
     }
@@ -165,6 +167,8 @@ curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/master/scrip
 # bash -s -- --slim --install-skills --skill analyst --non-interactive
 
 export DBT_MANIFEST_PATH=/path/to/manifest.json
+export DBT_NOVA_PRUNE_ALLOW_IDS='["model.my_proj.fct_orders","model.my_proj.dim_*"]'
+export DBT_NOVA_PRUNE_DENY_IDS='["model.my_proj.dim_legacy_*"]'
 export PATH="$HOME/.local/bin:$PATH"
 
 # Optional: enable semantic search layers after warming models/caches

--- a/docs/config_defaults.json
+++ b/docs/config_defaults.json
@@ -9,6 +9,8 @@
   "manifest_http_timeout_secs": 120,
   "manifest_fetch_timeout_secs": 300,
   "manifest_allow_http": false,
+  "manifest_prune_allow_ids": [],
+  "manifest_prune_deny_ids": [],
   "storage_dir": ".dbt-nova",
   "storage_instance_id": "",
   "cleanup_storage_on_start": false,

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -21,6 +21,8 @@ see [Modes & Combinations](../getting-started/modes-and-combinations.md).
 - `DBT_NOVA_MANIFEST_HTTP_TIMEOUT_SECS` – HTTP request timeout for manifest fetches (`0` = disabled, default: `120`)
 - `DBT_NOVA_MANIFEST_FETCH_TIMEOUT_SECS` – total fetch deadline for manifest fetches (`0` = disabled, default: `300`)
 - `DBT_NOVA_MANIFEST_ALLOW_HTTP` – allow `http://` manifest URIs (`true`|`false`, default: `false`)
+- `DBT_NOVA_PRUNE_ALLOW_IDS` – optional JSON array of dbt `unique_id` patterns to retain (exact or glob, default: `[]`)
+- `DBT_NOVA_PRUNE_DENY_IDS` – optional JSON array of dbt `unique_id` patterns to exclude (exact or glob, default: `[]`; deny wins overlaps)
 - `DBT_NOVA_STORAGE_ARTIFACT_URI` – optional URI to prebuilt storage archive (`file://`, `s3://`, `gs://`, `dbfs://`, `http(s)://`)
 - `DBT_NOVA_METADATA_ARTIFACT_URI` – optional URI to prebuilt metadata contract JSON (required with `DBT_NOVA_STORAGE_ARTIFACT_URI`)
 - `DBT_NOVA_MODELS_ARTIFACT_URI` – optional URI to prebuilt models archive
@@ -70,6 +72,11 @@ Remote manifest notes:
 - Bootstrap precedence is deterministic: explicit env vars override bootstrap values, and bootstrap values override defaults.
 - Streamable HTTP mode has **no built-in authentication**. Keep it bound to loopback for local use, or set `DBT_NOVA_HTTP_EXPECT_AUTH_PROXY=true` only when an authenticating reverse proxy is enforcing access in front of dbt-nova.
 - The MCP endpoint is mounted at `DBT_NOVA_HTTP_PATH`; plain probe endpoints are always available at `/healthz` and `/readyz`.
+
+Manifest pruning notes:
+- Matching is against dbt `unique_id` (not `fqn`).
+- If `DBT_NOVA_PRUNE_ALLOW_IDS` is empty, pruning starts from all entities, then applies deny rules.
+- `analysis` nodes are auto-included only when they directly depend on retained nodes and have no extra direct dependencies outside the retained set.
 
 ## Storage
 

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -77,6 +77,14 @@ Manifest pruning notes:
 - Matching is against dbt `unique_id` (not `fqn`).
 - If `DBT_NOVA_PRUNE_ALLOW_IDS` is empty, pruning starts from all entities, then applies deny rules.
 - `analysis` nodes are auto-included only when they directly depend on retained nodes and have no extra direct dependencies outside the retained set.
+- To generate a valid allow-list from dbt selectors, use `dbt ls` JSON output and extract `unique_id`:
+
+```bash
+export DBT_NOVA_PRUNE_ALLOW_IDS="$(
+  dbt ls -s <lineage selection expression> --output json --quiet \
+  | jq -cs '[.[] | .unique_id]'
+)"
+```
 
 ## Storage
 

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -75,6 +75,7 @@ Remote manifest notes:
 
 Manifest pruning notes:
 - Matching is against dbt `unique_id` (not `fqn`).
+- Prune variables must be valid JSON arrays of strings; invalid JSON fails config validation and server startup.
 - If `DBT_NOVA_PRUNE_ALLOW_IDS` is empty, pruning starts from all entities, then applies deny rules.
 - `analysis` nodes are auto-included only when they directly depend on retained nodes and have no extra direct dependencies outside the retained set.
 - To generate a valid allow-list from dbt selectors, use `dbt ls` JSON output and extract `unique_id`:

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -64,6 +64,16 @@ dbt-nova manifest load \
   --manifest-path /path/to/target/manifest.json
 ```
 
+### Build indexes with manifest pruning
+
+```bash
+DBT_NOVA_PRUNE_ALLOW_IDS='["model.my_proj.fct_orders","model.my_proj.dim_*"]' \
+DBT_NOVA_PRUNE_DENY_IDS='["model.my_proj.dim_legacy_*"]' \
+dbt-nova manifest load \
+  --manifest-path /path/to/target/manifest.json \
+  --json
+```
+
 ### Rebuild manifest indexes with override settings
 
 ```bash

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -86,6 +86,9 @@ dbt-nova manifest load \
   --json
 ```
 
+Prune variables must be valid JSON arrays of strings. Invalid JSON fails config
+validation and startup instead of falling back to an unpruned manifest.
+
 ### Rebuild manifest indexes with override settings
 
 ```bash

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -74,6 +74,18 @@ dbt-nova manifest load \
   --json
 ```
 
+Generate `DBT_NOVA_PRUNE_ALLOW_IDS` from a dbt selector:
+
+```bash
+DBT_NOVA_PRUNE_ALLOW_IDS="$(
+  dbt ls -s <lineage selection expression> --output json --quiet \
+  | jq -cs '[.[] | .unique_id]'
+)" \
+dbt-nova manifest load \
+  --manifest-path /path/to/target/manifest.json \
+  --json
+```
+
 ### Rebuild manifest indexes with override settings
 
 ```bash

--- a/docs/getting-started/mcp-clients.md
+++ b/docs/getting-started/mcp-clients.md
@@ -40,6 +40,7 @@ Optional manifest pruning (applies to MCP server startup and reloads):
 - `DBT_NOVA_PRUNE_ALLOW_IDS` (JSON array of dbt `unique_id` patterns)
 - `DBT_NOVA_PRUNE_DENY_IDS` (JSON array of dbt `unique_id` patterns; deny wins)
 - Matching is on `unique_id`, not `fqn`.
+- Invalid JSON fails startup; do not use comma-separated strings.
 
 ## Prebuilt Consumer Setup
 

--- a/docs/getting-started/mcp-clients.md
+++ b/docs/getting-started/mcp-clients.md
@@ -36,6 +36,11 @@ or reranking in your MCP client, enable them explicitly with:
 - `DBT_NOVA_SEARCH_ENABLE_SPARSE=true`
 - `DBT_NOVA_SEARCH_ENABLE_RERANKER=true`
 
+Optional manifest pruning (applies to MCP server startup and reloads):
+- `DBT_NOVA_PRUNE_ALLOW_IDS` (JSON array of dbt `unique_id` patterns)
+- `DBT_NOVA_PRUNE_DENY_IDS` (JSON array of dbt `unique_id` patterns; deny wins)
+- Matching is on `unique_id`, not `fqn`.
+
 ## Prebuilt Consumer Setup
 
 If you consume prebuilt Nova storage artifacts (built by the reusable producer
@@ -116,6 +121,8 @@ For producer/consumer workflow details, see:
       "command": "/path/to/dbt-nova",
       "env": {
         "DBT_MANIFEST_PATH": "/path/to/manifest.json",
+        "DBT_NOVA_PRUNE_ALLOW_IDS": "[\"model.my_proj.fct_orders\",\"model.my_proj.dim_*\"]",
+        "DBT_NOVA_PRUNE_DENY_IDS": "[\"model.my_proj.dim_legacy_*\"]",
         "DBT_NOVA_EMBEDDINGS_CACHE_DIR": "/Users/<you>/.dbt-nova/.fastembed_cache",
         "DATABRICKS_HOST": "https://<workspace>.cloud.databricks.com",
         "DATABRICKS_HTTP_PATH": "/sql/1.0/warehouses/<warehouse_id>",
@@ -135,6 +142,8 @@ startup_timeout_sec = 60
 
 [mcp_servers.dbt-nova.env]
 DBT_MANIFEST_PATH = "/path/to/manifest.json"
+DBT_NOVA_PRUNE_ALLOW_IDS = "[\"model.my_proj.fct_orders\",\"model.my_proj.dim_*\"]"
+DBT_NOVA_PRUNE_DENY_IDS = "[\"model.my_proj.dim_legacy_*\"]"
 DATABRICKS_HOST = "https://<workspace>.cloud.databricks.com"
 DATABRICKS_HTTP_PATH = "/sql/1.0/warehouses/<warehouse_id>"
 DATABRICKS_ACCESS_TOKEN = "<token>"

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -1666,7 +1666,9 @@ mod tests {
             }
         }
 
-        let error = config.validate().expect_err("invalid prune JSON should fail");
+        let error = config
+            .validate()
+            .expect_err("invalid prune JSON should fail");
         assert!(
             error
                 .to_string()

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -358,7 +358,8 @@ impl DbtNovaConfig {
     /// Whether manifest pruning is enabled.
     #[must_use]
     pub fn manifest_pruning_enabled(&self) -> bool {
-        !self.manifest_prune_allow_ids.is_empty() || !self.manifest_prune_deny_ids.is_empty()
+        !canonical_prune_patterns(&self.manifest_prune_allow_ids).is_empty()
+            || !canonical_prune_patterns(&self.manifest_prune_deny_ids).is_empty()
     }
 
     /// Deterministic fingerprint for pruning inputs used in cache/reuse identity.
@@ -368,10 +369,8 @@ impl DbtNovaConfig {
             return String::new();
         }
 
-        let mut allow = self.manifest_prune_allow_ids.clone();
-        let mut deny = self.manifest_prune_deny_ids.clone();
-        allow.sort();
-        deny.sort();
+        let allow = canonical_prune_patterns(&self.manifest_prune_allow_ids);
+        let deny = canonical_prune_patterns(&self.manifest_prune_deny_ids);
         let payload = serde_json::json!({
             "allow": allow,
             "deny": deny,
@@ -1059,6 +1058,18 @@ impl DbtNovaConfig {
     }
 }
 
+fn canonical_prune_patterns(patterns: &[String]) -> Vec<String> {
+    let mut values: Vec<String> = patterns
+        .iter()
+        .filter_map(|pattern| {
+            let trimmed = pattern.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        })
+        .collect();
+    values.sort();
+    values
+}
+
 fn artifact_uri_scheme(uri: &str) -> String {
     let lower = uri.trim().to_ascii_lowercase();
     if lower.starts_with("dbfs:/") && !lower.starts_with("dbfs://") {
@@ -1679,13 +1690,21 @@ mod tests {
     #[test]
     fn manifest_prune_fingerprint_is_order_independent() {
         let config_a = DbtNovaConfig {
-            manifest_prune_allow_ids: vec!["model.pkg.a".to_string(), "model.pkg.b".to_string()],
-            manifest_prune_deny_ids: vec!["model.pkg.c".to_string(), "model.pkg.d".to_string()],
+            manifest_prune_allow_ids: vec![
+                "model.pkg.a".to_string(),
+                "model.pkg.b".to_string(),
+                String::new(),
+            ],
+            manifest_prune_deny_ids: vec![
+                "model.pkg.c".to_string(),
+                "model.pkg.d".to_string(),
+                "   ".to_string(),
+            ],
             ..DbtNovaConfig::default()
         };
         let config_b = DbtNovaConfig {
-            manifest_prune_allow_ids: vec!["model.pkg.b".to_string(), "model.pkg.a".to_string()],
-            manifest_prune_deny_ids: vec!["model.pkg.d".to_string(), "model.pkg.c".to_string()],
+            manifest_prune_allow_ids: vec![" model.pkg.b ".to_string(), "model.pkg.a".to_string()],
+            manifest_prune_deny_ids: vec!["model.pkg.d".to_string(), " model.pkg.c ".to_string()],
             ..DbtNovaConfig::default()
         };
         assert_eq!(

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -159,9 +159,9 @@ pub struct DbtNovaConfig {
     pub manifest_fetch_timeout_secs: u64,
     /// Allow non-TLS manifest URIs (http://). Disable to enforce HTTPS-only.
     pub manifest_allow_http: bool,
-    /// Optional allowlist of dbt unique_id patterns to retain during manifest parse.
+    /// Optional allowlist of dbt `unique_id` patterns to retain during manifest parse.
     pub manifest_prune_allow_ids: Vec<String>,
-    /// Optional denylist of dbt unique_id patterns to remove during manifest parse.
+    /// Optional denylist of dbt `unique_id` patterns to remove during manifest parse.
     pub manifest_prune_deny_ids: Vec<String>,
     /// Base directory for on-disk storage (instances live under `storage_dir/instances`)
     pub storage_dir: String,

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -159,6 +159,10 @@ pub struct DbtNovaConfig {
     pub manifest_fetch_timeout_secs: u64,
     /// Allow non-TLS manifest URIs (http://). Disable to enforce HTTPS-only.
     pub manifest_allow_http: bool,
+    /// Optional allowlist of dbt unique_id patterns to retain during manifest parse.
+    pub manifest_prune_allow_ids: Vec<String>,
+    /// Optional denylist of dbt unique_id patterns to remove during manifest parse.
+    pub manifest_prune_deny_ids: Vec<String>,
     /// Base directory for on-disk storage (instances live under `storage_dir/instances`)
     pub storage_dir: String,
     /// Storage instance id (generated from manifest when empty)
@@ -252,6 +256,9 @@ pub struct DbtNovaConfig {
     /// Runtime bootstrap resolution status (not user-configurable).
     #[serde(skip)]
     pub bootstrap_status: Option<JsonValue>,
+    /// Configuration errors captured while reading fallible environment values.
+    #[serde(skip)]
+    pub env_errors: Vec<String>,
 }
 
 impl Default for DbtNovaConfig {
@@ -268,6 +275,8 @@ impl Default for DbtNovaConfig {
             manifest_http_timeout_secs: 120,
             manifest_fetch_timeout_secs: 300,
             manifest_allow_http: false,
+            manifest_prune_allow_ids: Vec::new(),
+            manifest_prune_deny_ids: Vec::new(),
             storage_dir: ".dbt-nova".to_string(),
             storage_instance_id: String::new(),
             cleanup_storage_on_start: false,
@@ -314,6 +323,7 @@ impl Default for DbtNovaConfig {
             governance_required_fields: default_governance_required_fields(),
             governance_gate: GovernanceGateConfig::default(),
             bootstrap_status: None,
+            env_errors: Vec::new(),
         }
     }
 }
@@ -345,6 +355,32 @@ fn default_governance_required_fields() -> HashMap<String, Vec<String>> {
 }
 
 impl DbtNovaConfig {
+    /// Whether manifest pruning is enabled.
+    #[must_use]
+    pub fn manifest_pruning_enabled(&self) -> bool {
+        !self.manifest_prune_allow_ids.is_empty() || !self.manifest_prune_deny_ids.is_empty()
+    }
+
+    /// Deterministic fingerprint for pruning inputs used in cache/reuse identity.
+    #[must_use]
+    pub fn manifest_prune_fingerprint(&self) -> String {
+        if !self.manifest_pruning_enabled() {
+            return String::new();
+        }
+
+        let mut allow = self.manifest_prune_allow_ids.clone();
+        let mut deny = self.manifest_prune_deny_ids.clone();
+        allow.sort();
+        deny.sort();
+        let payload = serde_json::json!({
+            "allow": allow,
+            "deny": deny,
+        });
+        blake3::hash(payload.to_string().as_bytes())
+            .to_hex()
+            .to_string()
+    }
+
     /// Ensure a deterministic storage instance id is set.
     pub fn ensure_storage_instance_id(&mut self) {
         if !self.storage_instance_id.trim().is_empty() {
@@ -465,6 +501,10 @@ impl DbtNovaConfig {
     ///
     /// Returns an error when an invalid configuration is detected.
     pub fn validate(&self) -> Result<()> {
+        if !self.env_errors.is_empty() {
+            return Err(DbtNovaError::InvalidParams(self.env_errors.join("; ")));
+        }
+
         if !self.manifest_allow_http && self.manifest_uri.trim().starts_with("http://") {
             return Err(DbtNovaError::InvalidParams(
                 "manifest_allow_http=false but manifest_uri uses http://".to_string(),
@@ -722,6 +762,26 @@ impl DbtNovaConfig {
         }
         if let Some(value) = parse_bool("DBT_NOVA_MANIFEST_ALLOW_HTTP") {
             self.manifest_allow_http = value;
+        }
+        if let Some(value) = env_string("DBT_NOVA_PRUNE_ALLOW_IDS") {
+            match serde_json::from_str::<Vec<String>>(&value) {
+                Ok(patterns) => self.manifest_prune_allow_ids = patterns,
+                Err(err) => {
+                    self.env_errors.push(format!(
+                        "Invalid DBT_NOVA_PRUNE_ALLOW_IDS JSON; expected a JSON array of strings (error: {err})"
+                    ));
+                }
+            }
+        }
+        if let Some(value) = env_string("DBT_NOVA_PRUNE_DENY_IDS") {
+            match serde_json::from_str::<Vec<String>>(&value) {
+                Ok(patterns) => self.manifest_prune_deny_ids = patterns,
+                Err(err) => {
+                    self.env_errors.push(format!(
+                        "Invalid DBT_NOVA_PRUNE_DENY_IDS JSON; expected a JSON array of strings (error: {err})"
+                    ));
+                }
+            }
         }
     }
 
@@ -1519,5 +1579,117 @@ mod tests {
         }
 
         assert!(config.http_expect_auth_proxy);
+    }
+
+    #[test]
+    fn from_env_parses_manifest_prune_ids() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let vars = [
+            (
+                "DBT_NOVA_PRUNE_ALLOW_IDS",
+                Some("[\"model.pkg.orders\",\"analysis.pkg.*\"]"),
+            ),
+            ("DBT_NOVA_PRUNE_DENY_IDS", Some("[\"model.pkg.stg_*\"]")),
+        ];
+        let previous = vars.map(|(key, _)| (key, std::env::var(key).ok()));
+        for (key, value) in vars {
+            match value {
+                Some(value) => {
+                    // SAFETY: tests serialize environment mutation with `ENV_LOCK`.
+                    unsafe { std::env::set_var(key, value) };
+                }
+                None => {
+                    // SAFETY: tests serialize environment mutation with `ENV_LOCK`.
+                    unsafe { std::env::remove_var(key) };
+                }
+            }
+        }
+
+        let config = DbtNovaConfig::from_env();
+
+        for (key, value) in previous {
+            match value {
+                Some(value) => {
+                    // SAFETY: tests serialize environment mutation with `ENV_LOCK`.
+                    unsafe { std::env::set_var(key, value) };
+                }
+                None => {
+                    // SAFETY: tests serialize environment mutation with `ENV_LOCK`.
+                    unsafe { std::env::remove_var(key) };
+                }
+            }
+        }
+
+        assert_eq!(
+            config.manifest_prune_allow_ids,
+            vec!["model.pkg.orders".to_string(), "analysis.pkg.*".to_string()]
+        );
+        assert_eq!(
+            config.manifest_prune_deny_ids,
+            vec!["model.pkg.stg_*".to_string()]
+        );
+    }
+
+    #[test]
+    fn from_env_invalid_manifest_prune_json_fails_validation() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let vars = [
+            ("DBT_NOVA_PRUNE_ALLOW_IDS", Some("model.pkg.*")),
+            ("DBT_NOVA_PRUNE_DENY_IDS", Some("[\"model.pkg.stg_*\"]")),
+        ];
+        let previous = vars.map(|(key, _)| (key, std::env::var(key).ok()));
+        for (key, value) in vars {
+            match value {
+                Some(value) => {
+                    // SAFETY: tests serialize environment mutation with `ENV_LOCK`.
+                    unsafe { std::env::set_var(key, value) };
+                }
+                None => {
+                    // SAFETY: tests serialize environment mutation with `ENV_LOCK`.
+                    unsafe { std::env::remove_var(key) };
+                }
+            }
+        }
+
+        let config = DbtNovaConfig::from_env();
+
+        for (key, value) in previous {
+            match value {
+                Some(value) => {
+                    // SAFETY: tests serialize environment mutation with `ENV_LOCK`.
+                    unsafe { std::env::set_var(key, value) };
+                }
+                None => {
+                    // SAFETY: tests serialize environment mutation with `ENV_LOCK`.
+                    unsafe { std::env::remove_var(key) };
+                }
+            }
+        }
+
+        let error = config.validate().expect_err("invalid prune JSON should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("Invalid DBT_NOVA_PRUNE_ALLOW_IDS JSON")
+        );
+    }
+
+    #[test]
+    fn manifest_prune_fingerprint_is_order_independent() {
+        let config_a = DbtNovaConfig {
+            manifest_prune_allow_ids: vec!["model.pkg.a".to_string(), "model.pkg.b".to_string()],
+            manifest_prune_deny_ids: vec!["model.pkg.c".to_string(), "model.pkg.d".to_string()],
+            ..DbtNovaConfig::default()
+        };
+        let config_b = DbtNovaConfig {
+            manifest_prune_allow_ids: vec!["model.pkg.b".to_string(), "model.pkg.a".to_string()],
+            manifest_prune_deny_ids: vec!["model.pkg.d".to_string(), "model.pkg.c".to_string()],
+            ..DbtNovaConfig::default()
+        };
+        assert_eq!(
+            config_a.manifest_prune_fingerprint(),
+            config_b.manifest_prune_fingerprint()
+        );
+        assert!(config_a.manifest_pruning_enabled());
     }
 }

--- a/src/manifest/loader.rs
+++ b/src/manifest/loader.rs
@@ -125,6 +125,7 @@ struct PersistContext<'a> {
     storage_dir: &'a Path,
     config: &'a DbtNovaConfig,
     needs_build: bool,
+    update_current_version: bool,
     indexes_reused: bool,
     parent_map: &'a HashMap<String, Vec<String>>,
     child_map: &'a HashMap<String, Vec<String>>,
@@ -190,6 +191,10 @@ impl ManifestSearch {
             cached_indexes,
             indexes_reused,
         } = prepared_manifest_data;
+        let update_current_version = !needs_build
+            && !config.storage_read_only
+            && reused.storage_dir == storage.storage_dir
+            && reused.current_version.as_deref() != Some(storage.version_id.as_str());
         let signature_path = reused.signature_path.clone();
         let storage_dir = reused.storage_dir.clone();
         let search_backends = build_search_backends_for_manifest(
@@ -216,6 +221,7 @@ impl ManifestSearch {
             storage_dir: &storage_dir,
             config: &config,
             needs_build,
+            update_current_version,
             indexes_reused,
             parent_map: &runtime.parent_map,
             child_map: &runtime.child_map,
@@ -806,6 +812,8 @@ fn persist_storage_outputs(
 ) -> Result<()> {
     if context.needs_build {
         write_manifest_signature(context.signature_path, &storage.signature)?;
+    }
+    if context.needs_build || context.update_current_version {
         write_current_version(&storage.instance_root, &storage.version_id)?;
     }
 
@@ -1368,6 +1376,56 @@ mod tests {
         let loaded = ManifestSearch::new(config).expect("load manifest search");
 
         assert_eq!(loaded.search.manifest_hash, expected_hash);
+    }
+
+    #[test]
+    fn manifest_search_updates_current_pointer_after_scoped_fallback_reuse() {
+        let temp = tempdir().unwrap_or_else(|err| panic!("tempdir failed: {err}"));
+        let manifest_path = temp.path().join("manifest.json");
+        std::fs::copy(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/minimal.json"),
+            &manifest_path,
+        )
+        .expect("copy fixture manifest");
+
+        let base = DbtNovaConfig {
+            manifest_path: manifest_path.to_string_lossy().to_string(),
+            storage_dir: temp.path().join("storage").to_string_lossy().to_string(),
+            storage_instance_id: "scoped-current".to_string(),
+            ..DbtNovaConfig::default()
+        };
+        let instance_root = base.storage_instance_root_dir().expect("instance root");
+        let allow_config = DbtNovaConfig {
+            manifest_prune_allow_ids: vec!["model.pkg.model_a".to_string()],
+            ..base.clone()
+        };
+        let deny_config = DbtNovaConfig {
+            manifest_prune_deny_ids: vec!["model.pkg.unused".to_string()],
+            ..base
+        };
+
+        let allow_first =
+            ManifestSearch::new(allow_config.clone()).expect("load allow-scoped manifest first");
+        let allow_version = allow_first.search.manifest_version;
+        let deny_loaded =
+            ManifestSearch::new(deny_config).expect("load alternate prune-scoped manifest");
+        let deny_version = deny_loaded.search.manifest_version;
+
+        assert_ne!(allow_version, deny_version);
+        assert_eq!(
+            read_current_version(&instance_root).expect("read current after alternate"),
+            Some(deny_version)
+        );
+
+        let allow_second =
+            ManifestSearch::new(allow_config).expect("reuse original prune-scoped manifest");
+
+        assert!(allow_second.entity_store_reused);
+        assert_eq!(allow_second.search.manifest_version, allow_version);
+        assert_eq!(
+            read_current_version(&instance_root).expect("read refreshed current"),
+            Some(allow_version)
+        );
     }
 
     #[test]

--- a/src/manifest/loader.rs
+++ b/src/manifest/loader.rs
@@ -114,6 +114,12 @@ struct PreparedManifestData {
     indexes_reused: bool,
 }
 
+struct ManifestParseContext<'a> {
+    path: &'a Path,
+    source_uri: &'a str,
+    load_start: Instant,
+}
+
 struct PersistContext<'a> {
     signature_path: &'a Path,
     storage_dir: &'a Path,
@@ -172,9 +178,11 @@ impl ManifestSearch {
             &storage.signature,
             reused.reuse_store,
             reused.entities,
-            &manifest_path,
-            &manifest_resolution.source_uri,
-            load_start,
+            &ManifestParseContext {
+                path: &manifest_path,
+                source_uri: &manifest_resolution.source_uri,
+                load_start,
+            },
         )?;
         let PreparedManifestData {
             accumulator,
@@ -506,10 +514,11 @@ fn prepare_manifest_data(
     signature: &ManifestSignature,
     reuse_store: bool,
     existing_entities: Option<EntityStore>,
-    manifest_path: &Path,
-    source_uri: &str,
-    load_start: Instant,
+    parse_context: &ManifestParseContext<'_>,
 ) -> Result<PreparedManifestData> {
+    let manifest_path = parse_context.path;
+    let source_uri = parse_context.source_uri;
+    let load_start = parse_context.load_start;
     let mut accumulator = ManifestAccumulator::new(storage_dir, !reuse_store)?;
     let mut cached_indexes =
         load_cached_indexes(storage_dir, signature, reuse_store, &mut accumulator);

--- a/src/manifest/loader.rs
+++ b/src/manifest/loader.rs
@@ -892,7 +892,7 @@ fn assemble_manifest_search(context: AssembleContext) -> ManifestSearch {
         lineage_cache_hits: AtomicU64::new(0),
         lineage_cache_misses: AtomicU64::new(0),
         manifest_source_uri,
-        manifest_hash: storage.signature.content_hash,
+        manifest_hash: scoped_manifest_hash(&storage.signature),
         manifest_len: storage.signature.len,
         manifest_modified_ms: storage.signature.modified_ms,
         manifest_version: storage.version_id,
@@ -1338,6 +1338,36 @@ mod tests {
         };
         prepare_storage(&config, &resolution, JsonValue::Null)
             .expect("scoped metadata hash should validate");
+    }
+
+    #[test]
+    fn manifest_search_reports_scoped_manifest_hash_when_pruned() {
+        let temp = tempdir().unwrap_or_else(|err| panic!("tempdir failed: {err}"));
+        let manifest_path = temp.path().join("manifest.json");
+        std::fs::copy(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/minimal.json"),
+            &manifest_path,
+        )
+        .expect("copy fixture manifest");
+
+        let config = DbtNovaConfig {
+            manifest_path: manifest_path.to_string_lossy().to_string(),
+            storage_dir: temp.path().join("storage").to_string_lossy().to_string(),
+            storage_instance_id: "scoped-report".to_string(),
+            manifest_prune_allow_ids: vec!["model.pkg.model_a".to_string()],
+            ..DbtNovaConfig::default()
+        };
+        let mut signature =
+            manifest_signature(&manifest_path, manifest_path.to_string_lossy().as_ref())
+                .expect("manifest signature");
+        signature.prune_fingerprint = config.manifest_prune_fingerprint();
+        let expected_hash = scoped_manifest_hash(&signature);
+
+        assert_ne!(expected_hash, signature.content_hash);
+
+        let loaded = ManifestSearch::new(config).expect("load manifest search");
+
+        assert_eq!(loaded.search.manifest_hash, expected_hash);
     }
 
     #[test]

--- a/src/manifest/loader.rs
+++ b/src/manifest/loader.rs
@@ -195,7 +195,7 @@ impl ManifestSearch {
         let search_backends = build_search_backends_for_manifest(
             &mut config,
             &reused.storage_dir,
-            &storage.signature.content_hash,
+            &storage.signature,
             &accumulator,
             &entities,
             reused.tantivy_opened,
@@ -276,15 +276,7 @@ fn prepare_storage(
         ))
     })?;
     signature.prune_fingerprint = config.manifest_prune_fingerprint();
-    let version_hash = if signature.prune_fingerprint.is_empty() {
-        signature.content_hash.clone()
-    } else {
-        blake3::hash(
-            format!("{}:{}", signature.content_hash, signature.prune_fingerprint).as_bytes(),
-        )
-        .to_hex()
-        .to_string()
-    };
+    let version_hash = scoped_manifest_hash(&signature);
     let mut version_id = version_hash.chars().take(12).collect::<String>();
     if version_id.is_empty() {
         version_id = "unknown".to_string();
@@ -348,6 +340,7 @@ fn load_reusable_artifacts(
     let mut entities: Option<EntityStore> = None;
     let mut reuse_store = false;
     let mut tantivy_opened: Option<TantivySearcher> = None;
+    let mut matched_signature = false;
 
     if let Some(current) = &current_version {
         let current_dir = versions_root.join(current);
@@ -357,6 +350,7 @@ fn load_reusable_artifacts(
         {
             storage_dir = current_dir;
             signature_path = current_sig_path;
+            matched_signature = true;
             if let Ok(store) = EntityStore::open(&storage_dir) {
                 entities = Some(store);
                 reuse_store = true;
@@ -365,9 +359,14 @@ fn load_reusable_artifacts(
                 tantivy_opened = opened;
             }
         }
-    } else if let Some(existing) = read_manifest_signature(&signature_path)?
+    }
+
+    if !matched_signature
+        && let Some(existing) = read_manifest_signature(initial_signature_path)?
         && manifest_signature_matches_for_reuse(&existing, signature)
     {
+        storage_dir = initial_storage_dir.to_path_buf();
+        signature_path = initial_signature_path.to_path_buf();
         if let Ok(store) = EntityStore::open(&storage_dir) {
             entities = Some(store);
             reuse_store = true;
@@ -706,12 +705,12 @@ fn build_search_indexes(
 fn build_search_backends_for_manifest(
     config: &mut DbtNovaConfig,
     storage_dir: &Path,
-    signature_hash: &str,
+    signature: &ManifestSignature,
     accumulator: &ManifestAccumulator,
     entities: &EntityStore,
     tantivy_opened: Option<TantivySearcher>,
 ) -> Result<SearchBackends> {
-    config.search.manifest_hash = Some(signature_hash.to_string());
+    config.search.manifest_hash = Some(scoped_manifest_hash(signature));
     build_search_indexes(
         storage_dir,
         accumulator,
@@ -719,6 +718,18 @@ fn build_search_backends_for_manifest(
         &config.search,
         tantivy_opened,
     )
+}
+
+fn scoped_manifest_hash(signature: &ManifestSignature) -> String {
+    if signature.prune_fingerprint.is_empty() {
+        signature.content_hash.clone()
+    } else {
+        blake3::hash(
+            format!("{}:{}", signature.content_hash, signature.prune_fingerprint).as_bytes(),
+        )
+        .to_hex()
+        .to_string()
+    }
 }
 
 fn build_runtime_components(
@@ -1246,5 +1257,66 @@ mod tests {
             source_uri: "file:///old/path".to_string(),
         };
         assert!(!manifest_signature_matches_for_reuse(&existing, &expected));
+    }
+
+    #[test]
+    fn scoped_manifest_hash_includes_prune_fingerprint() {
+        let unpruned = ManifestSignature {
+            content_hash: "same-hash".to_string(),
+            prune_fingerprint: String::new(),
+            ..ManifestSignature::default()
+        };
+        let pruned = ManifestSignature {
+            content_hash: "same-hash".to_string(),
+            prune_fingerprint: "fingerprint-a".to_string(),
+            ..ManifestSignature::default()
+        };
+        assert_eq!(scoped_manifest_hash(&unpruned), "same-hash");
+        assert_ne!(scoped_manifest_hash(&pruned), "same-hash");
+        assert_eq!(scoped_manifest_hash(&pruned).len(), 64);
+    }
+
+    #[test]
+    fn reusable_artifacts_fall_back_to_computed_version_when_current_differs() {
+        let temp = tempdir().unwrap_or_else(|err| panic!("tempdir failed: {err}"));
+        let instance_root = temp.path().join("instance");
+        let versions_root = instance_root.join("versions");
+        let current_dir = versions_root.join("current-scope");
+        let computed_dir = versions_root.join("computed-scope");
+        std::fs::create_dir_all(&current_dir).expect("create current version dir");
+        std::fs::create_dir_all(&computed_dir).expect("create computed version dir");
+
+        let expected = ManifestSignature {
+            content_hash: "same-hash".to_string(),
+            prune_fingerprint: "fingerprint-a".to_string(),
+            ..ManifestSignature::default()
+        };
+        let other_scope = ManifestSignature {
+            content_hash: "same-hash".to_string(),
+            prune_fingerprint: "fingerprint-b".to_string(),
+            ..ManifestSignature::default()
+        };
+        write_manifest_signature(&current_dir.join(MANIFEST_SIGNATURE_FILENAME), &other_scope)
+            .expect("write current signature");
+        write_manifest_signature(&computed_dir.join(MANIFEST_SIGNATURE_FILENAME), &expected)
+            .expect("write computed signature");
+        write_current_version(&instance_root, "current-scope").expect("write current pointer");
+
+        let reused = load_reusable_artifacts(
+            &DbtNovaConfig::default(),
+            &instance_root,
+            &versions_root,
+            &expected,
+            &computed_dir,
+            &computed_dir.join(MANIFEST_SIGNATURE_FILENAME),
+        )
+        .expect("load reusable artifacts");
+
+        assert_eq!(reused.current_version.as_deref(), Some("current-scope"));
+        assert_eq!(reused.storage_dir, computed_dir);
+        assert_eq!(
+            reused.signature_path,
+            reused.storage_dir.join(MANIFEST_SIGNATURE_FILENAME)
+        );
     }
 }

--- a/src/manifest/loader.rs
+++ b/src/manifest/loader.rs
@@ -292,7 +292,7 @@ fn prepare_storage(
     let mut artifact_consumer_status = build_artifact_consumer_status(config, None, None);
     if config.remote_artifact_mode_enabled() {
         let evaluated_at_ms = current_time_ms();
-        let materialization = materialize_file_artifacts(config, &signature.content_hash)?;
+        let materialization = materialize_file_artifacts(config, &version_hash)?;
         if let Some(outcome) = materialization {
             let last_materialized_at_ms =
                 if outcome.storage_materialized || outcome.models_materialized {
@@ -1274,6 +1274,70 @@ mod tests {
         assert_eq!(scoped_manifest_hash(&unpruned), "same-hash");
         assert_ne!(scoped_manifest_hash(&pruned), "same-hash");
         assert_eq!(scoped_manifest_hash(&pruned).len(), 64);
+    }
+
+    #[test]
+    fn prepare_storage_validates_artifacts_with_scoped_manifest_hash() {
+        let temp = tempdir().unwrap_or_else(|err| panic!("tempdir failed: {err}"));
+        let manifest_path = temp.path().join("manifest.json");
+        std::fs::write(&manifest_path, br#"{"metadata":{"dbt_version":"1.10.0"}}"#)
+            .expect("write manifest");
+
+        let mut config = DbtNovaConfig {
+            storage_dir: temp.path().join("storage").to_string_lossy().to_string(),
+            storage_instance_id: "analytics-prod".to_string(),
+            manifest_prune_allow_ids: vec!["model.pkg.orders".to_string()],
+            artifact_fetch_policy: crate::config::ArtifactFetchPolicy::Never,
+            ..DbtNovaConfig::default()
+        };
+        std::fs::create_dir_all(
+            temp.path()
+                .join("storage")
+                .join("instances")
+                .join("analytics-prod")
+                .join("versions")
+                .join("existing"),
+        )
+        .expect("create existing storage marker");
+
+        let mut signature =
+            manifest_signature(&manifest_path, manifest_path.to_string_lossy().as_ref())
+                .expect("manifest signature");
+        signature.prune_fingerprint = config.manifest_prune_fingerprint();
+        let scoped_hash = scoped_manifest_hash(&signature);
+
+        let metadata_path = temp.path().join("nova-build-metadata.json");
+        std::fs::write(
+            &metadata_path,
+            format!(
+                r#"{{
+  "contract_version":"v1",
+  "manifest_hash":"{scoped_hash}",
+  "manifest_version":"v12",
+  "entity_count":1,
+  "storage_instance_id":"analytics-prod",
+  "dbt_nova_version":"0.0.4",
+  "build_timestamp":"2026-04-25T00:00:00Z",
+  "artifact_name_storage":"storage.tar.gz",
+  "artifact_name_models":""
+}}"#
+            ),
+        )
+        .expect("write metadata");
+        config.storage_artifact_uri = temp
+            .path()
+            .join("unused-storage.tar.gz")
+            .to_string_lossy()
+            .to_string();
+        config.metadata_artifact_uri = metadata_path.to_string_lossy().to_string();
+
+        let resolution = crate::manifest::source::ManifestResolution {
+            local_path: manifest_path.clone(),
+            source_uri: manifest_path.to_string_lossy().to_string(),
+            cached: false,
+        };
+        prepare_storage(&config, &resolution, JsonValue::Null)
+            .expect("scoped metadata hash should validate");
     }
 
     #[test]

--- a/src/manifest/loader.rs
+++ b/src/manifest/loader.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::time::{Duration, Instant};
 
+use blake3;
 use moka::sync::Cache as MokaCache;
 use serde_json::Value as JsonValue;
 
@@ -166,6 +167,7 @@ impl ManifestSearch {
         ensure_build_reuse_state(&mut storage, &reused, &config, needs_build)?;
         let tantivy_reused = reused.tantivy_opened.is_some();
         let prepared_manifest_data = prepare_manifest_data(
+            &config,
             &reused.storage_dir,
             &storage.signature,
             reused.reuse_store,
@@ -255,7 +257,7 @@ fn prepare_storage(
     let versions_root = instance_root.join("versions");
     fs::create_dir_all(&versions_root)?;
 
-    let signature = manifest_signature(
+    let mut signature = manifest_signature(
         &manifest_resolution.local_path,
         &manifest_resolution.source_uri,
     )
@@ -265,7 +267,17 @@ fn prepare_storage(
             manifest_resolution.source_uri
         ))
     })?;
-    let mut version_id = signature.content_hash.chars().take(12).collect::<String>();
+    signature.prune_fingerprint = config.manifest_prune_fingerprint();
+    let version_hash = if signature.prune_fingerprint.is_empty() {
+        signature.content_hash.clone()
+    } else {
+        blake3::hash(
+            format!("{}:{}", signature.content_hash, signature.prune_fingerprint).as_bytes(),
+        )
+        .to_hex()
+        .to_string()
+    };
+    let mut version_id = version_hash.chars().take(12).collect::<String>();
     if version_id.is_empty() {
         version_id = "unknown".to_string();
     }
@@ -489,6 +501,7 @@ fn ensure_build_reuse_state(
 }
 
 fn prepare_manifest_data(
+    config: &DbtNovaConfig,
     storage_dir: &Path,
     signature: &ManifestSignature,
     reuse_store: bool,
@@ -504,7 +517,14 @@ fn prepare_manifest_data(
 
     let parse_manifest = !reuse_store || !cached_indexes.used_cached_indexes;
     if parse_manifest {
-        parse_manifest_file(manifest_path, source_uri, &mut accumulator, load_start)?;
+        parse_manifest_file(
+            manifest_path,
+            source_uri,
+            &config.manifest_prune_allow_ids,
+            &config.manifest_prune_deny_ids,
+            &mut accumulator,
+            load_start,
+        )?;
     } else {
         info!("reused entity/index caches; skipped manifest parse");
     }
@@ -1145,6 +1165,7 @@ mod tests {
             len: 12_345,
             modified_ms: 9_999,
             content_hash: "same-hash".to_string(),
+            prune_fingerprint: String::new(),
             source_uri: "file:///new/path".to_string(),
         };
         let existing = ManifestSignature {
@@ -1152,6 +1173,7 @@ mod tests {
             len: 1,
             modified_ms: 1,
             content_hash: "same-hash".to_string(),
+            prune_fingerprint: String::new(),
             source_uri: "file:///old/path".to_string(),
         };
         assert!(
@@ -1167,6 +1189,7 @@ mod tests {
             len: 12_345,
             modified_ms: 9_999,
             content_hash: "expected-hash".to_string(),
+            prune_fingerprint: String::new(),
             source_uri: "file:///new/path".to_string(),
         };
         let different_hash = ManifestSignature {
@@ -1174,6 +1197,7 @@ mod tests {
             len: 12_345,
             modified_ms: 1,
             content_hash: "different-hash".to_string(),
+            prune_fingerprint: String::new(),
             source_uri: "file:///old/path".to_string(),
         };
         let missing_hash = ManifestSignature {
@@ -1181,6 +1205,7 @@ mod tests {
             len: 12_345,
             modified_ms: 1,
             content_hash: String::new(),
+            prune_fingerprint: String::new(),
             source_uri: "file:///old/path".to_string(),
         };
         assert!(!manifest_signature_matches_for_reuse(
@@ -1191,5 +1216,26 @@ mod tests {
             &missing_hash,
             &expected
         ));
+    }
+
+    #[test]
+    fn manifest_signature_reuse_match_rejects_prune_fingerprint_mismatch() {
+        let expected = ManifestSignature {
+            path: "/tmp/new/path/manifest.json".to_string(),
+            len: 12_345,
+            modified_ms: 9_999,
+            content_hash: "same-hash".to_string(),
+            prune_fingerprint: "fingerprint-a".to_string(),
+            source_uri: "file:///new/path".to_string(),
+        };
+        let existing = ManifestSignature {
+            path: "/tmp/old/path/manifest.json".to_string(),
+            len: 12_345,
+            modified_ms: 1,
+            content_hash: "same-hash".to_string(),
+            prune_fingerprint: "fingerprint-b".to_string(),
+            source_uri: "file:///old/path".to_string(),
+        };
+        assert!(!manifest_signature_matches_for_reuse(&existing, &expected));
     }
 }

--- a/src/manifest/loader/parse.rs
+++ b/src/manifest/loader/parse.rs
@@ -7,11 +7,12 @@ use std::time::Instant;
 
 use serde::de::{self, DeserializeSeed, Deserializer, MapAccess, Visitor};
 use serde_json::Value as JsonValue;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::error::{DbtNovaError, Result};
 use crate::manifest::entity::Entity;
 use crate::manifest::store::{EntityStore, EntityStoreBuilder};
+use crate::utils::{GlobPattern, compile_glob, glob_match_compiled};
 
 pub(super) struct ManifestAccumulator {
     pub(super) store_builder: Option<EntityStoreBuilder>,
@@ -179,6 +180,7 @@ impl ManifestAccumulator {
 
 struct EntitiesSeed<'a> {
     accumulator: &'a mut ManifestAccumulator,
+    pruner: Option<&'a mut ManifestPruner>,
     forced_resource_type: Option<&'static str>,
 }
 
@@ -191,6 +193,7 @@ impl<'de> DeserializeSeed<'de> for EntitiesSeed<'_> {
     {
         deserializer.deserialize_any(EntitiesVisitor {
             accumulator: self.accumulator,
+            pruner: self.pruner,
             forced_resource_type: self.forced_resource_type,
         })
     }
@@ -198,6 +201,7 @@ impl<'de> DeserializeSeed<'de> for EntitiesSeed<'_> {
 
 struct EntitiesVisitor<'a> {
     accumulator: &'a mut ManifestAccumulator,
+    pruner: Option<&'a mut ManifestPruner>,
     forced_resource_type: Option<&'static str>,
 }
 
@@ -212,7 +216,17 @@ impl<'de> Visitor<'de> for EntitiesVisitor<'_> {
     where
         M: MapAccess<'de>,
     {
+        let mut pruner = self.pruner;
         while let Some((unique_id, payload)) = map.next_entry::<String, JsonValue>()? {
+            let keep = match pruner.as_deref_mut() {
+                Some(matcher) => {
+                    matcher.should_keep_entity(&unique_id, &payload, self.forced_resource_type)
+                }
+                None => true,
+            };
+            if !keep {
+                continue;
+            }
             let entity = Entity::from_json(&unique_id, &payload);
             self.accumulator
                 .add_entity(&unique_id, &entity, self.forced_resource_type)
@@ -239,6 +253,7 @@ impl<'de> Visitor<'de> for EntitiesVisitor<'_> {
 
 struct ManifestSeed<'a> {
     accumulator: &'a mut ManifestAccumulator,
+    pruner: Option<&'a mut ManifestPruner>,
 }
 
 impl<'de> DeserializeSeed<'de> for ManifestSeed<'_> {
@@ -250,12 +265,14 @@ impl<'de> DeserializeSeed<'de> for ManifestSeed<'_> {
     {
         deserializer.deserialize_map(ManifestVisitor {
             accumulator: self.accumulator,
+            pruner: self.pruner,
         })
     }
 }
 
 struct ManifestVisitor<'a> {
     accumulator: &'a mut ManifestAccumulator,
+    pruner: Option<&'a mut ManifestPruner>,
 }
 
 impl<'de> Visitor<'de> for ManifestVisitor<'_> {
@@ -265,7 +282,7 @@ impl<'de> Visitor<'de> for ManifestVisitor<'_> {
         formatter.write_str("a manifest object")
     }
 
-    fn visit_map<M>(self, mut map: M) -> std::result::Result<Self::Value, M::Error>
+    fn visit_map<M>(mut self, mut map: M) -> std::result::Result<Self::Value, M::Error>
     where
         M: MapAccess<'de>,
     {
@@ -274,60 +291,70 @@ impl<'de> Visitor<'de> for ManifestVisitor<'_> {
                 "nodes" => {
                     map.next_value_seed(EntitiesSeed {
                         accumulator: self.accumulator,
+                        pruner: self.pruner.as_deref_mut(),
                         forced_resource_type: None,
                     })?;
                 }
                 "sources" => {
                     map.next_value_seed(EntitiesSeed {
                         accumulator: self.accumulator,
+                        pruner: self.pruner.as_deref_mut(),
                         forced_resource_type: Some("source"),
                     })?;
                 }
                 "macros" => {
                     map.next_value_seed(EntitiesSeed {
                         accumulator: self.accumulator,
+                        pruner: self.pruner.as_deref_mut(),
                         forced_resource_type: Some("macro"),
                     })?;
                 }
                 "docs" => {
                     map.next_value_seed(EntitiesSeed {
                         accumulator: self.accumulator,
+                        pruner: self.pruner.as_deref_mut(),
                         forced_resource_type: Some("doc"),
                     })?;
                 }
                 "groups" => {
                     map.next_value_seed(EntitiesSeed {
                         accumulator: self.accumulator,
+                        pruner: self.pruner.as_deref_mut(),
                         forced_resource_type: Some("group"),
                     })?;
                 }
                 "exposures" => {
                     map.next_value_seed(EntitiesSeed {
                         accumulator: self.accumulator,
+                        pruner: self.pruner.as_deref_mut(),
                         forced_resource_type: Some("exposure"),
                     })?;
                 }
                 "metrics" => {
                     map.next_value_seed(EntitiesSeed {
                         accumulator: self.accumulator,
+                        pruner: self.pruner.as_deref_mut(),
                         forced_resource_type: Some("metric"),
                     })?;
                 }
                 "saved_queries" => {
                     map.next_value_seed(EntitiesSeed {
                         accumulator: self.accumulator,
+                        pruner: self.pruner.as_deref_mut(),
                         forced_resource_type: Some("saved_query"),
                     })?;
                 }
                 "semantic_models" => {
                     map.next_value_seed(EntitiesSeed {
                         accumulator: self.accumulator,
+                        pruner: self.pruner.as_deref_mut(),
                         forced_resource_type: Some("semantic_model"),
                     })?;
                 }
                 "unit_tests" => {
                     map.next_value_seed(EntitiesSeed {
                         accumulator: self.accumulator,
+                        pruner: self.pruner.as_deref_mut(),
                         forced_resource_type: Some("unit_test"),
                     })?;
                 }
@@ -363,9 +390,164 @@ impl<'de> Visitor<'de> for ManifestVisitor<'_> {
     }
 }
 
+struct CompiledPattern {
+    raw: String,
+    compiled: GlobPattern,
+    matched: bool,
+}
+
+impl CompiledPattern {
+    fn new(pattern: String) -> Self {
+        Self {
+            compiled: compile_glob(&pattern, true),
+            raw: pattern,
+            matched: false,
+        }
+    }
+}
+
+struct ManifestPruner {
+    allow_patterns: Vec<CompiledPattern>,
+    deny_patterns: Vec<CompiledPattern>,
+}
+
+impl ManifestPruner {
+    fn from_patterns(allow_ids: &[String], deny_ids: &[String]) -> Option<Self> {
+        let allow_patterns: Vec<CompiledPattern> = allow_ids
+            .iter()
+            .filter_map(|pattern| {
+                let trimmed = pattern.trim();
+                (!trimmed.is_empty()).then(|| CompiledPattern::new(trimmed.to_string()))
+            })
+            .collect();
+        let deny_patterns: Vec<CompiledPattern> = deny_ids
+            .iter()
+            .filter_map(|pattern| {
+                let trimmed = pattern.trim();
+                (!trimmed.is_empty()).then(|| CompiledPattern::new(trimmed.to_string()))
+            })
+            .collect();
+        if allow_patterns.is_empty() && deny_patterns.is_empty() {
+            return None;
+        }
+        Some(Self {
+            allow_patterns,
+            deny_patterns,
+        })
+    }
+
+    fn should_keep_entity(
+        &mut self,
+        unique_id: &str,
+        payload: &JsonValue,
+        forced_resource_type: Option<&str>,
+    ) -> bool {
+        let keep_base = self.keep_by_allow_deny(unique_id, true);
+        if keep_base {
+            return true;
+        }
+        if self.matches_deny(unique_id, false) || !self.is_analysis(payload, forced_resource_type) {
+            return false;
+        }
+        self.should_auto_include_analysis(payload)
+    }
+
+    fn should_auto_include_analysis(&mut self, payload: &JsonValue) -> bool {
+        let deps = payload
+            .get("depends_on")
+            .and_then(|d| d.get("nodes"))
+            .and_then(|n| n.as_array());
+        let Some(dependencies) = deps else {
+            return false;
+        };
+        if dependencies.is_empty() {
+            return false;
+        }
+        dependencies.iter().all(|value| {
+            value
+                .as_str()
+                .is_some_and(|id| self.keep_by_allow_deny(id, false))
+        })
+    }
+
+    fn report_unmatched(&self) {
+        for pattern in &self.allow_patterns {
+            if !pattern.matched {
+                warn!(
+                    pattern = %pattern.raw,
+                    "manifest prune allow pattern did not match any entities"
+                );
+            }
+        }
+        for pattern in &self.deny_patterns {
+            if !pattern.matched {
+                warn!(
+                    pattern = %pattern.raw,
+                    "manifest prune deny pattern did not match any entities"
+                );
+            }
+        }
+    }
+
+    fn is_analysis(&self, payload: &JsonValue, forced_resource_type: Option<&str>) -> bool {
+        forced_resource_type == Some("analysis")
+            || payload
+                .get("resource_type")
+                .and_then(JsonValue::as_str)
+                .is_some_and(|resource_type| resource_type == "analysis")
+    }
+
+    fn matches_mut(patterns: &mut [CompiledPattern], unique_id: &str, mark: bool) -> bool {
+        let mut matched = false;
+        for pattern in patterns {
+            if glob_match_compiled(&pattern.compiled, unique_id) {
+                matched = true;
+                if mark {
+                    pattern.matched = true;
+                }
+            }
+        }
+        matched
+    }
+
+    fn matches_allow(&mut self, unique_id: &str, mark: bool) -> bool {
+        Self::matches_mut(&mut self.allow_patterns, unique_id, mark)
+    }
+
+    fn matches_deny(&mut self, unique_id: &str, mark: bool) -> bool {
+        Self::matches_mut(&mut self.deny_patterns, unique_id, mark)
+    }
+
+    fn keep_by_allow_deny(&mut self, unique_id: &str, mark: bool) -> bool {
+        let keep_after_allow = if self.allow_patterns.is_empty() {
+            true
+        } else {
+            self.matches_allow(unique_id, mark)
+        };
+        keep_after_allow && !self.matches_deny(unique_id, mark)
+    }
+}
+
+fn prune_lineage_maps(accumulator: &mut ManifestAccumulator) {
+    accumulator
+        .parent_map
+        .retain(|node_id, _| accumulator.seen_unique_ids.contains(node_id));
+    for dependencies in accumulator.parent_map.values_mut() {
+        dependencies.retain(|dep_id| accumulator.seen_unique_ids.contains(dep_id));
+    }
+    accumulator
+        .child_map
+        .retain(|node_id, _| accumulator.seen_unique_ids.contains(node_id));
+    for children in accumulator.child_map.values_mut() {
+        children.retain(|child_id| accumulator.seen_unique_ids.contains(child_id));
+    }
+}
+
 pub(super) fn parse_manifest_file(
     manifest_path: &Path,
     source_uri: &str,
+    allow_ids: &[String],
+    deny_ids: &[String],
     accumulator: &mut ManifestAccumulator,
     load_start: Instant,
 ) -> Result<()> {
@@ -375,14 +557,175 @@ pub(super) fn parse_manifest_file(
     let reader = BufReader::new(file);
 
     let mut deserializer = serde_json::Deserializer::from_reader(reader);
-    ManifestSeed { accumulator }
-        .deserialize(&mut deserializer)
-        .map_err(|err| {
-            DbtNovaError::ManifestError(format!("Failed to parse manifest JSON: {err}"))
-        })?;
+    let mut pruner = ManifestPruner::from_patterns(allow_ids, deny_ids);
+    ManifestSeed {
+        accumulator,
+        pruner: pruner.as_mut(),
+    }
+    .deserialize(&mut deserializer)
+    .map_err(|err| DbtNovaError::ManifestError(format!("Failed to parse manifest JSON: {err}")))?;
+    if let Some(pruner) = pruner.as_ref() {
+        pruner.report_unmatched();
+    }
+    prune_lineage_maps(accumulator);
     info!(
         elapsed_ms = load_start.elapsed().as_millis(),
         "manifest parsed"
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ManifestAccumulator, parse_manifest_file};
+    use std::fs;
+    use std::time::Instant;
+    use tempfile::tempdir;
+
+    #[test]
+    fn parse_manifest_prunes_by_allow_and_strict_analysis_dependencies() {
+        let manifest = r#"{
+          "metadata": { "dbt_version": "1.10.0" },
+          "nodes": {
+            "model.pkg.base_a": {
+              "name": "base_a",
+              "resource_type": "model",
+              "package_name": "pkg",
+              "depends_on": { "nodes": [], "macros": [] }
+            },
+            "model.pkg.base_b": {
+              "name": "base_b",
+              "resource_type": "model",
+              "package_name": "pkg",
+              "depends_on": { "nodes": [], "macros": [] }
+            },
+            "analysis.pkg.only_a": {
+              "name": "only_a",
+              "resource_type": "analysis",
+              "package_name": "pkg",
+              "depends_on": { "nodes": ["model.pkg.base_a"], "macros": [] }
+            },
+            "analysis.pkg.a_and_b": {
+              "name": "a_and_b",
+              "resource_type": "analysis",
+              "package_name": "pkg",
+              "depends_on": { "nodes": ["model.pkg.base_a", "model.pkg.base_b"], "macros": [] }
+            },
+            "analysis.pkg.empty_deps": {
+              "name": "empty_deps",
+              "resource_type": "analysis",
+              "package_name": "pkg",
+              "depends_on": { "nodes": [], "macros": [] }
+            }
+          },
+          "sources": {},
+          "macros": {},
+          "docs": {},
+          "groups": {},
+          "exposures": {},
+          "metrics": {},
+          "saved_queries": {},
+          "semantic_models": {},
+          "unit_tests": {},
+          "parent_map": {
+            "analysis.pkg.only_a": ["model.pkg.base_a"],
+            "analysis.pkg.a_and_b": ["model.pkg.base_a", "model.pkg.base_b"]
+          },
+          "child_map": {
+            "model.pkg.base_a": ["analysis.pkg.only_a", "analysis.pkg.a_and_b"],
+            "model.pkg.base_b": ["analysis.pkg.a_and_b"]
+          }
+        }"#;
+
+        let temp = tempdir().expect("tempdir");
+        let manifest_path = temp.path().join("manifest.json");
+        fs::write(&manifest_path, manifest).expect("write manifest");
+        let mut accumulator = ManifestAccumulator::new(temp.path(), false).expect("accumulator");
+        let allow_ids = vec!["model.pkg.base_a".to_string()];
+        let deny_ids: Vec<String> = Vec::new();
+
+        parse_manifest_file(
+            &manifest_path,
+            manifest_path.to_string_lossy().as_ref(),
+            &allow_ids,
+            &deny_ids,
+            &mut accumulator,
+            Instant::now(),
+        )
+        .expect("parse manifest");
+
+        assert!(accumulator.seen_unique_ids.contains("model.pkg.base_a"));
+        assert!(!accumulator.seen_unique_ids.contains("model.pkg.base_b"));
+        assert!(accumulator.seen_unique_ids.contains("analysis.pkg.only_a"));
+        assert!(!accumulator.seen_unique_ids.contains("analysis.pkg.a_and_b"));
+        assert!(
+            !accumulator
+                .seen_unique_ids
+                .contains("analysis.pkg.empty_deps")
+        );
+
+        let parent_only_a = accumulator
+            .parent_map
+            .get("analysis.pkg.only_a")
+            .expect("parent map for only_a");
+        assert!(parent_only_a.contains("model.pkg.base_a"));
+        assert!(!accumulator.parent_map.contains_key("analysis.pkg.a_and_b"));
+
+        let child_base_a = accumulator
+            .child_map
+            .get("model.pkg.base_a")
+            .expect("child map for base_a");
+        assert!(child_base_a.contains("analysis.pkg.only_a"));
+        assert!(!child_base_a.contains("analysis.pkg.a_and_b"));
+    }
+
+    #[test]
+    fn parse_manifest_deny_overrides_auto_analysis_inclusion() {
+        let manifest = r#"{
+          "metadata": { "dbt_version": "1.10.0" },
+          "nodes": {
+            "model.pkg.base_a": {
+              "name": "base_a",
+              "resource_type": "model",
+              "package_name": "pkg",
+              "depends_on": { "nodes": [], "macros": [] }
+            },
+            "analysis.pkg.only_a": {
+              "name": "only_a",
+              "resource_type": "analysis",
+              "package_name": "pkg",
+              "depends_on": { "nodes": ["model.pkg.base_a"], "macros": [] }
+            }
+          },
+          "sources": {},
+          "macros": {},
+          "docs": {},
+          "groups": {},
+          "exposures": {},
+          "metrics": {},
+          "saved_queries": {},
+          "semantic_models": {},
+          "unit_tests": {}
+        }"#;
+
+        let temp = tempdir().expect("tempdir");
+        let manifest_path = temp.path().join("manifest.json");
+        fs::write(&manifest_path, manifest).expect("write manifest");
+        let mut accumulator = ManifestAccumulator::new(temp.path(), false).expect("accumulator");
+        let allow_ids = vec!["model.pkg.base_a".to_string()];
+        let deny_ids = vec!["analysis.pkg.*".to_string()];
+
+        parse_manifest_file(
+            &manifest_path,
+            manifest_path.to_string_lossy().as_ref(),
+            &allow_ids,
+            &deny_ids,
+            &mut accumulator,
+            Instant::now(),
+        )
+        .expect("parse manifest");
+
+        assert!(accumulator.seen_unique_ids.contains("model.pkg.base_a"));
+        assert!(!accumulator.seen_unique_ids.contains("analysis.pkg.only_a"));
+    }
 }

--- a/src/manifest/loader/parse.rs
+++ b/src/manifest/loader/parse.rs
@@ -446,8 +446,7 @@ impl ManifestPruner {
         if keep_base {
             return true;
         }
-        if self.matches_deny(unique_id, false)
-            || !Self::is_analysis(payload, forced_resource_type)
+        if self.matches_deny(unique_id, false) || !Self::is_analysis(payload, forced_resource_type)
         {
             return false;
         }

--- a/src/manifest/loader/parse.rs
+++ b/src/manifest/loader/parse.rs
@@ -446,7 +446,9 @@ impl ManifestPruner {
         if keep_base {
             return true;
         }
-        if self.matches_deny(unique_id, false) || !self.is_analysis(payload, forced_resource_type) {
+        if self.matches_deny(unique_id, false)
+            || !Self::is_analysis(payload, forced_resource_type)
+        {
             return false;
         }
         self.should_auto_include_analysis(payload)
@@ -489,7 +491,7 @@ impl ManifestPruner {
         }
     }
 
-    fn is_analysis(&self, payload: &JsonValue, forced_resource_type: Option<&str>) -> bool {
+    fn is_analysis(payload: &JsonValue, forced_resource_type: Option<&str>) -> bool {
         forced_resource_type == Some("analysis")
             || payload
                 .get("resource_type")

--- a/src/manifest/loader/storage.rs
+++ b/src/manifest/loader/storage.rs
@@ -44,6 +44,7 @@ pub(super) fn manifest_signature_matches_for_reuse(
     !existing.content_hash.is_empty()
         && !expected.content_hash.is_empty()
         && existing.content_hash == expected.content_hash
+        && existing.prune_fingerprint == expected.prune_fingerprint
 }
 
 pub(super) fn read_current_version(path: &Path) -> Result<Option<String>> {

--- a/src/manifest/source/mod.rs
+++ b/src/manifest/source/mod.rs
@@ -131,6 +131,7 @@ pub(crate) struct ManifestSignature {
     pub len: u64,
     pub modified_ms: u128,
     pub content_hash: String,
+    pub prune_fingerprint: String,
     pub source_uri: String,
 }
 
@@ -167,6 +168,7 @@ pub(crate) fn manifest_signature(path: &Path, source_uri: &str) -> Result<Manife
         len: meta.len(),
         modified_ms,
         content_hash,
+        prune_fingerprint: String::new(),
         source_uri: source_uri.to_string(),
     })
 }
@@ -944,6 +946,7 @@ where
     })
 }
 
+#[cfg(any(feature = "s3", feature = "gcs"))]
 fn run_async_fetch_blocking<F, Fut, T>(factory: F) -> Result<T>
 where
     F: FnOnce() -> Fut + Send + 'static,


### PR DESCRIPTION
# Add Manifest Scope Pruning via Allow/Deny Unique IDs

Closes #172

## Summary

This PR adds a simplified manifest-pruning capability to `dbt-nova` so teams can limit indexed/exposed entities to an explicit subset of dbt assets.

Instead of indexing the full `manifest.json`, users can now provide:

- `DBT_NOVA_PRUNE_ALLOW_IDS` (JSON array of `unique_id` patterns)
- `DBT_NOVA_PRUNE_DENY_IDS` (JSON array of `unique_id` patterns)

Pruning is applied at manifest-parse time and affects search/lineage/tool visibility.

## Why this solves #172

Issue #172 describes the need to support context-limited MCP deployments and wide dbt projects where only non-legacy/available tables should be exposed.

This implementation allows operators to:

- keep only approved entities (allowlist mode)
- remove legacy/out-of-scope entities (denylist mode)
- combine both for explicit scope control

## Key behavior

- Matching is done on dbt `unique_id` (not `fqn`).
- Supports exact match and glob patterns.
- If allow list is empty, base scope is “all entities”, then deny is applied.
- If allow list is set, base scope is “allow matches”, then deny is applied.
- Deny wins overlap conflicts.
- Unknown allow/deny patterns are warned and ignored (non-fatal).
- `analysis` nodes are auto-included only when:
  - they have direct dependencies, and
  - all direct dependencies are retained by allow/deny rules.

## Design choices and variable naming

### Chosen variables

- `DBT_NOVA_PRUNE_ALLOW_IDS`
- `DBT_NOVA_PRUNE_DENY_IDS`

### Why these names

- `PRUNE` keeps semantics explicit (this is manifest-scope filtering).
- `ALLOW_IDS` / `DENY_IDS` is clear and symmetric.
- `IDS` signals canonical dbt IDs (`unique_id`) rather than names/FQNs.
- `DBT_NOVA_` prefix matches existing project config convention.

### Why unique_id over fqn

- `unique_id` is canonical and deterministic in manifest keys.
- `fqn` can be ambiguous and is not the primary lookup key used internally.
- Using `unique_id` avoids resolver complexity and conflict policy edge cases.

## Implementation details

- Added config fields:
  - `manifest_prune_allow_ids: Vec<String>`
  - `manifest_prune_deny_ids: Vec<String>`
- Added env parsing for both variables (JSON arrays).
- Added deterministic prune fingerprinting and reuse-key integration.
- Extended manifest signature to include prune fingerprint.
- Reuse now requires both `content_hash` and `prune_fingerprint` match.
- Parse pipeline now applies pruning across all entity sections and trims lineage maps to retained IDs.

## Docs updates

- Configuration reference updated with new vars and behavior.
- CLI docs include pruning example.
- Added documented pattern to generate allow IDs directly from `dbt ls`:

```bash
dbt ls -s <lineage selection expression> --output json --quiet \
| jq -cs '[.[] | .unique_id]'
```

- MCP client examples and README snippets updated with prune env examples.

## Test coverage

Added/updated tests for:

- env parsing of prune lists
- prune fingerprint stability (order-independent)
- strict analysis auto-inclusion behavior
- deny precedence
- reuse rejection on prune fingerprint mismatch

## Example usage

```bash
DBT_NOVA_PRUNE_ALLOW_IDS='["model.my_proj.fct_orders","model.my_proj.dim_*"]' \
DBT_NOVA_PRUNE_DENY_IDS='["model.my_proj.dim_legacy_*"]' \
dbt-nova manifest load --manifest-path /path/to/manifest.json --json
```