### PR TITLE
Prepare v0.0.4 release readiness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,23 @@ jobs:
         with:
           cosign-release: "v2.4.1"
 
+      - name: Extract release notes
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          release_version="${RELEASE_TAG#v}"
+          awk -v version="${release_version}" '
+            index($0, "## [" version "]") == 1 { in_release=1; next }
+            /^## \[/ && in_release { exit }
+            in_release { print }
+          ' CHANGELOG.md > RELEASE_NOTES.md
+          if [ ! -s RELEASE_NOTES.md ]; then
+            echo "Failed to extract release notes for ${release_version} from CHANGELOG.md."
+            exit 1
+          fi
+
       - name: Build (release, all features)
         env:
           TARGET_TRIPLE: ${{ matrix.target }}
@@ -170,6 +187,7 @@ jobs:
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
         with:
           tag_name: ${{ needs.validate.outputs.release_tag }}
+          body_path: RELEASE_NOTES.md
           files: |
             dbt-nova-${{ matrix.asset }}.tar.gz
             dbt-nova-${{ matrix.asset }}.sha256

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,166 @@
+# AGENTS.md
+
+Guidance for coding agents working in this repository.
+
+## Project Overview
+
+`dbt-nova` is a Rust CLI and MCP server for turning dbt `manifest.json`
+artifacts into agent-ready search, lineage, metadata scoring, SQL execution,
+and recipe tools.
+
+Core areas:
+
+- `src/main.rs`, `src/cli/` - CLI entrypoints and command handling.
+- `src/server/` - MCP stdio and streamable HTTP server behavior.
+- `src/tools/` - MCP/CLI tool implementations.
+- `src/manifest/` - manifest loading, entity normalization, storage, search,
+  embeddings, bootstrap, and prebuilt artifact hydration.
+- `src/warehouse/` - Databricks, BigQuery, and DuckDB SQL providers.
+- `src/nova_meta/` - `meta.nova` schema validation and semantic checks.
+- `.github/workflows/` - CI, release, reusable asset build, and metadata audit
+  automation.
+- `.github/skills/` - packaged agent skills installed by the release/install
+  tooling.
+- `docs/` - MkDocs documentation site.
+- `schemas/nova/v0.json` - public Nova metadata schema.
+
+## High-Signal Commands
+
+Prefer focused checks while developing, then run the relevant release-grade
+checks before handoff.
+
+```bash
+cargo fmt --check
+cargo clippy --locked --all-targets --all-features -- -D warnings
+cargo test --locked --all-features
+uv run mkdocs build --strict
+cargo deny check
+bash scripts/check_dependency_watchlist.sh
+```
+
+Useful targeted commands:
+
+```bash
+cargo test --locked <module_or_test_name>
+cargo test --locked --test <integration_test_name>
+DBT_NOVA_SEARCH_ENABLE_VECTOR=false \
+DBT_NOVA_SEARCH_ENABLE_SPARSE=false \
+DBT_NOVA_SEARCH_ENABLE_RERANKER=false \
+  cargo test --locked --all-features
+```
+
+When editing workflow files, run:
+
+```bash
+actionlint .github/workflows/<workflow>.yml
+```
+
+When editing docs or config defaults, also check:
+
+```bash
+uv run mkdocs build --strict
+bash scripts/check_config_reference.sh
+```
+
+## Development Rules
+
+- Keep changes scoped. Avoid broad refactors inside release, CI, or security
+  patches unless the task explicitly requires them.
+- Preserve existing public CLI/MCP contracts unless the user asks for a breaking
+  change.
+- Use `rg`/`rg --files` for search.
+- Add or update tests for behavior changes.
+- Prefer explicit `DbtNovaError` propagation over panics.
+- Do not add `.expect()`/`.unwrap()` in production paths unless there is a
+  strong invariant and a clear message.
+- Do not silently ignore errors; return them or log enough context.
+- Keep source and docs ASCII unless the file already requires non-ASCII.
+- Do not commit generated build artifacts, caches, or local manifests.
+
+## Rust Notes
+
+- Minimum supported Rust version is 1.93.
+- Release artifacts are built with default features, so CI lint/test uses
+  `--all-features`.
+- `Cargo.lock` is committed and should remain reproducible.
+- Default features include embeddings plus S3/GCS support. Use
+  `--no-default-features` only when explicitly testing that mode.
+- Hot paths are search, manifest loading, artifact hydration, and SQL execution.
+  Avoid unnecessary allocations in those areas.
+
+## Manifest, Search, and Metadata Rules
+
+- `meta.nova` is the first-class semantic contract. Keep schema, docs, tests,
+  and search/scoring behavior aligned.
+- If changing `schemas/nova/v0.json`, update docs under `docs/features/` and add
+  validation/scoring tests.
+- dbt 1.11+ may place metadata under `config.meta`; preserve fallback behavior
+  from legacy `meta` to `config.meta`.
+- Avoid real customer/company/table names in examples and tests. Use synthetic
+  names like `analytics_reporting`, `model.pkg.orders`, or `jaffle_shop`.
+- Do not enable vector, sparse, or reranker work in smoke tests unless the task
+  specifically requires semantic model behavior.
+
+## MCP and Hosted Server Rules
+
+- `streamable_http` has no built-in authentication. Non-loopback binds require
+  `DBT_NOVA_HTTP_EXPECT_AUTH_PROXY=true` and must be behind an authenticating
+  proxy.
+- Probe endpoints are reserved:
+  - `/healthz` for process liveness
+  - `/readyz` for manifest/search readiness
+- The MCP endpoint defaults to `/mcp`.
+- Hosted bootstrap/artifact consumers need writable local storage on first run
+  unless artifacts are already materialized and strict read-only mode is used.
+
+## Reusable Workflow Rules
+
+For `.github/workflows/nova-build-assets.yml`:
+
+- Prefer structured dbt invocation with `dbt_command_args_json`.
+- Treat `dbt_command` as trusted shell execution only.
+- Keep `installer_ref` aligned with the reusable workflow ref in examples.
+- Use `search_warm_strategy: staged` for large manifests or constrained
+  runners.
+- Use `build_timeout_minutes` for large dbt projects or remote publishes.
+- Use `DBT_NOVA_SECRET_BUNDLE_JSON` for portable cross-owner secret mapping.
+
+For `.github/workflows/nova-metadata-audit.yml`:
+
+- Metadata-only audits should avoid full semantic startup unless explicitly
+  required.
+- `selection_mode=changed` should use immutable PR SHAs when available.
+
+## Release Rules
+
+- Do not use a `release/*` or `hotfix/*` branch name unless the user intends to
+  trigger the auto-tag release flow after merge to `master`.
+- Release tags are `vX.Y.Z`.
+- `release.yml` validates `Cargo.toml` and `CHANGELOG.md` against the tag.
+- If docs reference a new release tag before the tag exists, keep that change in
+  the release PR and tag promptly after merge.
+- Do not merge release PRs without explicit user approval.
+
+## Security and Supply Chain
+
+- Security reports belong in private disclosure, not public issues. See
+  `SECURITY.md`.
+- Keep `deny.toml` advisory ignores and `dependency-watchlist.toml` review dates
+  current.
+- Run `cargo deny check` after dependency or advisory changes.
+- Never log credentials, tokens, private keys, or unsanitized artifact/manifest
+  URIs.
+- Preserve URI sanitization when touching manifest, artifact, or warehouse code.
+
+## PR Checklist for Agents
+
+Before opening or updating a PR:
+
+- Run the narrowest meaningful tests for the touched code.
+- Run formatting and lint checks when code changed.
+- Run docs build when docs changed.
+- Update `CHANGELOG.md` for user-facing behavior, release, CLI/MCP, workflow, or
+  security changes.
+- Include validation commands in the PR body.
+- Call out any checks that were intentionally skipped and why.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.4] - 2026-04-28
+## [0.0.4] - 2026-04-25
+
 ### Added
 
 - CLI-only `dbt-nova audit nova-meta` validation for `meta.nova`, with project/file/resource/column targeting, JSON output, schema validation against `schemas/nova/v0.json`, and local semantic checks for references, grain consistency, duplicate definitions, and filter-operator rules.
