### PR TITLE
fix: remove unsupported reusable workflow context

### DIFF
--- a/.github/workflows/nova-build-assets.yml
+++ b/.github/workflows/nova-build-assets.yml
@@ -275,7 +275,6 @@ jobs:
           INPUT_GCP_PROJECT_ID: ${{ inputs.gcp_project_id }}
           INPUT_PUBLISH_DBFS_PREFIX: ${{ inputs.publish_dbfs_prefix }}
           INPUT_PUBLISH_DRY_RUN: ${{ inputs.publish_dry_run }}
-          JOB_WORKFLOW_REF: ${{ github.job_workflow_ref }}
           WORKFLOW_REF: ${{ github.workflow_ref }}
           ACTION_REPOSITORY: ${{ github.action_repository }}
           ACTION_REF: ${{ github.action_ref }}
@@ -614,19 +613,6 @@ jobs:
               exit 1
             fi
           done
-
-          if [[ -z "${installer_repository}" || -z "${installer_ref}" ]]; then
-            if [[ -n "${JOB_WORKFLOW_REF:-}" && "${JOB_WORKFLOW_REF}" == *"/.github/workflows/"* && "${JOB_WORKFLOW_REF}" == *"@"* ]]; then
-              job_workflow_repository="${JOB_WORKFLOW_REF%%/.github/workflows/*}"
-              job_workflow_ref="${JOB_WORKFLOW_REF##*@}"
-              if [[ -z "${installer_repository}" ]]; then
-                installer_repository="${job_workflow_repository}"
-              fi
-              if [[ -z "${installer_ref}" && "${installer_repository}" == "${job_workflow_repository}" ]]; then
-                installer_ref="${job_workflow_ref}"
-              fi
-            fi
-          fi
 
           if [[ -z "${installer_repository}" ]]; then
             if [[ -n "${WORKFLOW_REF:-}" && "${WORKFLOW_REF}" == *"/.github/workflows/"* && "${WORKFLOW_REF}" == *"@"* ]]; then

--- a/.github/workflows/nova-metadata-audit.yml
+++ b/.github/workflows/nova-metadata-audit.yml
@@ -327,7 +327,6 @@ jobs:
           INPUT_STORAGE_INSTANCE_ID: ${{ inputs.storage_instance_id }}
           INPUT_ARTIFACT_NAME_PREFIX: ${{ inputs.artifact_name_prefix }}
           INPUT_RETENTION_DAYS: ${{ inputs.retention_days }}
-          JOB_WORKFLOW_REF: ${{ github.job_workflow_ref }}
           WORKFLOW_REF: ${{ github.workflow_ref }}
           ACTION_REPOSITORY: ${{ github.action_repository }}
           CURRENT_REPOSITORY: ${{ github.repository }}
@@ -384,7 +383,6 @@ jobs:
           storage_instance_id = os.environ["INPUT_STORAGE_INSTANCE_ID"].strip() or "metadata-audit"
           artifact_name_prefix = os.environ["INPUT_ARTIFACT_NAME_PREFIX"].strip() or "dbt-nova-metadata-audit"
           retention_days = os.environ["INPUT_RETENTION_DAYS"].strip()
-          job_workflow_ref = os.environ.get("JOB_WORKFLOW_REF", "")
           workflow_ref = os.environ.get("WORKFLOW_REF", "")
           action_repository = os.environ.get("ACTION_REPOSITORY", "")
           current_repository = os.environ.get("CURRENT_REPOSITORY", "")
@@ -440,13 +438,6 @@ jobs:
           if not retention_days.isdigit() or not (1 <= int(retention_days) <= 90):
               fail("retention_days must be an integer between 1 and 90.")
 
-          if (not installer_repository or not installer_ref) and job_workflow_ref and "/.github/workflows/" in job_workflow_ref and "@" in job_workflow_ref:
-              workflow_repository = job_workflow_ref.split("/.github/workflows/")[0]
-              workflow_ref_value = job_workflow_ref.rsplit("@", 1)[1]
-              if not installer_repository:
-                  installer_repository = workflow_repository
-              if not installer_ref and installer_repository == workflow_repository:
-                  installer_ref = workflow_ref_value
           if (not installer_repository or not installer_ref) and workflow_ref and "/.github/workflows/" in workflow_ref and "@" in workflow_ref:
               workflow_repository = workflow_ref.split("/.github/workflows/")[0]
               workflow_ref_value = workflow_ref.rsplit("@", 1)[1]

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -36,6 +36,17 @@ jobs:
             exit 1
           fi
 
+          unreleased_content="$(awk '
+            /^## \[Unreleased\]/ { in_unreleased=1; next }
+            /^## \[/ && in_unreleased { exit }
+            in_unreleased && NF { print }
+          ' CHANGELOG.md)"
+          if [ -n "${unreleased_content}" ]; then
+            echo "CHANGELOG.md [Unreleased] must be empty before preparing a release."
+            echo "${unreleased_content}"
+            exit 1
+          fi
+
       - name: Create release branch
         env:
           VERSION: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,7 @@ on:
         type: string
 
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
-  packages: write
+  contents: read
 
 jobs:
   validate:
@@ -100,6 +97,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     needs: validate
+    permissions:
+      actions: read
+      attestations: write
+      contents: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -175,6 +177,15 @@ jobs:
               "$artifact"
           done
 
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610
+        with:
+          path: .
+          format: spdx-json
+          output-file: dbt-nova-${{ matrix.asset }}.sbom.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
       - name: Publish build provenance
         if: ${{ !github.event.repository.private }}
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be
@@ -182,6 +193,7 @@ jobs:
           subject-path: |
             dbt-nova-${{ matrix.asset }}.tar.gz
             dbt-nova-${{ matrix.asset }}.sha256
