### PR TITLE
fix: align docs deploy with Pages protection

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,8 @@ name: Deploy Documentation
 
 on:
   push:
-    tags:
-      - "v*"
+    branches:
+      - master
   workflow_dispatch:
 
 permissions:
@@ -50,6 +50,7 @@ jobs:
           path: site
 
   deploy:
+    if: github.ref == 'refs/heads/master'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,11 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch master and tag
+        env:
+          RELEASE_TAG: ${{ steps.resolve_tag.outputs.release_tag }}
         run: |
           git fetch --no-tags origin master
-          git fetch --tags origin
+          git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
 
       - name: Ensure tag is on master
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Documentation deployment now runs from `master` instead of release tags, matching
+  GitHub Pages environment protection rules.
+- Release validation now fetches only the requested release tag, preventing local
+  tag-clobber failures on tag-triggered release runs.
+
 ## [0.0.4] - 2026-04-26
 
 ### Added

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -131,7 +131,7 @@ Operational defaults:
 ### Docs Deploy
 
 - **File:** `.github/workflows/docs.yml`
-- **Trigger:** `v*` tag push
+- **Trigger:** `master` push or manual dispatch
 - **Action:** builds MkDocs and publishes to GitHub Pages
 
 ## Required Permissions

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -10,7 +10,8 @@ Releases use a `master`-only flow:
 
 Hotfixes follow the same pattern from `master` via `hotfix/<version>`.
 
-Docs are deployed from release tags (`v*`).
+Docs are deployed from `master` pushes so GitHub Pages environment protection
+rules can require the protected default branch.
 
 The release workflow enforces this policy:
 
@@ -34,6 +35,7 @@ After merge to `master`:
 
 - [ ] Tagging happens automatically when the release PR is merged
 - [ ] Verify release assets on GitHub
+- [ ] Verify docs deploy from the `master` push
 
 ## CI & Automation
 
@@ -65,7 +67,7 @@ This repo uses four GitHub Actions workflows for releases and documentation:
      - builds, smokes, and publishes a `linux/amd64` OCI image to GHCR
 
 4. **Docs Deploy** (`.github/workflows/docs.yml`)
-   - Trigger: `v*` tag push
+   - Trigger: `master` push or manual dispatch
    - Actions: builds MkDocs and publishes to GitHub Pages
 
 Release jobs now generate and publish checksum and cosign artifacts for every released platform,


### PR DESCRIPTION
## Summary
- deploy docs from master pushes instead of release tags to satisfy GitHub Pages environment protection
- fetch only the requested release tag during release validation to avoid tag-clobber failures on tag-triggered runs
- update release/CI docs and changelog

## Validation
- actionlint .github/workflows/docs.yml .github/workflows/release.yml
- uv run mkdocs build --strict
- git diff --check