@@ -24,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reusable metadata audit workflow plus `dbt-nova audit metadata-score` CLI support for project-wide, changed-entity, and explicit-entity metadata gating in CI.
 - Query-aware Nova semantic previews in search results, plus stronger canonical measure/metric ranking so analyst search surfaces the preferred execution model and formula directly.
 - Tagged releases now publish a smoke-tested OCI image for hosted/server deployments.
+- Reusable asset builds now expose `search_warm_strategy` (`staged` or `full`) and
+  `build_timeout_minutes` inputs so large manifests can warm semantic assets in
+  bounded stages and choose an explicit job timeout.
 
 ### Changed
 
@@ -39,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bundle selectors are mapped for compatibility.
 - CI hardening now includes lower-memory lint/coverage/test settings and extra
   runner disk cleanup for the `test` job.
-- Reusable asset publishing now supports GitHub OIDC for GCS targets, refreshes GCS access tokens during longer uploads, uses `gcloud storage cp` for large transfers, and applies higher publish timeout budgets.
+- Reusable asset publishing now supports GitHub OIDC for GCS targets, refreshes GCS access tokens during longer uploads, uses `gcloud storage cp` for large transfers, defaults semantic cache warmup to staged mode, and applies configurable build/publish timeout budgets.
 - Metadata audit and reusable asset workflows now support the shared `DBT_NOVA_SECRET_BUNDLE_JSON` secret-bundle contract for cross-repo dbt execution.
 - Analyst search now prefers matched canonical Nova measures and metrics more strongly, including cases where the same business term appears across multiple models or alongside standalone dbt `metric` entities.
 - Release automation now pushes the exact smoke-tested OCI image instead of rebuilding a separate image during release.