+            dbt-nova-${{ matrix.asset }}.sbom.spdx.json
 
       - name: Publish release assets
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
@@ -195,6 +207,7 @@ jobs:
             dbt-nova-${{ matrix.asset }}.tar.gz.crt
             dbt-nova-${{ matrix.asset }}.sha256.sig
             dbt-nova-${{ matrix.asset }}.sha256.crt
+            dbt-nova-${{ matrix.asset }}.sbom.spdx.json
 
   container:
     name: Publish OCI image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.4] - 2026-04-25
+## [0.0.4] - 2026-04-26
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reusable workflows now derive installer defaults from the supported
   `github.workflow_ref` context only, keeping asset build and metadata audit
   workflow validation compatible with `actionlint`.
+- Release builds now attach SPDX JSON SBOMs, use narrower job-level permissions,
+  and block release preparation if the `[Unreleased]` changelog section still
+  contains entries.
+- Crate metadata and the security policy now include fuller publication and
+  coordinated-disclosure details.
 - CI now lints and tests `--all-features`, and adds an explicit Rust 1.93 MSRV check to
   match the declared minimum supported toolchain.
 - Monthly fuzz maintenance now uses a shared Rust cache and a larger timeout budget so nightly fuzz targets spend time fuzzing instead of recompiling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release preparation and tagged releases now validate `Cargo.toml` and `CHANGELOG.md`
   against the requested version/tag so published binaries, OCI images, and release notes
   stay aligned.
+- Reusable workflows now derive installer defaults from the supported
+  `github.workflow_ref` context only, keeping asset build and metadata audit
+  workflow validation compatible with `actionlint`.
 - CI now lints and tests `--all-features`, and adds an explicit Rust 1.93 MSRV check to
   match the declared minimum supported toolchain.
 - Monthly fuzz maintenance now uses a shared Rust cache and a larger timeout budget so nightly fuzz targets spend time fuzzing instead of recompiling.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -435,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -3864,9 +3864,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,11 @@ version = "0.0.4"
 rust-version = "1.93"
 edition = "2024"
 description = "High-performance MCP server for searching and analyzing dbt manifest files"
+readme = "README.md"
 license = "MIT"
 repository = "https://github.com/joe-broadhead/dbt-nova"
+homepage = "https://github.com/joe-broadhead/dbt-nova"
+documentation = "https://joe-broadhead.github.io/dbt-nova/"
 keywords = ["dbt", "mcp", "search", "metadata", "lineage"]
 categories = ["command-line-utilities", "development-tools"]
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,11 @@
 
 Security fixes are provided for the latest released version of `dbt-nova`.
 
+| Version | Supported |
+| ------- | --------- |
+| Latest released version | Yes |
+| Older versions | No |
+
 ## Reporting a Vulnerability
 
 Please report suspected vulnerabilities privately instead of opening a public
@@ -14,8 +19,21 @@ issue. Email `joseph.broadhead.dev@gmail.com` with:
 - reproduction steps or proof of concept
 - expected impact
 
-You should receive an acknowledgement within 7 days. Confirmed issues will be
-handled with coordinated disclosure, a fix, and release notes when appropriate.
+You should receive an acknowledgement within 7 days. If GitHub private
+vulnerability reporting is enabled for this repository, you may use that channel
+instead of email.
+
+Confirmed issues are handled with coordinated disclosure, a fix, and release
+notes when appropriate.
+
+## Severity And Response Targets
+
+| Severity | Example impact | Target response |
+| -------- | -------------- | --------------- |
+| Critical | credential exposure, unauthenticated remote code execution, or auth bypass in hosted mode | acknowledge within 7 days and prioritize an urgent patch |
+| High | SQL execution safety bypass, artifact integrity bypass, or sensitive data disclosure | acknowledge within 7 days and target the next security patch |
+| Medium | denial of service, incorrect security defaults, or limited-scope information leak | triage for the next planned release |
+| Low | hardening, documentation, or defense-in-depth improvement | address on the normal maintenance cadence |
 
 ## Scope
 


### PR DESCRIPTION
## Summary
- remove unsupported github.job_workflow_ref usage from reusable workflows
- rely on github.workflow_ref for installer repository/ref inference
- attach SPDX JSON SBOMs during release builds
- narrow release workflow permissions to job-level writes
- make release preparation fail if [Unreleased] still contains entries
- add Cargo publish metadata and strengthen SECURITY.md
- update vulnerable transitives: aws-lc-rs/aws-lc-sys and quinn-proto
- document the release-readiness fixes in the v0.0.4 changelog

## Validation
- actionlint .github/workflows/ci.yml .github/workflows/docs.yml .github/workflows/monthly.yml .github/workflows/release-prepare.yml .github/workflows/release-tag.yml .github/workflows/release.yml .github/workflows/nova-build-assets.yml .github/workflows/nova-metadata-audit.yml
- cargo fmt --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo check --locked --no-default-features
- cargo test --locked --all-features
- uv run mkdocs build --strict
- bash scripts/check_config_reference.sh
- bash scripts/check_dependency_watchlist.sh
- cargo deny check
- CARGO_HOME=/tmp/dbt-nova-cargo-audit cargo audit