@@ -81,6 +85,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   acknowledgement explicitly for hosted deployments, and startup logs now warn
   clearly that the built-in streamable HTTP transport has no authentication layer.
 - Cold-start search model failures now degrade safely by disabling broken empty search indexes instead of leaving startup wedged.
+- Bootstrap artifact hydration now works when invoked from an existing current-thread
+  Tokio runtime, fixing hosted/embedded startup paths that fetch bootstrap contracts
+  during server initialization.
 - Metadata audit tests now use isolated storage roots under parallel execution, and the reusable audit workflow no longer cancels sibling invocations on the same ref.
 - Documentation and dependency maintenance issues that broke docs or security checks were corrected (`Pygments` compatibility and `tar` advisory updates).
 - Release installs with `--install-skills` now work with the standalone

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Code of Conduct
+
+## Our Pledge
+
+We are committed to a respectful, harassment-free project environment for
+everyone, regardless of background, identity, or experience level.
+
+## Expected Behavior
+
+- Be respectful and constructive.
+- Assume good intent, but accept corrections when impact differs from intent.
+- Keep technical criticism focused on the work, not the person.
+- Respect privacy and do not disclose private information without permission.
+
+## Unacceptable Behavior
+
+- Harassment, abuse, threats, or discriminatory language.
+- Sexualized language or imagery in project spaces.
+- Trolling, sustained disruption, or bad-faith participation.
+- Publishing private contact details, credentials, or proprietary information.
+
+## Enforcement
+
+Project maintainers may remove comments, close issues, block accounts, or take
+other proportionate action to protect the project environment.
+
+Report conduct concerns privately to `joseph.broadhead.dev@gmail.com`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest released version of `dbt-nova`.
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities privately instead of opening a public
+issue. Email `joseph.broadhead.dev@gmail.com` with:
+
+- affected version or commit SHA
+- environment and deployment mode, if relevant
+- reproduction steps or proof of concept
+- expected impact
+
+You should receive an acknowledgement within 7 days. Confirmed issues will be
+handled with coordinated disclosure, a fix, and release notes when appropriate.
+
+## Scope
+
+Security-sensitive areas include:
+
+- MCP server transports and hosted HTTP deployment behavior
+- SQL execution limits, parameter handling, and provider integrations
+- manifest/artifact fetching and archive materialization
+- installer, release, and reusable workflow supply-chain behavior
+- credential handling and logging redaction

--- a/deny.toml
+++ b/deny.toml
@@ -5,11 +5,11 @@ yanked = "warn"
 unmaintained = "transitive"
 unsound = "transitive"
 ignore = [
-  { id = "RUSTSEC-2024-0384", reason = "owner=@joe-broadhead; review_by=2026-04-30; transitive via tantivy -> measure_time -> instant. No upstream fix; upgrade tantivy when feasible." },
-  { id = "RUSTSEC-2024-0436", reason = "owner=@joe-broadhead; review_by=2026-04-30; transitive via fastembed -> tokenizers -> paste. No safe upgrade; monitor tokenizers." },
-  { id = "RUSTSEC-2025-0119", reason = "owner=@joe-broadhead; review_by=2026-04-30; transitive via fastembed -> hf-hub -> indicatif -> number_prefix. No safe upgrade; monitor hf-hub/indicatif." },
-  { id = "RUSTSEC-2025-0134", reason = "owner=@joe-broadhead; review_by=2026-04-30; transitive via google-cloud-storage -> reqwest 0.11 -> rustls-pemfile. Upgrade gcs stack when available." },
-  { id = "RUSTSEC-2026-0002", reason = "owner=@joe-broadhead; review_by=2026-04-30; transitive via tantivy -> lru 0.12. Upgrade tantivy to pull lru >=0.16.3." },
+  { id = "RUSTSEC-2024-0384", reason = "owner=@joe-broadhead; review_by=2026-05-31; transitive via tantivy -> measure_time -> instant. No upstream fix; upgrade tantivy when feasible." },
+  { id = "RUSTSEC-2024-0436", reason = "owner=@joe-broadhead; review_by=2026-05-31; transitive via fastembed -> tokenizers -> paste. No safe upgrade; monitor tokenizers." },
+  { id = "RUSTSEC-2025-0119", reason = "owner=@joe-broadhead; review_by=2026-05-31; transitive via fastembed -> hf-hub -> indicatif -> number_prefix. No safe upgrade; monitor hf-hub/indicatif." },
+  { id = "RUSTSEC-2025-0134", reason = "owner=@joe-broadhead; review_by=2026-05-31; transitive via google-cloud-storage -> reqwest 0.11 -> rustls-pemfile. Upgrade gcs stack when available." },
+  { id = "RUSTSEC-2026-0002", reason = "owner=@joe-broadhead; review_by=2026-05-31; transitive via tantivy -> lru 0.12. Upgrade tantivy to pull lru >=0.16.3." },
   { id = "RUSTSEC-2026-0097", reason = "owner=@joe-broadhead; review_by=2026-05-31; transitive via fastembed/tokenizers, tantivy/rand_distr, rmcp, and proptest. No semver-compatible upstream fix is available in the current graph. dbt-nova uses tracing_subscriber::fmt() and does not define a custom log::Log or call rand::rng() from logger code, so the reported UB path is not reachable in this codebase. Remove once upstreams move to rand >=0.9.3 or >=0.10.1." },
 ]
 unused-ignored-advisory = "warn"

--- a/dependency-watchlist.toml
+++ b/dependency-watchlist.toml
@@ -8,7 +8,7 @@
 [[item]]
 id = "ort-sys-pin"
 owner = "@joe-broadhead"
-review_by = "2026-04-30"
+review_by = "2026-05-31"
 summary = "Exact ort-sys RC pin is required for current fastembed compatibility."
 current_state = "Cargo.toml pins ort-sys = \"=2.0.0-rc.4\"."
 upgrade_trigger = "fastembed/ort ecosystem supports stable (non-RC) ort-sys without local patching."
@@ -18,7 +18,7 @@ state_checks = ["cargo_toml_has_ort_sys_rc_pin", "cargo_lock_has_ort_sys_rc4"]
 [[item]]
 id = "reqwest-transitive-split"
 owner = "@joe-broadhead"
-review_by = "2026-04-30"
+review_by = "2026-05-31"
 summary = "Dependency graph currently contains both reqwest 0.11 and 0.12."
 current_state = "reqwest 0.11 is pulled transitively by google-cloud-storage while dbt-nova uses reqwest 0.12 directly."
 upgrade_trigger = "google-cloud-storage stack upgrades to reqwest 0.12+."

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -41,7 +41,9 @@ Operational defaults:
   invocation (`dbt_command`), plus `dbt_env_json`,
   `dbt_secret_env_map_json`, optional workflow_call secret bundle
   (`DBT_NOVA_SECRET_BUNDLE_JSON`), optional installer source override
-  (`installer_repository`, `installer_ref`, `installer_install_mode`), optional models artifact, optional remote publish
+  (`installer_repository`, `installer_ref`, `installer_install_mode`), optional models artifact, staged/full semantic warmup
+  (`search_warm_strategy`), configurable build timeout
+  (`build_timeout_minutes`), optional remote publish
   targets (`s3`, `gcs`, `dbfs`) and `publish_dry_run`; models behavior is
   configured via `models_distribution_mode` (`none|publish_only|publish_and_bootstrap`)
 - **Invocation safety:** structured mode runs

--- a/docs/features/metadata-audit.md
+++ b/docs/features/metadata-audit.md
@@ -107,7 +107,7 @@ and across same-owner or cross-owner reusable workflow calls:
 ```yaml
 jobs:
   nova_metadata_audit:
-    uses: joe-broadhead/dbt-nova/.github/workflows/nova-metadata-audit.yml@c443c5c301db04189fea690ff1adc32823721d11
+    uses: joe-broadhead/dbt-nova/.github/workflows/nova-metadata-audit.yml@v0.0.4
     with:
       dbt_generate_manifest: true
       dbt_command_args_json: >-

--- a/docs/operations/prebuilt-assets.md
+++ b/docs/operations/prebuilt-assets.md
@@ -41,9 +41,8 @@ read-only reuse after local materialization.
 
 Create a workflow in the downstream repo that calls Nova's reusable producer.
 
-The examples below pin a commit SHA because they rely on the current
-unreleased secret-bundle workflow contract. After the next release, replace
-that SHA with the corresponding release tag.
+The examples below pin `v0.0.4`. For production, pin either a release tag or an
+immutable commit SHA and keep `installer_ref` aligned with the workflow ref.
 
 ```yaml
 name: Build Nova Assets
@@ -54,11 +53,11 @@ on:
 jobs:
   build_nova_assets:
     # Pin to a release tag or commit SHA
-    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@c443c5c301db04189fea690ff1adc32823721d11
+    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@v0.0.4
     with:
       manifest_path: target/manifest.json
       storage_instance_id: analytics-prod
-      installer_ref: c443c5c301db04189fea690ff1adc32823721d11
+      installer_ref: v0.0.4
       installer_install_mode: auto
       artifact_name_prefix: analytics-prod
       retention_days: 14
@@ -74,6 +73,8 @@ Alternative producer inputs:
 - `dbt_env_json` (JSON object of non-secret env vars exported before dbt invocation)
 - `dbt_secret_env_map_json` (JSON object mapping env var names to secret names)
 - `models_distribution_mode` (`none`, `publish_only`, `publish_and_bootstrap`)
+- `search_warm_strategy` (`staged` by default, or `full`)
+- `build_timeout_minutes` (integer `1..360`, default `360`)
 - workflow_call secret `DBT_NOVA_SECRET_BUNDLE_JSON` (optional JSON object of
   `secret-name -> secret-value` entries for cross-owner reusable workflow calls)
 
@@ -97,7 +98,7 @@ workflow works across Databricks, BigQuery, DuckDB, and mixed profiles:
 ```yaml
 jobs:
   build_nova_assets:
-    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@c443c5c301db04189fea690ff1adc32823721d11
+    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@v0.0.4
     with:
       dbt_generate_manifest: true
       dbt_command_args_json: >-
@@ -116,7 +117,7 @@ DBFS publish wrapper example:
 ```yaml
 jobs:
   build_nova_assets:
-    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@c443c5c301db04189fea690ff1adc32823721d11
+    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@v0.0.4
     with:
       dbt_generate_manifest: true
       dbt_command_args_json: >-
@@ -126,12 +127,14 @@ jobs:
       dbt_secret_env_map_json: >-
         {"DBT_ACCESS_TOKEN":"DBT_ACCESS_TOKEN","DATABRICKS_ACCESS_TOKEN":"DBT_ACCESS_TOKEN"}
       storage_instance_id: analytics-prod
-      installer_ref: c443c5c301db04189fea690ff1adc32823721d11
+      installer_ref: v0.0.4
       installer_install_mode: source
       publish_targets: dbfs
       publish_dbfs_prefix: dbfs:/FileStore/projects/my-project/nova-assets/prod
       publish_dry_run: false
       models_distribution_mode: none
+      search_warm_strategy: staged
+      build_timeout_minutes: 360
     secrets:
       DBT_NOVA_SECRET_BUNDLE_JSON: ${{ secrets.DBT_NOVA_SECRET_BUNDLE_JSON }}
 ```
@@ -148,6 +151,13 @@ Notes:
   2) inherited workflow secrets (`secrets: inherit`, same-owner/org calls).
 - Missing mapped secrets fail fast before dbt invocation.
 - Use trusted `dbt_command` only when you explicitly need shell semantics.
+- Keep `search_warm_strategy: staged` for large manifests or memory-constrained
+  runners. It warms dense, sparse, and reranker assets in separate bounded steps
+  instead of one full warmup process. Use `full` only when the runner has enough
+  memory and you want the legacy single-step warm behavior.
+- Increase `build_timeout_minutes` for large dbt projects or remote publishes
+  that need more than the default job budget; the workflow validates values from
+  `1` to `360`.
 
 Secret setup patterns:
 

--- a/src/warehouse/databricks.rs
+++ b/src/warehouse/databricks.rs
@@ -1237,8 +1237,8 @@ mod tests {
 
     #[test]
     fn schema_preflight_statement_uses_valid_show_syntax() {
-        let statement = schema_preflight_statement("prod_datalake_analytics_unified");
-        assert_eq!(statement, "SHOW TABLES IN prod_datalake_analytics_unified");
+        let statement = schema_preflight_statement("analytics_reporting");
+        assert_eq!(statement, "SHOW TABLES IN analytics_reporting");
         assert!(
             !statement.to_ascii_uppercase().contains("LIMIT"),
             "schema preflight statement must not include LIMIT"


### PR DESCRIPTION
## Summary

- add release-note extraction so GitHub releases use the v0.0.4 CHANGELOG section
- add SECURITY.md and CODE_OF_CONDUCT.md for public OSS readiness
- refresh v0.0.4 changelog/docs for reusable asset staged warmup and configurable build timeout
- extend dependency advisory/watchlist review dates after re-verifying gates
- remove a real-looking schema name from a Databricks unit test

## Validation

- actionlint .github/workflows/release.yml
- uv run mkdocs build --strict
- cargo fmt --check
- cargo deny check
- bash scripts/check_dependency_watchlist.sh
- cargo test --locked warehouse::databricks::tests::schema_preflight_statement_uses_valid_show_syntax
- release-note extraction smoke test
- git diff --check