### PR TITLE
Add Nova eval tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   both `expected_column` and `expected_parent_unique_id`.
 - The default OpenCode agent-eval provider preset no longer passes a redundant
   `--dir` flag; dbt-nova sets the provider process working directory directly.
+- Agent eval `final_answer` assertions now score extracted assistant final text
+  from provider JSON event streams instead of matching against full stdout.
 - The Claude provider preset now passes `--verbose` with `--output-format
   stream-json`, matching current Claude Code CLI requirements.
 - Eval artifact path generation now rejects colliding sanitized case IDs and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Agent evals now score Codex/Claude/OpenCode MCP tool calls from provider JSON
-  event streams when a local dbt-nova trace file is empty, which supports remote
-  hosted MCP endpoints that cannot inherit local trace environment variables.
+  event streams when a local dbt-nova trace file is empty, including MCP servers
+  configured with aliases such as `dbt-nova` instead of `nova`.
 - The Claude provider preset now passes `--verbose` with `--output-format
   stream-json`, matching current Claude Code CLI requirements.
 - Eval artifact path generation now rejects colliding sanitized case IDs and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   eval artifact path collisions case-insensitively.
 - Eval suite validation now rejects `search_columns_rank` assertions that omit
   both `expected_column` and `expected_parent_unique_id`.
+- The default OpenCode agent-eval provider preset no longer passes a redundant
+  `--dir` flag; dbt-nova sets the provider process working directory directly.
 - The Claude provider preset now passes `--verbose` with `--output-format
   stream-json`, matching current Claude Code CLI requirements.
 - Eval artifact path generation now rejects colliding sanitized case IDs and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Agent evals now score Codex/Claude/OpenCode MCP tool calls from provider JSON
   event streams when a local dbt-nova trace file is empty, including MCP servers
   configured with aliases such as `dbt-nova` instead of `nova`, and Claude
-  `tool_result` payloads now populate `selected_entities` evidence.
+  `tool_result` payloads now populate `selected_entities` evidence. Provider
+  fallback parsing now filters MCP events by Nova server aliases and validates
+  eval artifact path collisions case-insensitively.
 - The Claude provider preset now passes `--verbose` with `--output-format
   stream-json`, matching current Claude Code CLI requirements.
 - Eval artifact path generation now rejects colliding sanitized case IDs and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tool_result` payloads now populate `selected_entities` evidence. Provider
   fallback parsing now filters MCP events by Nova server aliases and validates
   eval artifact path collisions case-insensitively.
+- Eval suite validation now rejects `search_columns_rank` assertions that omit
+  both `expected_column` and `expected_parent_unique_id`.
 - The Claude provider preset now passes `--verbose` with `--output-format
   stream-json`, matching current Claude Code CLI requirements.
 - Eval artifact path generation now rejects colliding sanitized case IDs and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `dbt-nova eval` commands for manifest bridge evals and provider-backed
+  agent evals, including sanitized CLI/MCP tool-call tracing, YAML/JSON suite
+  definitions, score gates, and JSON/TSV/Markdown report artifacts.
+
 ### Fixed
 
+- Agent evals now score Codex/Claude/OpenCode MCP tool calls from provider JSON
+  event streams when a local dbt-nova trace file is empty, which supports remote
+  hosted MCP endpoints that cannot inherit local trace environment variables.
+- The Claude provider preset now passes `--verbose` with `--output-format
+  stream-json`, matching current Claude Code CLI requirements.
+- Eval artifact path generation now rejects colliding sanitized case IDs and
+  blocks `.`/`..` path segments; custom provider commands also reject empty
+  command values.
 - Documentation deployment now runs from `master` instead of release tags, matching
   GitHub Pages environment protection rules.
 - Release validation now fetches only the requested release tag, preventing local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Agent evals now score Codex/Claude/OpenCode MCP tool calls from provider JSON
   event streams when a local dbt-nova trace file is empty, including MCP servers
-  configured with aliases such as `dbt-nova` instead of `nova`.
+  configured with aliases such as `dbt-nova` instead of `nova`, and Claude
+  `tool_result` payloads now populate `selected_entities` evidence.
 - The Claude provider preset now passes `--verbose` with `--output-format
   stream-json`, matching current Claude Code CLI requirements.
 - Eval artifact path generation now rejects colliding sanitized case IDs and

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -40,7 +40,7 @@ cases:
         id_or_name: model.pkg.orders
         fields:
           - data.unique_id
-          - data.name
+          - data.entity.name
 ```
 
 ## Run Bridge Evals

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -1,0 +1,177 @@
+# Nova Evals
+
+Nova evals let teams test whether their manifest metadata works well for agents.
+They are intentionally split into two layers:
+
+- **Bridge evals** call Nova tools directly and verify deterministic search,
+  context, lineage, recipe, and metadata-score behavior.
+- **Agent evals** run an external agent CLI and score the tools the agent used,
+  using a sanitized tool-call trace emitted by dbt-nova.
+
+Use bridge evals to prove the metadata bridge is healthy. Use agent evals to
+prove analyst or engineering agents actually discover and apply the right Nova
+tools for realistic tasks.
+
+## Create a Suite
+
+Generate a starter suite:
+
+```bash
+dbt-nova eval init --persona analyst --out evals/analyst-smoke.yml
+```
+
+The suite format is YAML or JSON. A minimal bridge suite looks like this:
+
+```yaml
+version: 1
+name: analyst-smoke
+defaults:
+  persona: analyst
+  top_k: 5
+cases:
+  - id: canonical_orders_search
+    question: Find the canonical orders model.
+    assertions:
+      - type: search_rank
+        query: orders
+        expected_unique_id: model.pkg.orders
+        max_rank: 5
+      - type: context_has
+        id_or_name: model.pkg.orders
+        fields:
+          - data.unique_id
+          - data.name
+```
+
+## Run Bridge Evals
+
+```bash
+dbt-nova eval run \
+  --suite evals/analyst-smoke.yml \
+  --manifest-path /path/to/target/manifest.json \
+  --fail-under 1.0 \
+  --json
+```
+
+Outputs are written to `.nova/eval-runs/<timestamp>-<suite>-bridge/` by default:
+
+- `results.json` for machine-readable CI output.
+- `results.tsv` for spreadsheet review.
+- `report.md` for human review.
+- `suite.yml` as the exact suite copy used for the run.
+
+Bridge assertions currently support:
+
+- `search_rank`
+- `search_indicator_rank`
+- `search_columns_rank`
+- `context_has`
+- `metadata_score_min`
+- `recipe_rank`
+- `recipe_has_queries`
+- `lineage_contains`
+- `tool_success`
+
+## Run Agent Evals
+
+Agent evals execute a provider CLI and score observed Nova tool calls. The
+provider must already be configured to use dbt-nova as an MCP server or local
+CLI-backed tool source. dbt-nova first reads sanitized JSONL rows written to
+`DBT_NOVA_TRACE_TOOL_CALLS_PATH`; if that trace is empty, it falls back to
+provider JSON event streams for MCP tool calls from supported presets such as
+Codex, Claude, and OpenCode.
+
+```yaml
+version: 1
+name: analyst-agent-smoke
+agent_cases:
+  - id: metric_lookup_flow
+    task: Which canonical model and indicator should be used to analyze gross merchandise value?
+    expected:
+      must_call:
+        - search_indicator
+        - get_context
+      must_not_call:
+        - execute_sql
+      ordered:
+        - before: get_context
+          must_have_called:
+            - search_indicator
+      selected_entities:
+        - model.pkg.orders
+      final_answer:
+        must_contain:
+          - gross merchandise value
+```
+
+Run against the default `opencode` adapter:
+
+```bash
+dbt-nova eval agent run \
+  --suite evals/analyst-agent.yml \
+  --provider opencode \
+  --manifest-path /path/to/target/manifest.json \
+  --timeout-secs 600 \
+  --fail-under 0.9
+```
+
+Supported provider presets are `opencode`, `codex`, `claude`, and `goose`.
+Presets use each CLI's normal project/user configuration; dbt-nova injects
+`DBT_MANIFEST_PATH`, `DBT_NOVA_STORAGE_INSTANCE_ID`, and
+`DBT_NOVA_TRACE_TOOL_CALLS_PATH` into the provider process so local MCP/CLI
+tool servers inherit the eval manifest and trace path. Remote hosted MCP
+endpoints cannot inherit local trace environment variables, so use a provider
+that emits MCP calls in its JSON output or keep the Nova server local when
+asserting tool-use traces.
+
+For another provider or a custom local wrapper, pass an explicit command:
+
+```bash
+dbt-nova eval agent run \
+  --suite evals/analyst-agent.yml \
+  --provider custom \
+  --provider-command ./scripts/run-agent-eval.sh \
+  --provider-args-json '["--prompt","{prompt}","--workdir","{workdir}","--trace","{trace_path}"]' \
+  --manifest-path /path/to/target/manifest.json
+```
+
+Available placeholders in `--provider-args-json`:
+
+- `{prompt}`
+- `{workdir}`
+- `{trace_path}`
+- `{manifest_path}`
+
+## Tool Trace
+
+When `DBT_NOVA_TRACE_TOOL_CALLS_PATH` is set, dbt-nova appends sanitized JSONL
+rows for CLI, MCP, and eval tool calls. Rows include:
+
+- `transport`
+- `tool`
+- `success`
+- `duration_ms`
+- safe parameter summaries such as `query`, `persona`, `id_or_name`, and
+  `resource_types`
+- `selected_unique_ids` extracted from the response
+
+Trace rows deliberately do not record SQL recipe parameter maps or credential
+values. Keep eval artifacts out of public bug reports unless you have reviewed
+them for project-specific identifiers.
+
+## CI Pattern
+
+Use bridge evals as a fast metadata quality gate after producing a manifest:
+
+```bash
+dbt-nova eval run \
+  --suite evals/analyst-smoke.yml \
+  --manifest-path target/manifest.json \
+  --output-dir out/nova-evals \
+  --fail-under 0.95 \
+  --json
+```
+
+Run agent evals on a schedule, before major metadata changes, or when updating
+agent skills. They are intentionally slower and depend on the configured agent
+provider.

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -79,7 +79,10 @@ provider must already be configured to use dbt-nova as an MCP server or local
 CLI-backed tool source. dbt-nova first reads sanitized JSONL rows written to
 `DBT_NOVA_TRACE_TOOL_CALLS_PATH`; if that trace is empty, it falls back to
 provider JSON event streams for MCP tool calls from supported presets such as
-Codex, Claude, and OpenCode.
+Codex, Claude, and OpenCode. Fallback parsing only accepts MCP server aliases
+that look like Nova (`nova`, `dbt-nova`, `dbt_nova`, `dbtnova`, or
+`dbt-nova-mcp`). If your client uses a different alias, set
+`DBT_NOVA_EVAL_MCP_SERVER_ALIASES` to a comma-separated list of accepted aliases.
 
 ```yaml
 version: 1

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -127,6 +127,10 @@ endpoints cannot inherit local trace environment variables, so use a provider
 that emits MCP calls in its JSON output or keep the Nova server local when
 asserting tool-use traces.
 
+`final_answer` assertions are matched against extracted assistant final text
+from provider JSON event streams. For custom providers that do not emit JSON
+events, dbt-nova falls back to the provider stdout.
+
 For another provider or a custom local wrapper, pass an explicit command:
 
 ```bash

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -4,7 +4,7 @@ Use `dbt-nova` in two modes:
 
 - No subcommand: start MCP server (backward compatible behavior)
 - Subcommand: run one-shot CLI commands and exit
-- CLI surface: `12` CLI-only leaf commands, plus `tool call` access to all `33` MCP tools
+- CLI surface: `15` CLI-only leaf commands, plus `tool call` access to all `33` MCP tools
 
 ## Command Tree
 
@@ -22,6 +22,9 @@ dbt-nova
 ├── storage inspect [--storage-instance-id] [--json]
 ├── storage prune [--max-keep] [--max-bytes] [--storage-instance-id] [--json]
 ├── storage cleanup [--storage-instance-id] [--json]
+├── eval init --out <PATH> [--persona] [--force]
+├── eval run --suite <PATH> [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
+├── eval agent run --suite <PATH> [--provider] [--provider-command] [--provider-args-json] [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--timeout-secs] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
 └── health check [--manifest-path|--manifest-uri] [--json]
 ```
 
@@ -173,6 +176,33 @@ dbt-nova audit nova-meta \
   --resource-name fct_orders \
   --column order_date
 ```
+
+### Run Nova bridge evals
+
+```bash
+dbt-nova eval init --persona analyst --out evals/analyst-smoke.yml
+
+dbt-nova eval run \
+  --suite evals/analyst-smoke.yml \
+  --manifest-path /path/to/target/manifest.json \
+  --fail-under 1.0 \
+  --json
+```
+
+### Run provider-backed agent evals
+
+```bash
+dbt-nova eval agent run \
+  --suite evals/analyst-agent.yml \
+  --provider opencode \
+  --manifest-path /path/to/target/manifest.json \
+  --timeout-secs 600
+```
+
+Agent evals score sanitized Nova tool-call traces, falling back to supported
+provider JSON event streams when a remote MCP endpoint cannot inherit local
+trace environment variables. The selected provider must already be configured to
+use dbt-nova tools.
 
 ### Health diagnostics
 

--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -12,6 +12,37 @@ cargo test -- --nocapture
 - `src/tests/` – in‑crate unit tests
 - `tests/` – integration/property tests and fixtures
 
+## Nova Metadata and Agent Evals
+
+Use `dbt-nova eval run` to test that a manifest exposes the right search,
+indicator, context, lineage, recipe, and metadata-score evidence to agents:
+
+```bash
+dbt-nova eval run \
+  --suite evals/analyst-smoke.yml \
+  --manifest-path target/manifest.json \
+  --output-dir out/nova-evals \
+  --fail-under 0.95 \
+  --json
+```
+
+Use `dbt-nova eval agent run` for slower provider-backed smoke tests that verify
+how agents use Nova tools in practice:
+
+```bash
+dbt-nova eval agent run \
+  --suite evals/analyst-agent.yml \
+  --provider opencode \
+  --manifest-path target/manifest.json \
+  --timeout-secs 600
+```
+
+The agent provider must already be configured with dbt-nova MCP/CLI tools. Nova
+scores required tool calls, forbidden tool calls, order constraints, selected
+entities, and final-answer text checks from sanitized local trace rows. When a
+remote hosted MCP endpoint cannot inherit `DBT_NOVA_TRACE_TOOL_CALLS_PATH`,
+supported provider presets can also score MCP calls from JSON event streams.
+
 ## Test Storage Cleanup
 
 Tests use temporary storage under `target/dbt-nova-tests` and clean up automatically.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,7 @@ nav:
     - Error Codes: api/error-codes.md
     - Metrics Reference: api/metrics-reference.md
   - Features:
+    - Nova Evals: features/evals.md
     - Analysis Recipes: features/recipes.md
     - Column Lineage: features/column-lineage.md
     - Metadata Audit: features/metadata-audit.md

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -16,6 +16,7 @@ pub enum Command {
     Config(ConfigArgs),
     Storage(StorageArgs),
     Health(HealthArgs),
+    Eval(EvalArgs),
 }
 
 #[derive(Debug, Args)]
@@ -330,6 +331,92 @@ pub struct HealthCheckArgs {
     pub json: bool,
 }
 
+#[derive(Debug, Args)]
+pub struct EvalArgs {
+    #[command(subcommand)]
+    pub command: EvalCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum EvalCommand {
+    Init(EvalInitArgs),
+    Run(EvalRunArgs),
+    Agent(EvalAgentArgs),
+}
+
+#[derive(Debug, Clone, Args, Default)]
+pub struct EvalInitArgs {
+    #[arg(long, value_name = "PERSONA", default_value = "analyst")]
+    pub persona: String,
+    #[arg(long, value_name = "PATH")]
+    pub out: String,
+    #[arg(long, default_value_t = false)]
+    pub force: bool,
+}
+
+#[derive(Debug, Clone, Args, Default)]
+pub struct EvalRunArgs {
+    #[arg(long, value_name = "PATH")]
+    pub suite: String,
+    #[arg(long, value_name = "PATH", conflicts_with = "manifest_uri")]
+    pub manifest_path: Option<String>,
+    #[arg(long, value_name = "URI", conflicts_with = "manifest_path")]
+    pub manifest_uri: Option<String>,
+    #[arg(long, value_name = "INSTANCE_ID")]
+    pub storage_instance_id: Option<String>,
+    #[arg(long, value_name = "DIR")]
+    pub output_dir: Option<String>,
+    #[arg(long, value_name = "FLOAT")]
+    pub fail_under: Option<f64>,
+    #[arg(long, default_value_t = false)]
+    pub cleanup_storage_on_start: bool,
+    #[arg(long, default_value_t = false)]
+    pub read_only: bool,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct EvalAgentArgs {
+    #[command(subcommand)]
+    pub command: EvalAgentCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum EvalAgentCommand {
+    Run(EvalAgentRunArgs),
+}
+
+#[derive(Debug, Clone, Args, Default)]
+pub struct EvalAgentRunArgs {
+    #[arg(long, value_name = "PATH")]
+    pub suite: String,
+    #[arg(long, value_name = "PROVIDER", default_value = "opencode")]
+    pub provider: String,
+    #[arg(long, value_name = "COMMAND")]
+    pub provider_command: Option<String>,
+    #[arg(long, value_name = "JSON_ARRAY")]
+    pub provider_args_json: Option<String>,
+    #[arg(long, value_name = "PATH", conflicts_with = "manifest_uri")]
+    pub manifest_path: Option<String>,
+    #[arg(long, value_name = "URI", conflicts_with = "manifest_path")]
+    pub manifest_uri: Option<String>,
+    #[arg(long, value_name = "INSTANCE_ID")]
+    pub storage_instance_id: Option<String>,
+    #[arg(long, value_name = "DIR")]
+    pub output_dir: Option<String>,
+    #[arg(long, value_name = "SECS", default_value_t = 600)]
+    pub timeout_secs: u64,
+    #[arg(long, value_name = "FLOAT")]
+    pub fail_under: Option<f64>,
+    #[arg(long, default_value_t = false)]
+    pub cleanup_storage_on_start: bool,
+    #[arg(long, default_value_t = false)]
+    pub read_only: bool,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use clap::Parser;
@@ -379,7 +466,7 @@ mod tests {
 
     #[test]
     fn cli_parses_all_top_level_groups() {
-        let groups: [&[&str]; 7] = [
+        let groups: [&[&str]; 8] = [
             &["dbt-nova", "manifest", "load"],
             &["dbt-nova", "tool", "call", "search"],
             &["dbt-nova", "audit", "metadata-score"],
@@ -387,6 +474,7 @@ mod tests {
             &["dbt-nova", "config", "show"],
             &["dbt-nova", "storage", "inspect"],
             &["dbt-nova", "health", "check"],
+            &["dbt-nova", "eval", "run", "--suite", "suite.yml"],
         ];
         for args in groups {
             let cli = Cli::parse_from(args);

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -620,10 +620,12 @@ async fn run_agent_case(
     for error in &trace.errors {
         assertions.push(AssertionResult::error("tool_trace_parse", error.clone()));
     }
+    let final_answer_text =
+        provider::read_provider_final_answer(&stdout).unwrap_or_else(|| stdout.clone());
     assertions.extend(score_agent_expectations(
         &case.expected,
         &trace.rows,
-        &stdout,
+        &final_answer_text,
     ));
     EvalCaseReport::new(
         case.id.clone(),
@@ -640,7 +642,7 @@ async fn run_agent_case(
 fn score_agent_expectations(
     expected: &AgentExpected,
     trace: &[JsonValue],
-    stdout: &str,
+    final_answer_text: &str,
 ) -> Vec<AssertionResult> {
     let mut assertions = Vec::new();
     for tool in &expected.must_call {
@@ -692,7 +694,7 @@ fn score_agent_expectations(
         }
     }
     if let Some(final_answer) = expected.final_answer.as_ref() {
-        assertions.extend(score_final_answer(final_answer, stdout));
+        assertions.extend(score_final_answer(final_answer, final_answer_text));
     }
     assertions
 }
@@ -733,8 +735,11 @@ fn order_assertion(trace: &[JsonValue], order: &AgentOrder) -> AssertionResult {
     }
 }
 
-fn score_final_answer(expected: &FinalAnswerExpected, stdout: &str) -> Vec<AssertionResult> {
-    let haystack = stdout.to_lowercase();
+fn score_final_answer(
+    expected: &FinalAnswerExpected,
+    final_answer_text: &str,
+) -> Vec<AssertionResult> {
+    let haystack = final_answer_text.to_lowercase();
     let mut assertions = Vec::new();
     for needle in &expected.must_contain {
         if haystack.contains(&needle.to_lowercase()) {
@@ -747,7 +752,7 @@ fn score_final_answer(expected: &FinalAnswerExpected, stdout: &str) -> Vec<Asser
             assertions.push(AssertionResult::fail(
                 format!("final_answer_contains:{needle}"),
                 "final answer did not contain expected text",
-                json!({"stdout": truncate(stdout, 4000)}),
+                json!({"final_answer": truncate(final_answer_text, 4000)}),
             ));
         }
     }
@@ -756,7 +761,7 @@ fn score_final_answer(expected: &FinalAnswerExpected, stdout: &str) -> Vec<Asser
             assertions.push(AssertionResult::fail(
                 format!("final_answer_excludes:{needle}"),
                 "final answer contained forbidden text",
-                json!({"stdout": truncate(stdout, 4000)}),
+                json!({"final_answer": truncate(final_answer_text, 4000)}),
             ));
         } else {
             assertions.push(AssertionResult::pass(

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -1443,9 +1443,10 @@ fn validate_case_ids<'a>(
             )));
         }
         let artifact_segment = safe_path_segment(trimmed);
-        if !seen_artifact_segments.insert(artifact_segment.clone()) {
+        let artifact_segment_key = artifact_segment.to_ascii_lowercase();
+        if !seen_artifact_segments.insert(artifact_segment_key) {
             return Err(DbtNovaError::InvalidParams(format!(
-                "eval case ids in {section} must map to unique artifact paths; duplicate segment '{artifact_segment}'"
+                "eval case ids in {section} must map to unique artifact paths case-insensitively; duplicate segment '{artifact_segment}'"
             )));
         }
     }

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -1,0 +1,1578 @@
+#![allow(clippy::too_many_lines)]
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value as JsonValue, json};
+
+use crate::cli::args::{EvalAgentRunArgs, EvalInitArgs, EvalRunArgs, ManifestLoadArgs};
+use crate::cli::manifest::{build_manifest_load_config, execute_manifest_load};
+use crate::cli::output::CliEnvelope;
+use crate::cli::{DispatchError, DispatchResult};
+use crate::error::DbtNovaError;
+use crate::manifest::ManifestSearch;
+
+const DEFAULT_TOP_K: usize = 5;
+const DEFAULT_FAIL_UNDER: f64 = 1.0;
+const MAX_SAFE_PATH_SEGMENT_CHARS: usize = 120;
+
+mod provider;
+
+#[derive(Debug, Deserialize)]
+struct EvalSuite {
+    version: u32,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    defaults: EvalDefaults,
+    #[serde(default)]
+    cases: Vec<EvalCase>,
+    #[serde(default)]
+    agent_cases: Vec<AgentCase>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct EvalDefaults {
+    #[serde(default)]
+    persona: Option<String>,
+    #[serde(default = "default_top_k")]
+    top_k: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct EvalCase {
+    id: String,
+    #[serde(default)]
+    question: Option<String>,
+    #[serde(default)]
+    persona: Option<String>,
+    assertions: Vec<EvalAssertion>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum EvalAssertion {
+    SearchRank {
+        query: String,
+        expected_unique_id: String,
+        #[serde(default)]
+        max_rank: Option<usize>,
+        #[serde(default)]
+        resource_types: Vec<String>,
+        #[serde(default)]
+        persona: Option<String>,
+    },
+    SearchIndicatorRank {
+        query: String,
+        expected: String,
+        #[serde(default)]
+        max_rank: Option<usize>,
+        #[serde(default)]
+        resource_types: Vec<String>,
+        #[serde(default)]
+        indicator_types: Vec<String>,
+        #[serde(default)]
+        persona: Option<String>,
+    },
+    SearchColumnsRank {
+        query: String,
+        #[serde(default)]
+        expected_column: Option<String>,
+        #[serde(default)]
+        expected_parent_unique_id: Option<String>,
+        #[serde(default)]
+        max_rank: Option<usize>,
+    },
+    ContextHas {
+        id_or_name: String,
+        fields: Vec<String>,
+    },
+    MetadataScoreMin {
+        #[serde(default)]
+        id_or_name: Option<String>,
+        threshold: f64,
+        #[serde(default)]
+        persona: Option<String>,
+    },
+    RecipeRank {
+        query: String,
+        expected_recipe_id: String,
+        #[serde(default)]
+        max_rank: Option<usize>,
+    },
+    RecipeHasQueries {
+        recipe_id: String,
+        #[serde(default)]
+        min_queries: Option<usize>,
+    },
+    LineageContains {
+        id_or_name: String,
+        direction: String,
+        expected_unique_id: String,
+        #[serde(default)]
+        depth: Option<usize>,
+    },
+    ToolSuccess {
+        tool: String,
+        #[serde(default = "empty_object")]
+        params: JsonValue,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+struct AgentCase {
+    id: String,
+    task: String,
+    #[serde(default)]
+    expected: AgentExpected,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct AgentExpected {
+    #[serde(default)]
+    must_call: Vec<String>,
+    #[serde(default)]
+    must_not_call: Vec<String>,
+    #[serde(default)]
+    ordered: Vec<AgentOrder>,
+    #[serde(default)]
+    selected_entities: Vec<String>,
+    #[serde(default)]
+    final_answer: Option<FinalAnswerExpected>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AgentOrder {
+    before: String,
+    #[serde(default)]
+    must_have_called: Vec<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct FinalAnswerExpected {
+    #[serde(default)]
+    must_contain: Vec<String>,
+    #[serde(default)]
+    must_not_contain: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct EvalReport {
+    suite_name: String,
+    version: u32,
+    mode: &'static str,
+    output_dir: String,
+    assertion_count: usize,
+    pass_count: usize,
+    fail_count: usize,
+    error_count: usize,
+    pass_rate: f64,
+    fail_under: f64,
+    gate_status: &'static str,
+    cases: Vec<EvalCaseReport>,
+}
+
+#[derive(Debug, Serialize)]
+struct EvalCaseReport {
+    id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    question: Option<String>,
+    pass_count: usize,
+    fail_count: usize,
+    error_count: usize,
+    assertions: Vec<AssertionResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    artifacts: Option<AgentArtifacts>,
+}
+
+#[derive(Debug, Serialize)]
+struct AssertionResult {
+    name: String,
+    status: &'static str,
+    message: String,
+    #[serde(skip_serializing_if = "JsonValue::is_null")]
+    evidence: JsonValue,
+}
+
+#[derive(Debug, Serialize)]
+struct AgentArtifacts {
+    stdout: String,
+    stderr: String,
+    tool_trace: String,
+}
+
+/// Writes a starter eval suite.
+///
+/// # Errors
+/// Returns an error when the target exists without `--force` or cannot be written.
+pub fn run_init_command(args: &EvalInitArgs) -> DispatchResult {
+    let started = Instant::now();
+    let path = PathBuf::from(&args.out);
+    if path.exists() && !args.force {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "eval suite '{}' already exists; pass --force to overwrite",
+            path.display()
+        ))
+        .into());
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| server_error(error.to_string()))?;
+    }
+
+    fs::write(&path, starter_suite(&args.persona))
+        .map_err(|error| server_error(error.to_string()))?;
+    let payload = json!({
+        "path": path.display().to_string(),
+        "persona": args.persona,
+    });
+    let envelope = CliEnvelope::success("eval init", payload, started.elapsed().as_millis());
+    let out =
+        serde_json::to_string_pretty(&envelope).map_err(|error| server_error(error.to_string()))?;
+    println!("{out}");
+    Ok(())
+}
+
+/// Runs deterministic Nova bridge assertions against a manifest.
+///
+/// # Errors
+/// Returns an error when the suite is invalid, manifest loading fails, assertions error, or the score gate fails.
+pub async fn run_eval_command(args: &EvalRunArgs) -> DispatchResult {
+    let started = Instant::now();
+    let suite = load_suite(&args.suite)?;
+    validate_fail_under(args.fail_under)?;
+    if suite.cases.is_empty() {
+        return Err(
+            DbtNovaError::InvalidParams("eval suite contains no bridge cases".to_string()).into(),
+        );
+    }
+    let output_dir = resolve_output_dir(args.output_dir.as_deref(), &suite, "bridge");
+    fs::create_dir_all(&output_dir).map_err(|error| server_error(error.to_string()))?;
+
+    let config = build_manifest_load_config(&ManifestLoadArgs {
+        manifest_path: args.manifest_path.clone(),
+        manifest_uri: args.manifest_uri.clone(),
+        storage_instance_id: args.storage_instance_id.clone(),
+        cleanup_storage_on_start: args.cleanup_storage_on_start,
+        read_only: args.read_only,
+        json: false,
+    })?;
+    let load_result = execute_manifest_load(config).await?;
+
+    let mut cases = Vec::with_capacity(suite.cases.len());
+    for case in &suite.cases {
+        cases.push(evaluate_bridge_case(case, &suite, &load_result.search).await);
+    }
+    let report = build_report(
+        &suite,
+        "bridge",
+        output_dir.display().to_string(),
+        args.fail_under.unwrap_or(DEFAULT_FAIL_UNDER),
+        cases,
+    );
+    write_report_artifacts(&output_dir, &report, &args.suite)?;
+    finish_report(
+        "eval run",
+        &report,
+        args.json,
+        started.elapsed().as_millis(),
+    )
+}
+
+/// Runs agent-provider evals and scores the tool-use trace.
+///
+/// # Errors
+/// Returns an error when the suite is invalid, a provider command cannot be run, or the score gate fails.
+pub async fn run_agent_eval_command(args: &EvalAgentRunArgs) -> DispatchResult {
+    let started = Instant::now();
+    let suite = load_suite(&args.suite)?;
+    validate_fail_under(args.fail_under)?;
+    if suite.agent_cases.is_empty() {
+        return Err(
+            DbtNovaError::InvalidParams("eval suite contains no agent_cases".to_string()).into(),
+        );
+    }
+    let output_dir = resolve_output_dir(args.output_dir.as_deref(), &suite, "agent");
+    fs::create_dir_all(output_dir.join("tool-calls"))
+        .map_err(|error| server_error(error.to_string()))?;
+
+    let mut cases = Vec::with_capacity(suite.agent_cases.len());
+    for case in &suite.agent_cases {
+        cases.push(run_agent_case(case, args, &output_dir).await);
+    }
+    let report = build_report(
+        &suite,
+        "agent",
+        output_dir.display().to_string(),
+        args.fail_under.unwrap_or(DEFAULT_FAIL_UNDER),
+        cases,
+    );
+    write_report_artifacts(&output_dir, &report, &args.suite)?;
+    finish_report(
+        "eval agent run",
+        &report,
+        args.json,
+        started.elapsed().as_millis(),
+    )
+}
+
+async fn evaluate_bridge_case(
+    case: &EvalCase,
+    suite: &EvalSuite,
+    search: &ManifestSearch,
+) -> EvalCaseReport {
+    let mut assertions = Vec::with_capacity(case.assertions.len());
+    for assertion in &case.assertions {
+        assertions.push(evaluate_bridge_assertion(assertion, case, suite, search).await);
+    }
+    EvalCaseReport::new(case.id.clone(), case.question.clone(), assertions, None)
+}
+
+async fn evaluate_bridge_assertion(
+    assertion: &EvalAssertion,
+    case: &EvalCase,
+    suite: &EvalSuite,
+    search: &ManifestSearch,
+) -> AssertionResult {
+    match assertion {
+        EvalAssertion::SearchRank {
+            query,
+            expected_unique_id,
+            max_rank,
+            resource_types,
+            persona,
+        } => {
+            let limit = effective_limit(*max_rank, suite.defaults.top_k);
+            let params = json!({
+                "query": query,
+                "resource_types": resource_types,
+                "persona": effective_persona(persona.as_ref(), case, suite),
+                "limit": limit,
+            });
+            match call_tool(search, "search", params).await {
+                Ok(response) => rank_assertion(
+                    "search_rank",
+                    &response,
+                    expected_unique_id,
+                    *max_rank,
+                    "unique_id",
+                ),
+                Err(error) => AssertionResult::error("search_rank", error.to_string()),
+            }
+        }
+        EvalAssertion::SearchIndicatorRank {
+            query,
+            expected,
+            max_rank,
+            resource_types,
+            indicator_types,
+            persona,
+        } => {
+            let limit = effective_limit(*max_rank, suite.defaults.top_k);
+            let params = json!({
+                "query": query,
+                "resource_types": resource_types,
+                "indicator_types": indicator_types,
+                "persona": effective_persona(persona.as_ref(), case, suite),
+                "limit": limit,
+            });
+            match call_tool(search, "search_indicator", params).await {
+                Ok(response) => {
+                    contains_rank_assertion("search_indicator_rank", &response, expected, *max_rank)
+                }
+                Err(error) => AssertionResult::error("search_indicator_rank", error.to_string()),
+            }
+        }
+        EvalAssertion::SearchColumnsRank {
+            query,
+            expected_column,
+            expected_parent_unique_id,
+            max_rank,
+        } => {
+            let limit = effective_limit(*max_rank, suite.defaults.top_k);
+            let params = json!({"query": query, "limit": limit});
+            match call_tool(search, "search_columns", params).await {
+                Ok(response) => search_columns_assertion(
+                    &response,
+                    expected_column.as_deref(),
+                    expected_parent_unique_id.as_deref(),
+                    *max_rank,
+                ),
+                Err(error) => AssertionResult::error("search_columns_rank", error.to_string()),
+            }
+        }
+        EvalAssertion::ContextHas { id_or_name, fields } => {
+            let params = json!({"id_or_name": id_or_name});
+            match call_tool(search, "get_context", params).await {
+                Ok(response) => fields_assertion("context_has", &response, fields),
+                Err(error) => AssertionResult::error("context_has", error.to_string()),
+            }
+        }
+        EvalAssertion::MetadataScoreMin {
+            id_or_name,
+            threshold,
+            persona,
+        } => {
+            let params = json!({
+                "id_or_name": id_or_name,
+                "persona": effective_persona(persona.as_ref(), case, suite),
+                "limit": 20,
+            });
+            match call_tool(search, "get_metadata_score", params).await {
+                Ok(response) => metadata_score_assertion(&response, *threshold),
+                Err(error) => AssertionResult::error("metadata_score_min", error.to_string()),
+            }
+        }
+        EvalAssertion::RecipeRank {
+            query,
+            expected_recipe_id,
+            max_rank,
+        } => {
+            let limit = effective_limit(*max_rank, suite.defaults.top_k);
+            let params = json!({"query": query, "include_queries": false, "limit": limit});
+            match call_tool(search, "search_recipes", params).await {
+                Ok(response) => rank_assertion(
+                    "recipe_rank",
+                    &response,
+                    expected_recipe_id,
+                    *max_rank,
+                    "recipe_id",
+                ),
+                Err(error) => AssertionResult::error("recipe_rank", error.to_string()),
+            }
+        }
+        EvalAssertion::RecipeHasQueries {
+            recipe_id,
+            min_queries,
+        } => {
+            let params = json!({"recipe_id": recipe_id, "include_queries": true});
+            match call_tool(search, "get_recipe", params).await {
+                Ok(response) => recipe_queries_assertion(&response, min_queries.unwrap_or(1)),
+                Err(error) => AssertionResult::error("recipe_has_queries", error.to_string()),
+            }
+        }
+        EvalAssertion::LineageContains {
+            id_or_name,
+            direction,
+            expected_unique_id,
+            depth,
+        } => {
+            let params = json!({
+                "id_or_name": id_or_name,
+                "direction": direction,
+                "depth": depth.unwrap_or(2),
+            });
+            match call_tool(search, "get_lineage", params).await {
+                Ok(response) => {
+                    contains_string_assertion("lineage_contains", &response, expected_unique_id)
+                }
+                Err(error) => AssertionResult::error("lineage_contains", error.to_string()),
+            }
+        }
+        EvalAssertion::ToolSuccess { tool, params } => {
+            match call_tool(search, tool, params.clone()).await {
+                Ok(response) => AssertionResult::pass(
+                    format!("tool_success:{tool}"),
+                    "tool returned success",
+                    json!({"count": response.get("count").cloned().unwrap_or(JsonValue::Null)}),
+                ),
+                Err(error) => {
+                    AssertionResult::error(format!("tool_success:{tool}"), error.to_string())
+                }
+            }
+        }
+    }
+}
+
+async fn call_tool(
+    search: &ManifestSearch,
+    tool: &str,
+    params: JsonValue,
+) -> crate::error::Result<JsonValue> {
+    let started = Instant::now();
+    let result = crate::cli::tool::dispatch_tool(search, tool, params.clone()).await;
+    match &result {
+        Ok(response) => crate::utils::tool_trace::record_tool_call(
+            "eval",
+            tool,
+            Some(&params),
+            Some(response),
+            true,
+            elapsed_ms_to_u64(started.elapsed()),
+        ),
+        Err(error) => crate::utils::tool_trace::record_tool_call(
+            "eval",
+            tool,
+            Some(&params),
+            Some(&json!({"error_code": error.error_code(), "message": error.to_string()})),
+            false,
+            elapsed_ms_to_u64(started.elapsed()),
+        ),
+    }
+    result
+}
+
+async fn run_agent_case(
+    case: &AgentCase,
+    args: &EvalAgentRunArgs,
+    output_dir: &Path,
+) -> EvalCaseReport {
+    let case_dir = output_dir.join(safe_path_segment(&case.id));
+    if let Err(error) = fs::create_dir_all(&case_dir) {
+        return EvalCaseReport::new(
+            case.id.clone(),
+            Some(case.task.clone()),
+            vec![AssertionResult::error(
+                "provider_exit_success",
+                format!("failed to create case artifact directory: {error}"),
+            )],
+            None,
+        );
+    }
+    let trace_path = output_dir
+        .join("tool-calls")
+        .join(format!("{}.jsonl", safe_path_segment(&case.id)));
+    if let Err(error) = reset_trace_file(&trace_path) {
+        return EvalCaseReport::new(
+            case.id.clone(),
+            Some(case.task.clone()),
+            vec![AssertionResult::error(
+                "tool_trace_reset",
+                format!("failed to reset tool trace file: {error}"),
+            )],
+            None,
+        );
+    }
+    let prompt = agent_prompt(case);
+    let invocation = match provider::provider_invocation(args, &prompt, &trace_path) {
+        Ok(invocation) => invocation,
+        Err(error) => {
+            return EvalCaseReport::new(
+                case.id.clone(),
+                Some(case.task.clone()),
+                vec![AssertionResult::error(
+                    "provider_exit_success",
+                    error.to_string(),
+                )],
+                None,
+            );
+        }
+    };
+
+    let output = provider::run_provider_command(&invocation, args, &trace_path, &case_dir).await;
+    let (stdout, _stderr, assertions) = match output {
+        Ok(output) => {
+            if let Err(error) = fs::write(case_dir.join("stdout.log"), &output.stdout) {
+                tracing::warn!(error = %error, case_id = %case.id, "failed to write eval stdout");
+            }
+            if let Err(error) = fs::write(case_dir.join("stderr.log"), &output.stderr) {
+                tracing::warn!(error = %error, case_id = %case.id, "failed to write eval stderr");
+            }
+            let mut assertions = Vec::new();
+            if output.status_success {
+                assertions.push(AssertionResult::pass(
+                    "provider_exit_success",
+                    "provider command exited successfully",
+                    json!({"command": invocation.command, "args": invocation.args}),
+                ));
+            } else {
+                assertions.push(AssertionResult::fail(
+                    "provider_exit_success",
+                    "provider command exited with a non-zero status",
+                    json!({
+                        "command": invocation.command,
+                        "args": invocation.args,
+                        "stderr": truncate(&output.stderr, 4000),
+                    }),
+                ));
+            }
+            (output.stdout, output.stderr, assertions)
+        }
+        Err(error) => (
+            String::new(),
+            String::new(),
+            vec![AssertionResult::error(
+                "provider_exit_success",
+                error.to_string(),
+            )],
+        ),
+    };
+
+    let mut assertions = assertions;
+    let mut trace = read_tool_trace(&trace_path);
+    if trace.rows.is_empty() {
+        let provider_trace = provider::read_provider_tool_trace(&stdout);
+        if !provider_trace.rows.is_empty() {
+            trace.rows = provider_trace.rows;
+            trace.errors.extend(provider_trace.errors);
+            trace.missing = false;
+        }
+    }
+    if trace.rows.is_empty() && case.expected.requires_trace() {
+        assertions.push(AssertionResult::error(
+            "tool_trace_missing",
+            "tool trace rows were not observed; verify the provider launches a local dbt-nova process, emits MCP tool events, or writes trace rows",
+        ));
+    }
+    for error in &trace.errors {
+        assertions.push(AssertionResult::error("tool_trace_parse", error.clone()));
+    }
+    assertions.extend(score_agent_expectations(
+        &case.expected,
+        &trace.rows,
+        &stdout,
+    ));
+    EvalCaseReport::new(
+        case.id.clone(),
+        Some(case.task.clone()),
+        assertions,
+        Some(AgentArtifacts {
+            stdout: case_dir.join("stdout.log").display().to_string(),
+            stderr: case_dir.join("stderr.log").display().to_string(),
+            tool_trace: trace_path.display().to_string(),
+        }),
+    )
+}
+
+fn score_agent_expectations(
+    expected: &AgentExpected,
+    trace: &[JsonValue],
+    stdout: &str,
+) -> Vec<AssertionResult> {
+    let mut assertions = Vec::new();
+    for tool in &expected.must_call {
+        if first_tool_index(trace, tool).is_some() {
+            assertions.push(AssertionResult::pass(
+                format!("must_call:{tool}"),
+                "required tool was called",
+                JsonValue::Null,
+            ));
+        } else {
+            assertions.push(AssertionResult::fail(
+                format!("must_call:{tool}"),
+                "required tool was not called",
+                json!({"observed_tools": observed_tools(trace)}),
+            ));
+        }
+    }
+    for tool in &expected.must_not_call {
+        if first_tool_index(trace, tool).is_some() {
+            assertions.push(AssertionResult::fail(
+                format!("must_not_call:{tool}"),
+                "forbidden tool was called",
+                json!({"observed_tools": observed_tools(trace)}),
+            ));
+        } else {
+            assertions.push(AssertionResult::pass(
+                format!("must_not_call:{tool}"),
+                "forbidden tool was not called",
+                JsonValue::Null,
+            ));
+        }
+    }
+    for order in &expected.ordered {
+        assertions.push(order_assertion(trace, order));
+    }
+    for entity in &expected.selected_entities {
+        if trace_selected_entity(trace, entity) {
+            assertions.push(AssertionResult::pass(
+                format!("selected_entity:{entity}"),
+                "expected entity appeared in tool evidence",
+                JsonValue::Null,
+            ));
+        } else {
+            assertions.push(AssertionResult::fail(
+                format!("selected_entity:{entity}"),
+                "expected entity did not appear in tool evidence",
+                json!({"selected_unique_ids": selected_entities(trace)}),
+            ));
+        }
+    }
+    if let Some(final_answer) = expected.final_answer.as_ref() {
+        assertions.extend(score_final_answer(final_answer, stdout));
+    }
+    assertions
+}
+
+fn order_assertion(trace: &[JsonValue], order: &AgentOrder) -> AssertionResult {
+    let before_index = first_tool_index(trace, &order.before);
+    let missing: Vec<&str> = order
+        .must_have_called
+        .iter()
+        .filter_map(|tool| {
+            let index = first_tool_index(trace, tool);
+            if index.is_none()
+                || before_index.is_none_or(|before| index.unwrap_or(usize::MAX) >= before)
+            {
+                Some(tool.as_str())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if before_index.is_some() && missing.is_empty() {
+        AssertionResult::pass(
+            format!("order:{}", order.before),
+            "tool order matched",
+            JsonValue::Null,
+        )
+    } else {
+        AssertionResult::fail(
+            format!("order:{}", order.before),
+            "tool order did not match",
+            json!({
+                "before": order.before,
+                "must_have_called": order.must_have_called,
+                "observed_tools": observed_tools(trace),
+            }),
+        )
+    }
+}
+
+fn score_final_answer(expected: &FinalAnswerExpected, stdout: &str) -> Vec<AssertionResult> {
+    let haystack = stdout.to_lowercase();
+    let mut assertions = Vec::new();
+    for needle in &expected.must_contain {
+        if haystack.contains(&needle.to_lowercase()) {
+            assertions.push(AssertionResult::pass(
+                format!("final_answer_contains:{needle}"),
+                "final answer contained expected text",
+                JsonValue::Null,
+            ));
+        } else {
+            assertions.push(AssertionResult::fail(
+                format!("final_answer_contains:{needle}"),
+                "final answer did not contain expected text",
+                json!({"stdout": truncate(stdout, 4000)}),
+            ));
+        }
+    }
+    for needle in &expected.must_not_contain {
+        if haystack.contains(&needle.to_lowercase()) {
+            assertions.push(AssertionResult::fail(
+                format!("final_answer_excludes:{needle}"),
+                "final answer contained forbidden text",
+                json!({"stdout": truncate(stdout, 4000)}),
+            ));
+        } else {
+            assertions.push(AssertionResult::pass(
+                format!("final_answer_excludes:{needle}"),
+                "final answer excluded forbidden text",
+                JsonValue::Null,
+            ));
+        }
+    }
+    assertions
+}
+
+fn first_tool_index(trace: &[JsonValue], tool: &str) -> Option<usize> {
+    trace
+        .iter()
+        .position(|row| row.get("tool").and_then(JsonValue::as_str) == Some(tool))
+}
+
+fn observed_tools(trace: &[JsonValue]) -> Vec<String> {
+    trace
+        .iter()
+        .filter_map(|row| row.get("tool").and_then(JsonValue::as_str))
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn trace_selected_entity(trace: &[JsonValue], entity: &str) -> bool {
+    trace.iter().any(|row| {
+        row.get("selected_unique_ids")
+            .and_then(JsonValue::as_array)
+            .is_some_and(|ids| ids.iter().any(|id| id.as_str() == Some(entity)))
+    })
+}
+
+fn selected_entities(trace: &[JsonValue]) -> Vec<String> {
+    let mut out = BTreeSet::new();
+    for row in trace {
+        if let Some(ids) = row.get("selected_unique_ids").and_then(JsonValue::as_array) {
+            for id in ids {
+                if let Some(id) = id.as_str() {
+                    out.insert(id.to_string());
+                }
+            }
+        }
+    }
+    out.into_iter().collect()
+}
+
+struct ToolTraceRead {
+    rows: Vec<JsonValue>,
+    errors: Vec<String>,
+    missing: bool,
+}
+
+fn reset_trace_file(path: &Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, "")
+}
+
+fn read_tool_trace(path: &Path) -> ToolTraceRead {
+    let raw = match fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return ToolTraceRead {
+                rows: Vec::new(),
+                errors: Vec::new(),
+                missing: true,
+            };
+        }
+        Err(error) => {
+            return ToolTraceRead {
+                rows: Vec::new(),
+                errors: vec![format!(
+                    "failed to read tool trace '{}': {error}",
+                    path.display()
+                )],
+                missing: false,
+            };
+        }
+    };
+
+    let mut rows = Vec::new();
+    let mut errors = Vec::new();
+    for (index, line) in raw.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<JsonValue>(line) {
+            Ok(row) => rows.push(row),
+            Err(error) => errors.push(format!(
+                "failed to parse tool trace line {} in '{}': {error}",
+                index + 1,
+                path.display()
+            )),
+        }
+    }
+    ToolTraceRead {
+        rows,
+        errors,
+        missing: false,
+    }
+}
+
+fn rank_assertion(
+    name: &str,
+    response: &JsonValue,
+    expected: &str,
+    max_rank: Option<usize>,
+    field: &str,
+) -> AssertionResult {
+    let rows = data_rows(response);
+    if let Some(index) = rows
+        .iter()
+        .position(|row| string_field_equals(row, field, expected))
+    {
+        let rank = index + 1;
+        if max_rank.is_none_or(|max| rank <= max) {
+            AssertionResult::pass(
+                name,
+                format!("expected item ranked {rank}"),
+                json!({"rank": rank, "expected": expected}),
+            )
+        } else {
+            AssertionResult::fail(
+                name,
+                format!(
+                    "expected item ranked {rank}, above max rank {}",
+                    max_rank.unwrap_or(0)
+                ),
+                top_evidence(rows, field),
+            )
+        }
+    } else {
+        AssertionResult::fail(
+            name,
+            "expected item was not returned",
+            json!({"expected": expected, "top": top_evidence(rows, field)}),
+        )
+    }
+}
+
+fn contains_rank_assertion(
+    name: &str,
+    response: &JsonValue,
+    expected: &str,
+    max_rank: Option<usize>,
+) -> AssertionResult {
+    let rows = data_rows(response);
+    if let Some(index) = rows
+        .iter()
+        .position(|row| json_contains_string(row, expected))
+    {
+        let rank = index + 1;
+        if max_rank.is_none_or(|max| rank <= max) {
+            AssertionResult::pass(
+                name,
+                format!("expected value ranked {rank}"),
+                json!({"rank": rank, "expected": expected}),
+            )
+        } else {
+            AssertionResult::fail(
+                name,
+                format!(
+                    "expected value ranked {rank}, above max rank {}",
+                    max_rank.unwrap_or(0)
+                ),
+                top_evidence(rows, "unique_id"),
+            )
+        }
+    } else {
+        AssertionResult::fail(
+            name,
+            "expected value was not returned",
+            json!({"expected": expected, "top": top_evidence(rows, "unique_id")}),
+        )
+    }
+}
+
+fn search_columns_assertion(
+    response: &JsonValue,
+    expected_column: Option<&str>,
+    expected_parent_unique_id: Option<&str>,
+    max_rank: Option<usize>,
+) -> AssertionResult {
+    let rows = data_rows(response);
+    let position = rows.iter().position(|row| {
+        expected_column.is_none_or(|column| json_contains_string(row, column))
+            && expected_parent_unique_id
+                .is_none_or(|parent| string_field_equals(row, "parent_unique_id", parent))
+    });
+    if let Some(index) = position {
+        let rank = index + 1;
+        if max_rank.is_none_or(|max| rank <= max) {
+            AssertionResult::pass(
+                "search_columns_rank",
+                format!("expected column result ranked {rank}"),
+                json!({"rank": rank}),
+            )
+        } else {
+            AssertionResult::fail(
+                "search_columns_rank",
+                format!(
+                    "expected column result ranked {rank}, above max rank {}",
+                    max_rank.unwrap_or(0)
+                ),
+                top_evidence(rows, "parent_unique_id"),
+            )
+        }
+    } else {
+        AssertionResult::fail(
+            "search_columns_rank",
+            "expected column result was not returned",
+            top_evidence(rows, "parent_unique_id"),
+        )
+    }
+}
+
+fn fields_assertion(name: &str, response: &JsonValue, fields: &[String]) -> AssertionResult {
+    let missing: Vec<&str> = fields
+        .iter()
+        .map(String::as_str)
+        .filter(|field| !json_has_field_path(response, field))
+        .collect();
+    if missing.is_empty() {
+        AssertionResult::pass(name, "required fields were present", JsonValue::Null)
+    } else {
+        AssertionResult::fail(
+            name,
+            "required fields were missing",
+            json!({"missing": missing}),
+        )
+    }
+}
+
+fn metadata_score_assertion(response: &JsonValue, threshold: f64) -> AssertionResult {
+    let score = find_score(response);
+    match score {
+        Some(score) if score >= threshold => AssertionResult::pass(
+            "metadata_score_min",
+            format!("metadata score {score:.3} met threshold {threshold:.3}"),
+            json!({"score": score, "threshold": threshold}),
+        ),
+        Some(score) => AssertionResult::fail(
+            "metadata_score_min",
+            format!("metadata score {score:.3} was below threshold {threshold:.3}"),
+            json!({"score": score, "threshold": threshold}),
+        ),
+        None => AssertionResult::fail(
+            "metadata_score_min",
+            "metadata score response did not contain a numeric score",
+            JsonValue::Null,
+        ),
+    }
+}
+
+fn recipe_queries_assertion(response: &JsonValue, min_queries: usize) -> AssertionResult {
+    let query_count = count_recipe_queries(response);
+    if query_count >= min_queries {
+        AssertionResult::pass(
+            "recipe_has_queries",
+            format!("recipe contained {query_count} queries"),
+            json!({"query_count": query_count, "min_queries": min_queries}),
+        )
+    } else {
+        AssertionResult::fail(
+            "recipe_has_queries",
+            format!("recipe contained {query_count} queries, below minimum {min_queries}"),
+            json!({"query_count": query_count, "min_queries": min_queries}),
+        )
+    }
+}
+
+fn contains_string_assertion(name: &str, response: &JsonValue, expected: &str) -> AssertionResult {
+    if json_contains_string(response, expected) {
+        AssertionResult::pass(
+            name,
+            "expected value appeared in response",
+            json!({"expected": expected}),
+        )
+    } else {
+        AssertionResult::fail(
+            name,
+            "expected value did not appear in response",
+            json!({"expected": expected}),
+        )
+    }
+}
+
+fn data_rows(response: &JsonValue) -> &[JsonValue] {
+    response
+        .get("data")
+        .and_then(JsonValue::as_array)
+        .map_or(&[], Vec::as_slice)
+}
+
+fn string_field_equals(row: &JsonValue, field: &str, expected: &str) -> bool {
+    row.get(field)
+        .and_then(JsonValue::as_str)
+        .is_some_and(|value| value.eq_ignore_ascii_case(expected))
+}
+
+fn json_contains_string(value: &JsonValue, expected: &str) -> bool {
+    let expected = expected.to_lowercase();
+    json_contains_string_lower(value, &expected)
+}
+
+fn json_contains_string_lower(value: &JsonValue, expected: &str) -> bool {
+    match value {
+        JsonValue::String(value) => value.to_lowercase().contains(expected),
+        JsonValue::Array(items) => items
+            .iter()
+            .any(|item| json_contains_string_lower(item, expected)),
+        JsonValue::Object(map) => map
+            .values()
+            .any(|child| json_contains_string_lower(child, expected)),
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) => false,
+    }
+}
+
+fn json_has_field_path(value: &JsonValue, field_path: &str) -> bool {
+    let mut current = value;
+    for part in field_path.split('.') {
+        let Some(next) = current.get(part) else {
+            return false;
+        };
+        current = next;
+    }
+    !current.is_null()
+}
+
+fn find_score(value: &JsonValue) -> Option<f64> {
+    for key in ["overall_score", "score", "metadata_score"] {
+        if let Some(score) = find_number_by_key(value, key) {
+            return Some(score);
+        }
+    }
+    None
+}
+
+fn find_number_by_key(value: &JsonValue, key: &str) -> Option<f64> {
+    match value {
+        JsonValue::Object(map) => {
+            if let Some(score) = map.get(key).and_then(JsonValue::as_f64) {
+                return Some(score);
+            }
+            map.values()
+                .find_map(|child| find_number_by_key(child, key))
+        }
+        JsonValue::Array(items) => items.iter().find_map(|item| find_number_by_key(item, key)),
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) | JsonValue::String(_) => None,
+    }
+}
+
+fn count_recipe_queries(value: &JsonValue) -> usize {
+    match value {
+        JsonValue::Object(map) => {
+            for key in ["queries", "query_names"] {
+                if let Some(count) = map.get(key).and_then(JsonValue::as_array).map(Vec::len) {
+                    return count;
+                }
+            }
+            map.values().map(count_recipe_queries).max().unwrap_or(0)
+        }
+        JsonValue::Array(items) => items.iter().map(count_recipe_queries).max().unwrap_or(0),
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) | JsonValue::String(_) => 0,
+    }
+}
+
+fn top_evidence(rows: &[JsonValue], field: &str) -> JsonValue {
+    JsonValue::Array(
+        rows.iter()
+            .take(10)
+            .map(|row| {
+                json!({
+                    field: row.get(field).cloned().unwrap_or(JsonValue::Null),
+                    "name": row.get("name").cloned().unwrap_or(JsonValue::Null),
+                    "unique_id": row.get("unique_id").cloned().unwrap_or(JsonValue::Null),
+                })
+            })
+            .collect(),
+    )
+}
+
+fn effective_limit(max_rank: Option<usize>, default_top_k: usize) -> usize {
+    max_rank.unwrap_or(default_top_k).max(1)
+}
+
+fn effective_persona(
+    assertion_persona: Option<&String>,
+    case: &EvalCase,
+    suite: &EvalSuite,
+) -> Option<String> {
+    assertion_persona
+        .cloned()
+        .or_else(|| case.persona.clone())
+        .or_else(|| suite.defaults.persona.clone())
+}
+
+fn build_report(
+    suite: &EvalSuite,
+    mode: &'static str,
+    output_dir: String,
+    fail_under: f64,
+    cases: Vec<EvalCaseReport>,
+) -> EvalReport {
+    let pass_count = cases.iter().map(|case| case.pass_count).sum();
+    let fail_count = cases.iter().map(|case| case.fail_count).sum();
+    let error_count = cases.iter().map(|case| case.error_count).sum();
+    let assertion_count = pass_count + fail_count + error_count;
+    let pass_rate = if assertion_count == 0 {
+        0.0
+    } else {
+        ratio(pass_count, assertion_count)
+    };
+    let gate_status = if pass_rate >= fail_under {
+        "pass"
+    } else {
+        "fail"
+    };
+    EvalReport {
+        suite_name: suite.name.clone().unwrap_or_else(|| "unnamed".to_string()),
+        version: suite.version,
+        mode,
+        output_dir,
+        assertion_count,
+        pass_count,
+        fail_count,
+        error_count,
+        pass_rate,
+        fail_under,
+        gate_status,
+        cases,
+    }
+}
+
+fn write_report_artifacts(
+    output_dir: &Path,
+    report: &EvalReport,
+    suite_path: &str,
+) -> DispatchResult {
+    fs::create_dir_all(output_dir).map_err(|error| server_error(error.to_string()))?;
+    let report_json =
+        serde_json::to_string_pretty(report).map_err(|error| server_error(error.to_string()))?;
+    fs::write(output_dir.join("results.json"), report_json)
+        .map_err(|error| server_error(error.to_string()))?;
+    fs::write(output_dir.join("results.tsv"), render_tsv(report))
+        .map_err(|error| server_error(error.to_string()))?;
+    fs::write(output_dir.join("report.md"), render_markdown(report))
+        .map_err(|error| server_error(error.to_string()))?;
+    if let Err(error) = fs::copy(suite_path, output_dir.join("suite.yml")) {
+        tracing::warn!(error = %error, suite_path, "failed to copy eval suite");
+    }
+    Ok(())
+}
+
+fn render_tsv(report: &EvalReport) -> String {
+    let mut out = String::from("case_id\tassertion\tstatus\tmessage\n");
+    for case in &report.cases {
+        for assertion in &case.assertions {
+            let _ = writeln!(
+                out,
+                "{}\t{}\t{}\t{}",
+                tsv_escape(&case.id),
+                tsv_escape(&assertion.name),
+                assertion.status,
+                tsv_escape(&assertion.message)
+            );
+        }
+    }
+    out
+}
+
+fn render_markdown(report: &EvalReport) -> String {
+    let mut out = format!(
+        "# Nova Eval Report\n\n- Suite: `{}`\n- Mode: `{}`\n- Gate: `{}`\n- Pass rate: `{:.1}%`\n- Assertions: {} pass, {} fail, {} error\n\n",
+        report.suite_name,
+        report.mode,
+        report.gate_status,
+        report.pass_rate * 100.0,
+        report.pass_count,
+        report.fail_count,
+        report.error_count
+    );
+    for case in &report.cases {
+        let _ = writeln!(out, "## {}\n", case.id);
+        for assertion in &case.assertions {
+            let _ = writeln!(
+                out,
+                "- `{}` `{}`: {}",
+                assertion.status, assertion.name, assertion.message
+            );
+        }
+        out.push('\n');
+    }
+    out
+}
+
+fn tsv_escape(value: &str) -> String {
+    value.replace(['\t', '\n', '\r'], " ")
+}
+
+fn finish_report(
+    command: &str,
+    report: &EvalReport,
+    json_output: bool,
+    elapsed_ms: u128,
+) -> DispatchResult {
+    let gate_failed = report.gate_status != "pass";
+    if json_output {
+        let envelope = CliEnvelope::success(command, &report, elapsed_ms);
+        let out = serde_json::to_string_pretty(&envelope)
+            .map_err(|error| server_error(error.to_string()))?;
+        println!("{out}");
+        if gate_failed {
+            return Err(DispatchError {
+                error: DbtNovaError::ServerError(format!(
+                    "eval gate failed: pass rate {:.3} below threshold {:.3}",
+                    report.pass_rate, report.fail_under
+                )),
+                rendered: true,
+            });
+        }
+        return Ok(());
+    }
+
+    println!(
+        "Nova eval {}: {} ({}/{} passed, {:.1}%). Artifacts: {}",
+        report.mode,
+        report.gate_status,
+        report.pass_count,
+        report.assertion_count,
+        report.pass_rate * 100.0,
+        report.output_dir
+    );
+    if gate_failed {
+        return Err(DbtNovaError::ServerError(format!(
+            "eval gate failed: pass rate {:.3} below threshold {:.3}",
+            report.pass_rate, report.fail_under
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+impl EvalCaseReport {
+    fn new(
+        id: String,
+        question: Option<String>,
+        assertions: Vec<AssertionResult>,
+        artifacts: Option<AgentArtifacts>,
+    ) -> Self {
+        let pass_count = assertions
+            .iter()
+            .filter(|assertion| assertion.status == "pass")
+            .count();
+        let fail_count = assertions
+            .iter()
+            .filter(|assertion| assertion.status == "fail")
+            .count();
+        let error_count = assertions
+            .iter()
+            .filter(|assertion| assertion.status == "error")
+            .count();
+        Self {
+            id,
+            question,
+            pass_count,
+            fail_count,
+            error_count,
+            assertions,
+            artifacts,
+        }
+    }
+}
+
+impl AssertionResult {
+    fn pass(name: impl Into<String>, message: impl Into<String>, evidence: JsonValue) -> Self {
+        Self {
+            name: name.into(),
+            status: "pass",
+            message: message.into(),
+            evidence,
+        }
+    }
+
+    fn fail(name: impl Into<String>, message: impl Into<String>, evidence: JsonValue) -> Self {
+        Self {
+            name: name.into(),
+            status: "fail",
+            message: message.into(),
+            evidence,
+        }
+    }
+
+    fn error(name: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: "error",
+            message: message.into(),
+            evidence: JsonValue::Null,
+        }
+    }
+}
+
+impl AgentExpected {
+    fn requires_trace(&self) -> bool {
+        !self.must_call.is_empty()
+            || !self.must_not_call.is_empty()
+            || !self.ordered.is_empty()
+            || !self.selected_entities.is_empty()
+    }
+}
+
+fn load_suite(path: &str) -> crate::error::Result<EvalSuite> {
+    let raw = fs::read_to_string(path).map_err(|error| {
+        DbtNovaError::InvalidParams(format!("failed to read eval suite '{path}': {error}"))
+    })?;
+    let suite: EvalSuite = if Path::new(path)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
+    {
+        serde_json::from_str(&raw).map_err(|error| {
+            DbtNovaError::InvalidParams(format!("failed to parse eval suite JSON: {error}"))
+        })?
+    } else {
+        serde_yaml::from_str(&raw).map_err(|error| {
+            DbtNovaError::InvalidParams(format!("failed to parse eval suite YAML: {error}"))
+        })?
+    };
+    validate_suite(&suite)?;
+    Ok(suite)
+}
+
+fn validate_suite(suite: &EvalSuite) -> crate::error::Result<()> {
+    if suite.version == 0 {
+        return Err(DbtNovaError::InvalidParams(
+            "eval suite version must be greater than zero".to_string(),
+        ));
+    }
+    validate_case_ids(suite.cases.iter().map(|case| case.id.as_str()), "cases")?;
+    validate_case_ids(
+        suite.agent_cases.iter().map(|case| case.id.as_str()),
+        "agent_cases",
+    )?;
+    for case in &suite.cases {
+        if case.assertions.is_empty() {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "eval case '{}' must include at least one assertion",
+                case.id
+            )));
+        }
+    }
+    for case in &suite.agent_cases {
+        if case.task.trim().is_empty() {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "agent case '{}' must include a non-empty task",
+                case.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_case_ids<'a>(
+    ids: impl Iterator<Item = &'a str>,
+    section: &str,
+) -> crate::error::Result<()> {
+    let mut seen = BTreeSet::new();
+    let mut seen_artifact_segments = BTreeSet::new();
+    for id in ids {
+        let trimmed = id.trim();
+        if trimmed.is_empty() {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "{section} entries must include non-empty ids"
+            )));
+        }
+        if !seen.insert(trimmed.to_string()) {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "duplicate eval case id '{trimmed}' in {section}"
+            )));
+        }
+        let artifact_segment = safe_path_segment(trimmed);
+        if !seen_artifact_segments.insert(artifact_segment.clone()) {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "eval case ids in {section} must map to unique artifact paths; duplicate segment '{artifact_segment}'"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn resolve_output_dir(explicit: Option<&str>, suite: &EvalSuite, mode: &str) -> PathBuf {
+    if let Some(path) = explicit {
+        return PathBuf::from(path);
+    }
+    let suite_name = suite.name.as_deref().unwrap_or("suite");
+    PathBuf::from(".nova").join("eval-runs").join(format!(
+        "{}-{}-{}",
+        timestamp_secs(),
+        safe_path_segment(suite_name),
+        mode
+    ))
+}
+
+fn validate_fail_under(value: Option<f64>) -> crate::error::Result<()> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    if !(0.0..=1.0).contains(&value) {
+        return Err(DbtNovaError::InvalidParams(
+            "--fail-under must be between 0.0 and 1.0".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn agent_prompt(case: &AgentCase) -> String {
+    format!(
+        "You are running a dbt-nova eval case.\n\nTask:\n{}\n\nUse Nova tools when they are needed. Do not mutate repository files. Finish with a concise answer that cites the evidence you used.",
+        case.task
+    )
+}
+
+fn starter_suite(persona: &str) -> String {
+    let safe_persona = safe_path_segment(persona);
+    let persona_yaml = serde_json::to_string(persona).unwrap_or_else(|_| "\"analyst\"".to_string());
+    format!(
+        r"version: 1
+name: nova-{safe_persona}-smoke
+defaults:
+  persona: {persona_yaml}
+  top_k: 5
+cases:
+  - id: canonical_entity_search
+    question: Find the canonical entity for a business concept.
+    assertions:
+      - type: search_rank
+        query: orders
+        expected_unique_id: model.pkg.orders
+        max_rank: 5
+      - type: context_has
+        id_or_name: model.pkg.orders
+        fields:
+          - data.unique_id
+          - data.name
+agent_cases:
+  - id: analyst_metric_lookup
+    task: Which canonical model and indicator should be used to analyze gross merchandise value?
+    expected:
+      must_call:
+        - search_indicator
+        - get_context
+      selected_entities:
+        - model.pkg.orders
+      final_answer:
+        must_contain:
+          - gross merchandise value
+"
+    )
+}
+
+fn empty_object() -> JsonValue {
+    json!({})
+}
+
+fn default_top_k() -> usize {
+    DEFAULT_TOP_K
+}
+
+fn safe_path_segment(value: &str) -> String {
+    let sanitized: String = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let trimmed = sanitized.trim_matches(['-', '.']).trim();
+    let capped: String = trimmed.chars().take(MAX_SAFE_PATH_SEGMENT_CHARS).collect();
+    if capped.is_empty() || matches!(capped.as_str(), "." | "..") {
+        "eval".to_string()
+    } else {
+        capped
+    }
+}
+
+fn truncate(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
+}
+
+fn timestamp_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_secs())
+}
+
+fn elapsed_ms_to_u64(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn ratio(numerator: usize, denominator: usize) -> f64 {
+    let numerator = u32::try_from(numerator).unwrap_or(u32::MAX);
+    let denominator = u32::try_from(denominator).unwrap_or(u32::MAX);
+    f64::from(numerator) / f64::from(denominator)
+}
+
+fn server_error(message: String) -> DbtNovaError {
+    DbtNovaError::ServerError(message)
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -1412,12 +1412,37 @@ fn validate_suite(suite: &EvalSuite) -> crate::error::Result<()> {
                 case.id
             )));
         }
+        for assertion in &case.assertions {
+            validate_assertion(assertion, &case.id)?;
+        }
     }
     for case in &suite.agent_cases {
         if case.task.trim().is_empty() {
             return Err(DbtNovaError::InvalidParams(format!(
                 "agent case '{}' must include a non-empty task",
                 case.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_assertion(assertion: &EvalAssertion, case_id: &str) -> crate::error::Result<()> {
+    if let EvalAssertion::SearchColumnsRank {
+        expected_column,
+        expected_parent_unique_id,
+        ..
+    } = assertion
+    {
+        let has_expected_column = expected_column
+            .as_ref()
+            .is_some_and(|value| !value.trim().is_empty());
+        let has_expected_parent = expected_parent_unique_id
+            .as_ref()
+            .is_some_and(|value| !value.trim().is_empty());
+        if !has_expected_column && !has_expected_parent {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "search_columns_rank assertion in case '{case_id}' must include expected_column or expected_parent_unique_id"
             )));
         }
     }

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -1505,7 +1505,7 @@ cases:
         id_or_name: model.pkg.orders
         fields:
           - data.unique_id
-          - data.name
+          - data.entity.name
 agent_cases:
   - id: analyst_metric_lookup
     task: Which canonical model and indicator should be used to analyze gross merchandise value?

--- a/src/cli/eval_cmd/provider.rs
+++ b/src/cli/eval_cmd/provider.rs
@@ -363,10 +363,8 @@ fn normalize_provider_nova_tool_name(name: &str) -> Option<String> {
         suffix.rsplit_once("__")?
     } else if let Some(parts) = name.rsplit_once("__") {
         parts
-    } else if let Some(parts) = name.rsplit_once('.') {
-        parts
     } else {
-        return None;
+        name.rsplit_once('.')?
     };
     let tool = tool.trim();
     (is_nova_mcp_server_alias(Some(server_alias)) && is_nova_tool_name(tool))

--- a/src/cli/eval_cmd/provider.rs
+++ b/src/cli/eval_cmd/provider.rs
@@ -8,6 +8,7 @@ use tokio::process::Command;
 
 use crate::cli::args::EvalAgentRunArgs;
 use crate::error::DbtNovaError;
+use crate::tools::catalog::MCP_TOOL_NAMES;
 use crate::utils::tool_trace::TRACE_ENV;
 
 use super::server_error;
@@ -233,12 +234,13 @@ fn codex_mcp_tool_row(event: &JsonValue) -> Option<JsonValue> {
         return None;
     }
     let item = event.get("item")?;
-    if item.get("type").and_then(JsonValue::as_str) != Some("mcp_tool_call")
-        || item.get("server").and_then(JsonValue::as_str) != Some("nova")
-    {
+    if item.get("type").and_then(JsonValue::as_str) != Some("mcp_tool_call") {
         return None;
     }
     let tool = item.get("tool").and_then(JsonValue::as_str)?;
+    if !is_nova_tool_name(tool) {
+        return None;
+    }
     let success = item.get("error").is_none_or(JsonValue::is_null);
     Some(provider_tool_row(
         "provider_stdout_codex",
@@ -300,11 +302,18 @@ fn opencode_mcp_tool_row(event: &JsonValue) -> Option<JsonValue> {
 }
 
 fn normalize_provider_nova_tool_name(name: &str) -> Option<String> {
-    name.strip_prefix("mcp__nova__")
-        .or_else(|| name.strip_prefix("nova__"))
-        .or_else(|| name.strip_prefix("nova."))
-        .filter(|tool| !tool.trim().is_empty())
-        .map(ToString::to_string)
+    let candidate = name
+        .strip_prefix("mcp__")
+        .and_then(|suffix| suffix.rsplit_once("__").map(|(_, tool)| tool))
+        .or_else(|| name.rsplit_once("__").map(|(_, tool)| tool))
+        .or_else(|| name.rsplit_once('.').map(|(_, tool)| tool))
+        .unwrap_or(name)
+        .trim();
+    is_nova_tool_name(candidate).then(|| candidate.to_string())
+}
+
+fn is_nova_tool_name(name: &str) -> bool {
+    MCP_TOOL_NAMES.contains(&name)
 }
 
 fn provider_tool_row(
@@ -480,6 +489,19 @@ mod tests {
     }
 
     #[test]
+    fn provider_trace_reads_codex_events_with_custom_server_alias() {
+        let stdout = r#"{"type":"item.completed","item":{"type":"mcp_tool_call","server":"dbt-nova","tool":"get_context","arguments":{"id_or_name":"model.pkg.orders"},"result":{"content":[{"type":"text","text":"{}"}]},"error":null,"status":"completed"}}"#;
+        let trace = read_provider_tool_trace(stdout);
+        assert_eq!(trace.errors, Vec::<String>::new());
+        assert_eq!(trace.rows.len(), 1);
+        assert_eq!(trace.rows[0]["tool"], "get_context");
+        assert_eq!(
+            trace.rows[0]["params_summary"]["id_or_name"],
+            "model.pkg.orders"
+        );
+    }
+
+    #[test]
     fn provider_trace_reads_claude_mcp_tool_use_events() {
         let stdout = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp__nova__search_indicator","input":{"query":"gmv"}},{"type":"tool_use","name":"mcp__nova__get_context","input":{"id_or_name":"model.pkg.orders"}}]}}"#;
         let trace = read_provider_tool_trace(stdout);
@@ -491,5 +513,15 @@ mod tests {
             trace.rows[1]["params_summary"]["id_or_name"],
             "model.pkg.orders"
         );
+    }
+
+    #[test]
+    fn provider_trace_normalizes_custom_mcp_aliases() {
+        let stdout = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp__dbt_nova__search_indicator","input":{"query":"gmv"}},{"type":"tool_use","name":"dbt-nova.get_context","input":{"id_or_name":"model.pkg.orders"}},{"type":"tool_use","name":"other_server.not_a_nova_tool","input":{}}]}}"#;
+        let trace = read_provider_tool_trace(stdout);
+        assert_eq!(trace.errors, Vec::<String>::new());
+        assert_eq!(trace.rows.len(), 2);
+        assert_eq!(trace.rows[0]["tool"], "search_indicator");
+        assert_eq!(trace.rows[1]["tool"], "get_context");
     }
 }

--- a/src/cli/eval_cmd/provider.rs
+++ b/src/cli/eval_cmd/provider.rs
@@ -1,0 +1,495 @@
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde_json::{Value as JsonValue, json};
+use tokio::process::Command;
+
+use crate::cli::args::EvalAgentRunArgs;
+use crate::error::DbtNovaError;
+use crate::utils::tool_trace::TRACE_ENV;
+
+use super::server_error;
+
+#[derive(Debug)]
+pub(super) struct ProviderInvocation {
+    pub(super) command: String,
+    pub(super) args: Vec<String>,
+}
+
+pub(super) struct ProviderOutput {
+    pub(super) status_success: bool,
+    pub(super) stdout: String,
+    pub(super) stderr: String,
+}
+
+pub(super) async fn run_provider_command(
+    invocation: &ProviderInvocation,
+    args: &EvalAgentRunArgs,
+    trace_path: &Path,
+    case_dir: &Path,
+) -> crate::error::Result<ProviderOutput> {
+    let mut command = Command::new(&invocation.command);
+    command
+        .args(&invocation.args)
+        .current_dir(std::env::current_dir().map_err(|error| server_error(error.to_string()))?)
+        .env(TRACE_ENV, trace_path)
+        .env("DBT_NOVA_EVAL_CASE_DIR", case_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    if let Some(path) = args.manifest_path.as_ref() {
+        command.env("DBT_MANIFEST_PATH", path);
+    }
+    if let Some(uri) = args.manifest_uri.as_ref() {
+        command.env("DBT_NOVA_MANIFEST_URI", uri);
+    }
+    if let Some(instance_id) = args.storage_instance_id.as_ref() {
+        command.env("DBT_NOVA_STORAGE_INSTANCE_ID", instance_id);
+    }
+    if args.cleanup_storage_on_start {
+        command.env("DBT_NOVA_CLEANUP_STORAGE_ON_START", "true");
+    }
+    if args.read_only {
+        command.env("DBT_NOVA_STORAGE_READ_ONLY", "true");
+    }
+
+    let timeout = Duration::from_secs(args.timeout_secs.max(1));
+    let output = tokio::time::timeout(timeout, command.output())
+        .await
+        .map_err(|_| {
+            DbtNovaError::ServerError(format!(
+                "provider command timed out after {} seconds",
+                timeout.as_secs()
+            ))
+        })?
+        .map_err(|error| {
+            DbtNovaError::ServerError(format!(
+                "failed to run provider command '{}': {error}",
+                invocation.command
+            ))
+        })?;
+
+    Ok(ProviderOutput {
+        status_success: output.status.success(),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}
+
+pub(super) fn provider_invocation(
+    args: &EvalAgentRunArgs,
+    prompt: &str,
+    trace_path: &Path,
+) -> crate::error::Result<ProviderInvocation> {
+    let command = args.provider_command.clone().map_or_else(
+        || default_provider_command(&args.provider),
+        validate_custom_command,
+    )?;
+    let raw_args = if let Some(json) = args.provider_args_json.as_ref() {
+        let values: Vec<String> = serde_json::from_str(json).map_err(|error| {
+            DbtNovaError::InvalidParams(format!("invalid --provider-args-json: {error}"))
+        })?;
+        substitute_provider_args(values, prompt, trace_path, args)
+    } else {
+        default_provider_args(&args.provider, prompt)?
+    };
+    Ok(ProviderInvocation {
+        command,
+        args: raw_args,
+    })
+}
+
+fn validate_custom_command(command: String) -> crate::error::Result<String> {
+    if command.trim().is_empty() {
+        return Err(DbtNovaError::InvalidParams(
+            "--provider-command cannot be empty".to_string(),
+        ));
+    }
+    Ok(command)
+}
+
+fn default_provider_command(provider: &str) -> crate::error::Result<String> {
+    match provider {
+        "opencode" => Ok("opencode".to_string()),
+        "codex" => Ok("codex".to_string()),
+        "claude" => Ok("claude".to_string()),
+        "goose" => Ok("goose".to_string()),
+        other => Err(DbtNovaError::InvalidParams(format!(
+            "unsupported provider '{other}'; use opencode, codex, claude, goose, or pass --provider-command"
+        ))),
+    }
+}
+
+fn default_provider_args(provider: &str, prompt: &str) -> crate::error::Result<Vec<String>> {
+    match provider {
+        "opencode" => Ok(vec![
+            "run".to_string(),
+            "--format".to_string(),
+            "json".to_string(),
+            "--dir".to_string(),
+            std::env::current_dir()
+                .map_err(|error| server_error(error.to_string()))?
+                .display()
+                .to_string(),
+            prompt.to_string(),
+        ]),
+        "codex" => Ok(vec![
+            "exec".to_string(),
+            "--json".to_string(),
+            "--cd".to_string(),
+            std::env::current_dir()
+                .map_err(|error| server_error(error.to_string()))?
+                .display()
+                .to_string(),
+            prompt.to_string(),
+        ]),
+        "claude" => Ok(vec![
+            "-p".to_string(),
+            "--verbose".to_string(),
+            "--output-format".to_string(),
+            "stream-json".to_string(),
+            prompt.to_string(),
+        ]),
+        "goose" => Ok(vec![
+            "run".to_string(),
+            "--text".to_string(),
+            prompt.to_string(),
+            "--output-format".to_string(),
+            "stream-json".to_string(),
+            "--no-session".to_string(),
+        ]),
+        other => Err(DbtNovaError::InvalidParams(format!(
+            "unsupported provider '{other}'; use opencode, codex, claude, goose, or pass --provider-command with --provider-args-json"
+        ))),
+    }
+}
+
+fn substitute_provider_args(
+    args: Vec<String>,
+    prompt: &str,
+    trace_path: &Path,
+    run_args: &EvalAgentRunArgs,
+) -> Vec<String> {
+    let workdir = std::env::current_dir()
+        .map(|path| path.display().to_string())
+        .unwrap_or_default();
+    let manifest_path = run_args.manifest_path.as_deref().unwrap_or_default();
+    args.into_iter()
+        .map(|arg| {
+            arg.replace("{prompt}", prompt)
+                .replace("{workdir}", &workdir)
+                .replace("{trace_path}", &trace_path.display().to_string())
+                .replace("{manifest_path}", manifest_path)
+        })
+        .collect()
+}
+
+pub(super) struct ToolTraceRead {
+    pub(super) rows: Vec<JsonValue>,
+    pub(super) errors: Vec<String>,
+}
+
+pub(super) fn read_provider_tool_trace(stdout: &str) -> ToolTraceRead {
+    let mut rows = Vec::new();
+    let mut errors = Vec::new();
+    for (index, line) in stdout.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let event = match serde_json::from_str::<JsonValue>(trimmed) {
+            Ok(event) => event,
+            Err(error) => {
+                if trimmed.starts_with('{') {
+                    errors.push(format!(
+                        "failed to parse provider stdout JSON line {}: {error}",
+                        index + 1
+                    ));
+                }
+                continue;
+            }
+        };
+        rows.extend(provider_event_tool_rows(&event));
+    }
+    ToolTraceRead { rows, errors }
+}
+
+fn provider_event_tool_rows(event: &JsonValue) -> Vec<JsonValue> {
+    let mut rows = Vec::new();
+    if let Some(row) = codex_mcp_tool_row(event) {
+        rows.push(row);
+    }
+    rows.extend(claude_tool_use_rows(event));
+    if let Some(row) = opencode_mcp_tool_row(event) {
+        rows.push(row);
+    }
+    rows
+}
+
+fn codex_mcp_tool_row(event: &JsonValue) -> Option<JsonValue> {
+    if event.get("type").and_then(JsonValue::as_str) != Some("item.completed") {
+        return None;
+    }
+    let item = event.get("item")?;
+    if item.get("type").and_then(JsonValue::as_str) != Some("mcp_tool_call")
+        || item.get("server").and_then(JsonValue::as_str) != Some("nova")
+    {
+        return None;
+    }
+    let tool = item.get("tool").and_then(JsonValue::as_str)?;
+    let success = item.get("error").is_none_or(JsonValue::is_null);
+    Some(provider_tool_row(
+        "provider_stdout_codex",
+        tool,
+        success,
+        item.get("arguments"),
+        item.get("result"),
+    ))
+}
+
+fn claude_tool_use_rows(event: &JsonValue) -> Vec<JsonValue> {
+    let mut rows = Vec::new();
+    let content = event
+        .get("message")
+        .and_then(|message| message.get("content"))
+        .and_then(JsonValue::as_array);
+    let Some(content) = content else {
+        return rows;
+    };
+    for part in content {
+        if part.get("type").and_then(JsonValue::as_str) != Some("tool_use") {
+            continue;
+        }
+        let Some(name) = part.get("name").and_then(JsonValue::as_str) else {
+            continue;
+        };
+        if let Some(tool) = normalize_provider_nova_tool_name(name) {
+            rows.push(provider_tool_row(
+                "provider_stdout_claude",
+                &tool,
+                true,
+                part.get("input"),
+                None,
+            ));
+        }
+    }
+    rows
+}
+
+fn opencode_mcp_tool_row(event: &JsonValue) -> Option<JsonValue> {
+    if event.get("type").and_then(JsonValue::as_str) != Some("tool_use") {
+        return None;
+    }
+    let part = event.get("part")?;
+    let name = part.get("tool").and_then(JsonValue::as_str)?;
+    let tool = normalize_provider_nova_tool_name(name)?;
+    let state = part.get("state");
+    let success = state
+        .and_then(|state| state.get("status"))
+        .and_then(JsonValue::as_str)
+        .is_none_or(|status| status == "completed");
+    Some(provider_tool_row(
+        "provider_stdout_opencode",
+        &tool,
+        success,
+        state.and_then(|state| state.get("input")),
+        state.and_then(|state| state.get("output")),
+    ))
+}
+
+fn normalize_provider_nova_tool_name(name: &str) -> Option<String> {
+    name.strip_prefix("mcp__nova__")
+        .or_else(|| name.strip_prefix("nova__"))
+        .or_else(|| name.strip_prefix("nova."))
+        .filter(|tool| !tool.trim().is_empty())
+        .map(ToString::to_string)
+}
+
+fn provider_tool_row(
+    transport: &str,
+    tool: &str,
+    success: bool,
+    params: Option<&JsonValue>,
+    response: Option<&JsonValue>,
+) -> JsonValue {
+    json!({
+        "transport": transport,
+        "tool": tool,
+        "success": success,
+        "duration_ms": 0,
+        "params_summary": provider_params_summary(params),
+        "selected_unique_ids": provider_selected_unique_ids(response),
+    })
+}
+
+fn provider_params_summary(params: Option<&JsonValue>) -> JsonValue {
+    let Some(JsonValue::Object(map)) = params else {
+        return JsonValue::Null;
+    };
+    let keys: Vec<JsonValue> = map
+        .keys()
+        .take(50)
+        .cloned()
+        .map(JsonValue::String)
+        .collect();
+    let mut summary = serde_json::Map::from_iter([(String::from("keys"), JsonValue::Array(keys))]);
+    for key in ["query", "persona", "id_or_name", "recipe_id", "direction"] {
+        if let Some(value) = map.get(key).and_then(provider_safe_scalar) {
+            summary.insert(key.to_string(), value);
+        }
+    }
+    JsonValue::Object(summary)
+}
+
+fn provider_safe_scalar(value: &JsonValue) -> Option<JsonValue> {
+    match value {
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) => Some(value.clone()),
+        JsonValue::String(value) => Some(JsonValue::String(value.chars().take(256).collect())),
+        JsonValue::Array(_) | JsonValue::Object(_) => None,
+    }
+}
+
+fn provider_selected_unique_ids(response: Option<&JsonValue>) -> Vec<String> {
+    let mut out = BTreeSet::new();
+    if let Some(response) = response {
+        collect_provider_unique_ids(response, &mut out);
+    }
+    out.into_iter().collect()
+}
+
+fn collect_provider_unique_ids(value: &JsonValue, out: &mut BTreeSet<String>) {
+    if out.len() >= 200 {
+        return;
+    }
+    match value {
+        JsonValue::Object(map) => {
+            for key in ["unique_id", "parent_unique_id", "root_id"] {
+                if let Some(id) = map.get(key).and_then(JsonValue::as_str)
+                    && !id.trim().is_empty()
+                {
+                    out.insert(id.chars().take(512).collect());
+                }
+            }
+            for child in map.values() {
+                collect_provider_unique_ids(child, out);
+                if out.len() >= 200 {
+                    return;
+                }
+            }
+        }
+        JsonValue::Array(items) => {
+            for item in items {
+                collect_provider_unique_ids(item, out);
+                if out.len() >= 200 {
+                    return;
+                }
+            }
+        }
+        JsonValue::String(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.starts_with('{')
+                && let Ok(parsed) = serde_json::from_str::<JsonValue>(trimmed)
+            {
+                collect_provider_unique_ids(&parsed, out);
+            }
+        }
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use serde_json::json;
+
+    use super::{provider_invocation, read_provider_tool_trace};
+    use crate::cli::args::EvalAgentRunArgs;
+
+    #[test]
+    fn provider_invocation_rejects_unknown_provider_without_command() {
+        let args = EvalAgentRunArgs {
+            provider: "custom".to_string(),
+            ..EvalAgentRunArgs::default()
+        };
+        let error = provider_invocation(&args, "prompt", Path::new("trace.jsonl"))
+            .expect_err("unknown provider should fail");
+        assert!(error.to_string().contains("unsupported provider"));
+    }
+
+    #[test]
+    fn provider_invocation_rejects_empty_custom_command() {
+        let args = EvalAgentRunArgs {
+            provider: "custom".to_string(),
+            provider_command: Some(" ".to_string()),
+            ..EvalAgentRunArgs::default()
+        };
+        let error = provider_invocation(&args, "prompt", Path::new("trace.jsonl"))
+            .expect_err("empty provider command should fail");
+        assert!(error.to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn provider_invocation_substitutes_custom_args() {
+        let args = EvalAgentRunArgs {
+            provider: "custom".to_string(),
+            provider_command: Some("runner".to_string()),
+            provider_args_json: Some(
+                r#"["--prompt","{prompt}","--trace","{trace_path}"]"#.to_string(),
+            ),
+            ..EvalAgentRunArgs::default()
+        };
+        let invocation = provider_invocation(&args, "hello", Path::new("/tmp/trace.jsonl"))
+            .expect("custom provider");
+        assert_eq!(invocation.command, "runner");
+        assert_eq!(
+            invocation.args,
+            vec!["--prompt", "hello", "--trace", "/tmp/trace.jsonl"]
+        );
+    }
+
+    #[test]
+    fn provider_invocation_uses_claude_verbose_stream_json() {
+        let args = EvalAgentRunArgs {
+            provider: "claude".to_string(),
+            ..EvalAgentRunArgs::default()
+        };
+        let invocation = provider_invocation(&args, "hello", Path::new("/tmp/trace.jsonl"))
+            .expect("claude provider");
+        assert_eq!(invocation.command, "claude");
+        assert_eq!(
+            invocation.args,
+            vec!["-p", "--verbose", "--output-format", "stream-json", "hello"]
+        );
+    }
+
+    #[test]
+    fn provider_trace_reads_codex_mcp_tool_events() {
+        let stdout = r#"{"type":"item.completed","item":{"type":"mcp_tool_call","server":"nova","tool":"search_indicator","arguments":{"query":"gmv"},"result":{"content":[{"type":"text","text":"{\"data\":[{\"parent_unique_id\":\"model.pkg.orders\"}]}"}]},"error":null,"status":"completed"}}"#;
+        let trace = read_provider_tool_trace(stdout);
+        assert_eq!(trace.errors, Vec::<String>::new());
+        assert_eq!(trace.rows.len(), 1);
+        assert_eq!(trace.rows[0]["tool"], "search_indicator");
+        assert_eq!(trace.rows[0]["params_summary"]["query"], "gmv");
+        assert_eq!(
+            trace.rows[0]["selected_unique_ids"],
+            json!(["model.pkg.orders"])
+        );
+    }
+
+    #[test]
+    fn provider_trace_reads_claude_mcp_tool_use_events() {
+        let stdout = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp__nova__search_indicator","input":{"query":"gmv"}},{"type":"tool_use","name":"mcp__nova__get_context","input":{"id_or_name":"model.pkg.orders"}}]}}"#;
+        let trace = read_provider_tool_trace(stdout);
+        assert_eq!(trace.errors, Vec::<String>::new());
+        assert_eq!(trace.rows.len(), 2);
+        assert_eq!(trace.rows[0]["tool"], "search_indicator");
+        assert_eq!(trace.rows[1]["tool"], "get_context");
+        assert_eq!(
+            trace.rows[1]["params_summary"]["id_or_name"],
+            "model.pkg.orders"
+        );
+    }
+}

--- a/src/cli/eval_cmd/provider.rs
+++ b/src/cli/eval_cmd/provider.rs
@@ -133,11 +133,6 @@ fn default_provider_args(provider: &str, prompt: &str) -> crate::error::Result<V
             "run".to_string(),
             "--format".to_string(),
             "json".to_string(),
-            "--dir".to_string(),
-            std::env::current_dir()
-                .map_err(|error| server_error(error.to_string()))?
-                .display()
-                .to_string(),
             prompt.to_string(),
         ]),
         "codex" => Ok(vec![
@@ -544,6 +539,18 @@ mod tests {
             invocation.args,
             vec!["--prompt", "hello", "--trace", "/tmp/trace.jsonl"]
         );
+    }
+
+    #[test]
+    fn provider_invocation_uses_opencode_without_dir_flag() {
+        let args = EvalAgentRunArgs {
+            provider: "opencode".to_string(),
+            ..EvalAgentRunArgs::default()
+        };
+        let invocation = provider_invocation(&args, "hello", Path::new("/tmp/trace.jsonl"))
+            .expect("opencode provider");
+        assert_eq!(invocation.command, "opencode");
+        assert_eq!(invocation.args, vec!["run", "--format", "json", "hello"]);
     }
 
     #[test]

--- a/src/cli/eval_cmd/provider.rs
+++ b/src/cli/eval_cmd/provider.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::process::Stdio;
 use std::time::Duration;
@@ -193,7 +193,7 @@ pub(super) struct ToolTraceRead {
 }
 
 pub(super) fn read_provider_tool_trace(stdout: &str) -> ToolTraceRead {
-    let mut rows = Vec::new();
+    let mut trace = ProviderTraceState::default();
     let mut errors = Vec::new();
     for (index, line) in stdout.lines().enumerate() {
         let trimmed = line.trim();
@@ -212,21 +212,91 @@ pub(super) fn read_provider_tool_trace(stdout: &str) -> ToolTraceRead {
                 continue;
             }
         };
-        rows.extend(provider_event_tool_rows(&event));
+        trace.ingest_event(&event);
     }
-    ToolTraceRead { rows, errors }
+    ToolTraceRead {
+        rows: trace.rows,
+        errors,
+    }
 }
 
-fn provider_event_tool_rows(event: &JsonValue) -> Vec<JsonValue> {
-    let mut rows = Vec::new();
-    if let Some(row) = codex_mcp_tool_row(event) {
-        rows.push(row);
+#[derive(Default)]
+struct ProviderTraceState {
+    rows: Vec<JsonValue>,
+    claude_tool_row_by_id: BTreeMap<String, usize>,
+}
+
+impl ProviderTraceState {
+    fn ingest_event(&mut self, event: &JsonValue) {
+        if let Some(row) = codex_mcp_tool_row(event) {
+            self.rows.push(row);
+        }
+        self.ingest_claude_event(event);
+        if let Some(row) = opencode_mcp_tool_row(event) {
+            self.rows.push(row);
+        }
     }
-    rows.extend(claude_tool_use_rows(event));
-    if let Some(row) = opencode_mcp_tool_row(event) {
-        rows.push(row);
+
+    fn ingest_claude_event(&mut self, event: &JsonValue) {
+        let Some(content) = claude_message_content(event) else {
+            return;
+        };
+        for part in content {
+            match part.get("type").and_then(JsonValue::as_str) {
+                Some("tool_use") => self.ingest_claude_tool_use(part),
+                Some("tool_result") => self.ingest_claude_tool_result(part),
+                _ => {}
+            }
+        }
     }
-    rows
+
+    fn ingest_claude_tool_use(&mut self, part: &JsonValue) {
+        let Some(name) = part.get("name").and_then(JsonValue::as_str) else {
+            return;
+        };
+        let Some(tool) = normalize_provider_nova_tool_name(name) else {
+            return;
+        };
+        let row_index = self.rows.len();
+        self.rows.push(provider_tool_row(
+            "provider_stdout_claude",
+            &tool,
+            true,
+            part.get("input"),
+            None,
+        ));
+        if let Some(id) = part.get("id").and_then(JsonValue::as_str)
+            && !id.trim().is_empty()
+        {
+            self.claude_tool_row_by_id.insert(id.to_string(), row_index);
+        }
+    }
+
+    fn ingest_claude_tool_result(&mut self, part: &JsonValue) {
+        let Some(tool_use_id) = part.get("tool_use_id").and_then(JsonValue::as_str) else {
+            return;
+        };
+        let Some(row_index) = self.claude_tool_row_by_id.get(tool_use_id).copied() else {
+            return;
+        };
+        let success = !part
+            .get("is_error")
+            .and_then(JsonValue::as_bool)
+            .unwrap_or(false);
+        let response = part.get("content").unwrap_or(part);
+        let selected_unique_ids = provider_selected_unique_ids(Some(response));
+        if let Some(row) = self
+            .rows
+            .get_mut(row_index)
+            .and_then(JsonValue::as_object_mut)
+        {
+            row.insert("success".to_string(), JsonValue::Bool(success));
+            row.insert(
+                "selected_unique_ids".to_string(),
+                json!(selected_unique_ids),
+            );
+        }
+    }
 }
 
 fn codex_mcp_tool_row(event: &JsonValue) -> Option<JsonValue> {
@@ -251,33 +321,12 @@ fn codex_mcp_tool_row(event: &JsonValue) -> Option<JsonValue> {
     ))
 }
 
-fn claude_tool_use_rows(event: &JsonValue) -> Vec<JsonValue> {
-    let mut rows = Vec::new();
-    let content = event
+fn claude_message_content(event: &JsonValue) -> Option<&Vec<JsonValue>> {
+    event
         .get("message")
         .and_then(|message| message.get("content"))
-        .and_then(JsonValue::as_array);
-    let Some(content) = content else {
-        return rows;
-    };
-    for part in content {
-        if part.get("type").and_then(JsonValue::as_str) != Some("tool_use") {
-            continue;
-        }
-        let Some(name) = part.get("name").and_then(JsonValue::as_str) else {
-            continue;
-        };
-        if let Some(tool) = normalize_provider_nova_tool_name(name) {
-            rows.push(provider_tool_row(
-                "provider_stdout_claude",
-                &tool,
-                true,
-                part.get("input"),
-                None,
-            ));
-        }
-    }
-    rows
+        .and_then(JsonValue::as_array)
+        .or_else(|| event.get("content").and_then(JsonValue::as_array))
 }
 
 fn opencode_mcp_tool_row(event: &JsonValue) -> Option<JsonValue> {
@@ -512,6 +561,20 @@ mod tests {
         assert_eq!(
             trace.rows[1]["params_summary"]["id_or_name"],
             "model.pkg.orders"
+        );
+    }
+
+    #[test]
+    fn provider_trace_attaches_claude_tool_results() {
+        let stdout = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"mcp__dbt_nova__search_indicator","input":{"query":"gmv"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":[{"type":"text","text":"{\"data\":[{\"parent_unique_id\":\"model.pkg.orders\"}]}"}]}]}}"#;
+        let trace = read_provider_tool_trace(stdout);
+        assert_eq!(trace.errors, Vec::<String>::new());
+        assert_eq!(trace.rows.len(), 1);
+        assert_eq!(trace.rows[0]["tool"], "search_indicator");
+        assert_eq!(
+            trace.rows[0]["selected_unique_ids"],
+            json!(["model.pkg.orders"])
         );
     }
 

--- a/src/cli/eval_cmd/provider.rs
+++ b/src/cli/eval_cmd/provider.rs
@@ -13,6 +13,10 @@ use crate::utils::tool_trace::TRACE_ENV;
 
 use super::server_error;
 
+const PROVIDER_MCP_SERVER_ALIASES_ENV: &str = "DBT_NOVA_EVAL_MCP_SERVER_ALIASES";
+const DEFAULT_NOVA_MCP_SERVER_ALIASES: [&str; 5] =
+    ["nova", "dbt-nova", "dbt_nova", "dbtnova", "dbt-nova-mcp"];
+
 #[derive(Debug)]
 pub(super) struct ProviderInvocation {
     pub(super) command: String,
@@ -307,6 +311,9 @@ fn codex_mcp_tool_row(event: &JsonValue) -> Option<JsonValue> {
     if item.get("type").and_then(JsonValue::as_str) != Some("mcp_tool_call") {
         return None;
     }
+    if !is_nova_mcp_server_alias(item.get("server").and_then(JsonValue::as_str)) {
+        return None;
+    }
     let tool = item.get("tool").and_then(JsonValue::as_str)?;
     if !is_nova_tool_name(tool) {
         return None;
@@ -351,18 +358,51 @@ fn opencode_mcp_tool_row(event: &JsonValue) -> Option<JsonValue> {
 }
 
 fn normalize_provider_nova_tool_name(name: &str) -> Option<String> {
-    let candidate = name
-        .strip_prefix("mcp__")
-        .and_then(|suffix| suffix.rsplit_once("__").map(|(_, tool)| tool))
-        .or_else(|| name.rsplit_once("__").map(|(_, tool)| tool))
-        .or_else(|| name.rsplit_once('.').map(|(_, tool)| tool))
-        .unwrap_or(name)
-        .trim();
-    is_nova_tool_name(candidate).then(|| candidate.to_string())
+    let name = name.trim();
+    let (server_alias, tool) = if let Some(suffix) = name.strip_prefix("mcp__") {
+        suffix.rsplit_once("__")?
+    } else if let Some(parts) = name.rsplit_once("__") {
+        parts
+    } else if let Some(parts) = name.rsplit_once('.') {
+        parts
+    } else {
+        return None;
+    };
+    let tool = tool.trim();
+    (is_nova_mcp_server_alias(Some(server_alias)) && is_nova_tool_name(tool))
+        .then(|| tool.to_string())
 }
 
 fn is_nova_tool_name(name: &str) -> bool {
     MCP_TOOL_NAMES.contains(&name)
+}
+
+fn is_nova_mcp_server_alias(alias: Option<&str>) -> bool {
+    let Some(alias) = alias else {
+        return false;
+    };
+    let normalized = normalize_mcp_server_alias(alias);
+    if normalized.is_empty() {
+        return false;
+    }
+    DEFAULT_NOVA_MCP_SERVER_ALIASES
+        .iter()
+        .any(|default_alias| normalize_mcp_server_alias(default_alias) == normalized)
+        || std::env::var(PROVIDER_MCP_SERVER_ALIASES_ENV)
+            .ok()
+            .is_some_and(|configured| {
+                configured
+                    .split([',', ';', ' '])
+                    .any(|entry| normalize_mcp_server_alias(entry) == normalized)
+            })
+}
+
+fn normalize_mcp_server_alias(alias: &str) -> String {
+    alias
+        .chars()
+        .filter(char::is_ascii_alphanumeric)
+        .map(|ch| ch.to_ascii_lowercase())
+        .collect()
 }
 
 fn provider_tool_row(
@@ -551,6 +591,14 @@ mod tests {
     }
 
     #[test]
+    fn provider_trace_rejects_codex_events_from_other_servers() {
+        let stdout = r#"{"type":"item.completed","item":{"type":"mcp_tool_call","server":"other-server","tool":"search","arguments":{"query":"gmv"},"result":{"content":[{"type":"text","text":"{\"data\":[{\"unique_id\":\"model.pkg.orders\"}]}"}]},"error":null,"status":"completed"}}"#;
+        let trace = read_provider_tool_trace(stdout);
+        assert_eq!(trace.errors, Vec::<String>::new());
+        assert!(trace.rows.is_empty());
+    }
+
+    #[test]
     fn provider_trace_reads_claude_mcp_tool_use_events() {
         let stdout = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp__nova__search_indicator","input":{"query":"gmv"}},{"type":"tool_use","name":"mcp__nova__get_context","input":{"id_or_name":"model.pkg.orders"}}]}}"#;
         let trace = read_provider_tool_trace(stdout);
@@ -580,7 +628,7 @@ mod tests {
 
     #[test]
     fn provider_trace_normalizes_custom_mcp_aliases() {
-        let stdout = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp__dbt_nova__search_indicator","input":{"query":"gmv"}},{"type":"tool_use","name":"dbt-nova.get_context","input":{"id_or_name":"model.pkg.orders"}},{"type":"tool_use","name":"other_server.not_a_nova_tool","input":{}}]}}"#;
+        let stdout = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp__dbt_nova__search_indicator","input":{"query":"gmv"}},{"type":"tool_use","name":"dbt-nova.get_context","input":{"id_or_name":"model.pkg.orders"}},{"type":"tool_use","name":"other_server.search","input":{"query":"gmv"}},{"type":"tool_use","name":"other_server.not_a_nova_tool","input":{}}]}}"#;
         let trace = read_provider_tool_trace(stdout);
         assert_eq!(trace.errors, Vec::<String>::new());
         assert_eq!(trace.rows.len(), 2);

--- a/src/cli/eval_cmd/provider.rs
+++ b/src/cli/eval_cmd/provider.rs
@@ -219,6 +219,110 @@ pub(super) fn read_provider_tool_trace(stdout: &str) -> ToolTraceRead {
     }
 }
 
+pub(super) fn read_provider_final_answer(stdout: &str) -> Option<String> {
+    let mut assistant_parts = Vec::new();
+    let mut result_parts = Vec::new();
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || !trimmed.starts_with('{') {
+            continue;
+        }
+        let Ok(event) = serde_json::from_str::<JsonValue>(trimmed) else {
+            continue;
+        };
+        collect_provider_final_answer_event(&event, &mut assistant_parts, &mut result_parts);
+    }
+    join_provider_text_parts(&result_parts).or_else(|| join_provider_text_parts(&assistant_parts))
+}
+
+fn collect_provider_final_answer_event(
+    event: &JsonValue,
+    assistant_parts: &mut Vec<String>,
+    result_parts: &mut Vec<String>,
+) {
+    if event.get("type").and_then(JsonValue::as_str) == Some("result") {
+        collect_provider_text_content(event.get("result").unwrap_or(event), result_parts);
+        return;
+    }
+    if event.get("type").and_then(JsonValue::as_str) == Some("assistant")
+        && let Some(message) = event.get("message")
+    {
+        collect_provider_text_content(message, assistant_parts);
+        return;
+    }
+    if provider_role(event) == Some("assistant") {
+        collect_provider_text_content(event, assistant_parts);
+        return;
+    }
+    if let Some(message) = event.get("message")
+        && provider_role(message) == Some("assistant")
+    {
+        collect_provider_text_content(message, assistant_parts);
+        return;
+    }
+    if let Some(item) = event.get("item")
+        && provider_role(item) == Some("assistant")
+    {
+        collect_provider_text_content(item, assistant_parts);
+        return;
+    }
+    if let Some("assistant_message" | "agent_message") =
+        event.get("type").and_then(JsonValue::as_str)
+    {
+        collect_provider_text_content(event, assistant_parts);
+    }
+}
+
+fn provider_role(value: &JsonValue) -> Option<&str> {
+    value.get("role").and_then(JsonValue::as_str)
+}
+
+fn collect_provider_text_content(value: &JsonValue, out: &mut Vec<String>) {
+    match value {
+        JsonValue::Object(map) => {
+            if matches!(
+                map.get("type").and_then(JsonValue::as_str),
+                Some("tool_use" | "tool_result" | "mcp_tool_call")
+            ) {
+                return;
+            }
+            for key in ["text", "output_text"] {
+                if let Some(text) = map.get(key).and_then(JsonValue::as_str)
+                    && !text.trim().is_empty()
+                {
+                    out.push(text.to_owned());
+                }
+            }
+            for key in ["content", "parts", "message", "messages"] {
+                if let Some(child) = map.get(key) {
+                    collect_provider_text_content(child, out);
+                }
+            }
+        }
+        JsonValue::Array(items) => {
+            for item in items {
+                collect_provider_text_content(item, out);
+            }
+        }
+        JsonValue::String(text) => {
+            if !text.trim().is_empty() {
+                out.push(text.clone());
+            }
+        }
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) => {}
+    }
+}
+
+fn join_provider_text_parts(parts: &[String]) -> Option<String> {
+    let joined = parts
+        .iter()
+        .map(|part| part.trim())
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+    (!joined.is_empty()).then_some(joined)
+}
+
 #[derive(Default)]
 struct ProviderTraceState {
     rows: Vec<JsonValue>,
@@ -496,7 +600,7 @@ mod tests {
 
     use serde_json::json;
 
-    use super::{provider_invocation, read_provider_tool_trace};
+    use super::{provider_invocation, read_provider_final_answer, read_provider_tool_trace};
     use crate::cli::args::EvalAgentRunArgs;
 
     #[test]
@@ -639,5 +743,32 @@ mod tests {
         assert_eq!(trace.rows.len(), 2);
         assert_eq!(trace.rows[0]["tool"], "search_indicator");
         assert_eq!(trace.rows[1]["tool"], "get_context");
+    }
+
+    #[test]
+    fn provider_final_answer_reads_claude_result_event() {
+        let stdout = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"mcp__nova__search","input":{"query":"prompt-only term"}}]}}
+{"type":"result","subtype":"success","result":"Final answer uses model.pkg.orders only."}"#;
+        let final_answer = read_provider_final_answer(stdout).expect("final answer");
+        assert_eq!(final_answer, "Final answer uses model.pkg.orders only.");
+        assert!(!final_answer.contains("prompt-only term"));
+    }
+
+    #[test]
+    fn provider_final_answer_reads_codex_completed_assistant_message() {
+        let stdout = r#"{"type":"item.completed","item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Use gross merchandise value from model.pkg.orders."}]}}"#;
+        let final_answer = read_provider_final_answer(stdout).expect("final answer");
+        assert_eq!(
+            final_answer,
+            "Use gross merchandise value from model.pkg.orders."
+        );
+    }
+
+    #[test]
+    fn provider_final_answer_ignores_tool_payload_text() {
+        let stdout = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"mcp__nova__search","input":{"query":"must not leak"}}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Clean final answer."}]}}"#;
+        let final_answer = read_provider_final_answer(stdout).expect("final answer");
+        assert_eq!(final_answer, "Clean final answer.");
     }
 }

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -154,6 +154,29 @@ fn validate_suite_rejects_case_insensitive_artifact_segment_collisions() {
 }
 
 #[test]
+fn validate_suite_rejects_vacuous_search_columns_rank_assertion() {
+    let suite = EvalSuite {
+        version: 1,
+        name: None,
+        defaults: EvalDefaults::default(),
+        cases: vec![super::EvalCase {
+            id: "columns".to_string(),
+            question: None,
+            persona: None,
+            assertions: vec![super::EvalAssertion::SearchColumnsRank {
+                query: "revenue".to_string(),
+                expected_column: None,
+                expected_parent_unique_id: None,
+                max_rank: None,
+            }],
+        }],
+        agent_cases: Vec::new(),
+    };
+    let error = validate_suite(&suite).expect_err("vacuous column rank should fail");
+    assert!(error.to_string().contains("expected_column"));
+}
+
+#[test]
 fn safe_path_segment_blocks_dot_segments_and_caps_length() {
     assert_eq!(safe_path_segment("."), "eval");
     assert_eq!(safe_path_segment(".."), "eval");

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -1,0 +1,139 @@
+use serde_json::json;
+use tempfile::NamedTempFile;
+
+use super::{
+    AgentExpected, AgentOrder, AssertionResult, EvalCaseReport, EvalDefaults, EvalSuite,
+    FinalAnswerExpected, contains_rank_assertion, json_has_field_path, read_tool_trace,
+    safe_path_segment, score_agent_expectations, validate_suite,
+};
+
+#[test]
+fn field_path_checks_nested_response() {
+    let response = json!({"data": {"name": "orders", "nested": {"value": 1}}});
+    assert!(json_has_field_path(&response, "data.name"));
+    assert!(json_has_field_path(&response, "data.nested.value"));
+    assert!(!json_has_field_path(&response, "data.missing"));
+}
+
+#[test]
+fn contains_rank_assertion_respects_max_rank() {
+    let response = json!({
+        "data": [
+            {"unique_id": "model.pkg.other"},
+            {"unique_id": "model.pkg.orders"}
+        ]
+    });
+    let result = contains_rank_assertion("search_indicator_rank", &response, "orders", Some(1));
+    assert_eq!(result.status, "fail");
+}
+
+#[test]
+fn agent_expectations_score_tool_trace() {
+    let trace = vec![
+        json!({"tool": "search_indicator", "selected_unique_ids": ["model.pkg.orders"]}),
+        json!({"tool": "get_context", "selected_unique_ids": ["model.pkg.orders"]}),
+    ];
+    let expected = AgentExpected {
+        must_call: vec!["search_indicator".to_string(), "get_context".to_string()],
+        must_not_call: vec!["execute_sql".to_string()],
+        ordered: vec![AgentOrder {
+            before: "get_context".to_string(),
+            must_have_called: vec!["search_indicator".to_string()],
+        }],
+        selected_entities: vec!["model.pkg.orders".to_string()],
+        final_answer: Some(FinalAnswerExpected {
+            must_contain: vec!["gmv".to_string()],
+            must_not_contain: vec!["secret".to_string()],
+        }),
+    };
+    let results = score_agent_expectations(&expected, &trace, "GMV uses model.pkg.orders");
+    assert!(results.iter().all(|result| result.status == "pass"));
+}
+
+#[test]
+fn case_report_counts_statuses() {
+    let report = EvalCaseReport::new(
+        "case".to_string(),
+        None,
+        vec![
+            AssertionResult::pass("a", "ok", json!({})),
+            AssertionResult::fail("b", "bad", json!({})),
+            AssertionResult::error("c", "err"),
+        ],
+        None,
+    );
+    assert_eq!(report.pass_count, 1);
+    assert_eq!(report.fail_count, 1);
+    assert_eq!(report.error_count, 1);
+}
+
+#[test]
+fn read_tool_trace_reports_parse_errors() {
+    let file = NamedTempFile::new().expect("temp file");
+    std::fs::write(
+        file.path(),
+        "{\"tool\":\"search\"}\nnot-json\n{\"tool\":\"get_context\"}\n",
+    )
+    .expect("write trace");
+    let trace = read_tool_trace(file.path());
+    assert_eq!(trace.rows.len(), 2);
+    assert_eq!(trace.errors.len(), 1);
+    assert!(!trace.missing);
+}
+
+#[test]
+fn validate_suite_rejects_duplicate_agent_case_ids() {
+    let suite = EvalSuite {
+        version: 1,
+        name: None,
+        defaults: EvalDefaults::default(),
+        cases: Vec::new(),
+        agent_cases: vec![
+            super::AgentCase {
+                id: "same".to_string(),
+                task: "one".to_string(),
+                expected: AgentExpected::default(),
+            },
+            super::AgentCase {
+                id: "same".to_string(),
+                task: "two".to_string(),
+                expected: AgentExpected::default(),
+            },
+        ],
+    };
+    let error = validate_suite(&suite).expect_err("duplicate id should fail");
+    assert!(error.to_string().contains("duplicate eval case id"));
+}
+
+#[test]
+fn validate_suite_rejects_duplicate_artifact_segments() {
+    let suite = EvalSuite {
+        version: 1,
+        name: None,
+        defaults: EvalDefaults::default(),
+        cases: Vec::new(),
+        agent_cases: vec![
+            super::AgentCase {
+                id: "a/b".to_string(),
+                task: "one".to_string(),
+                expected: AgentExpected::default(),
+            },
+            super::AgentCase {
+                id: "a b".to_string(),
+                task: "two".to_string(),
+                expected: AgentExpected::default(),
+            },
+        ],
+    };
+    let error = validate_suite(&suite).expect_err("artifact path collision should fail");
+    assert!(error.to_string().contains("artifact paths"));
+}
+
+#[test]
+fn safe_path_segment_blocks_dot_segments_and_caps_length() {
+    assert_eq!(safe_path_segment("."), "eval");
+    assert_eq!(safe_path_segment(".."), "eval");
+    assert_eq!(safe_path_segment("../secret"), "secret");
+    assert_eq!(safe_path_segment("a/b"), "a-b");
+    assert!(safe_path_segment(&"x".repeat(200)).len() <= 120);
+}

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -130,6 +130,30 @@ fn validate_suite_rejects_duplicate_artifact_segments() {
 }
 
 #[test]
+fn validate_suite_rejects_case_insensitive_artifact_segment_collisions() {
+    let suite = EvalSuite {
+        version: 1,
+        name: None,
+        defaults: EvalDefaults::default(),
+        cases: Vec::new(),
+        agent_cases: vec![
+            super::AgentCase {
+                id: "RevenueFlow".to_string(),
+                task: "one".to_string(),
+                expected: AgentExpected::default(),
+            },
+            super::AgentCase {
+                id: "revenueflow".to_string(),
+                task: "two".to_string(),
+                expected: AgentExpected::default(),
+            },
+        ],
+    };
+    let error = validate_suite(&suite).expect_err("case-insensitive collision should fail");
+    assert!(error.to_string().contains("case-insensitively"));
+}
+
+#[test]
 fn safe_path_segment_blocks_dot_segments_and_caps_length() {
     assert_eq!(safe_path_segment("."), "eval");
     assert_eq!(safe_path_segment(".."), "eval");

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,6 +7,7 @@ use crate::utils::{dir_in_use, prune_dirs};
 pub mod args;
 pub mod audit_cmd;
 pub mod config_cmd;
+pub mod eval_cmd;
 pub mod health_cmd;
 pub mod manifest;
 pub mod nova_meta_cmd;
@@ -79,6 +80,15 @@ pub async fn dispatch(command: args::Command) -> DispatchResult {
             args::HealthCommand::Check(check_args) => {
                 health_cmd::run_check_command(&check_args).await
             }
+        },
+        args::Command::Eval(eval_args) => match eval_args.command {
+            args::EvalCommand::Init(init_args) => eval_cmd::run_init_command(&init_args),
+            args::EvalCommand::Run(run_args) => eval_cmd::run_eval_command(&run_args).await,
+            args::EvalCommand::Agent(agent_args) => match agent_args.command {
+                args::EvalAgentCommand::Run(run_args) => {
+                    eval_cmd::run_agent_eval_command(&run_args).await
+                }
+            },
         },
     }
 }

--- a/src/cli/tool.rs
+++ b/src/cli/tool.rs
@@ -184,14 +184,39 @@ pub async fn run_call_command(args: &ToolCallArgs) -> DispatchResult {
     }
     let params = resolve_params_value(args)
         .map_err(|error| render_or_propagate_error(args, error, started.elapsed().as_millis()))?;
+    let trace_params = params.clone();
     let config = build_manifest_load_config(&manifest_load_args_from_tool_args(args))
         .map_err(|error| render_or_propagate_error(args, error, started.elapsed().as_millis()))?;
     let load_result = execute_manifest_load(config)
         .await
         .map_err(|error| render_or_propagate_error(args, error, started.elapsed().as_millis()))?;
-    let result = dispatch_tool(&load_result.search, &args.tool_name, params)
-        .await
-        .map_err(|error| render_or_propagate_error(args, error, started.elapsed().as_millis()))?;
+    let result = match dispatch_tool(&load_result.search, &args.tool_name, params).await {
+        Ok(result) => result,
+        Err(error) => {
+            let trace_error = trace_error_response(&error);
+            crate::utils::tool_trace::record_tool_call(
+                "cli",
+                &args.tool_name,
+                Some(&trace_params),
+                Some(&trace_error),
+                false,
+                elapsed_ms_to_u64(started.elapsed()),
+            );
+            return Err(render_or_propagate_error(
+                args,
+                error,
+                started.elapsed().as_millis(),
+            ));
+        }
+    };
+    crate::utils::tool_trace::record_tool_call(
+        "cli",
+        &args.tool_name,
+        Some(&trace_params),
+        Some(&result),
+        true,
+        elapsed_ms_to_u64(started.elapsed()),
+    );
 
     if args.json {
         let envelope = CliEnvelope::success(
@@ -217,6 +242,7 @@ pub async fn run_call_command(args: &ToolCallArgs) -> DispatchResult {
 async fn run_reload_manifest_tool_call(args: &ToolCallArgs, started: Instant) -> DispatchResult {
     let params = resolve_params_value(args)
         .map_err(|error| render_or_propagate_error(args, error, started.elapsed().as_millis()))?;
+    let trace_params = params.clone();
     let reload_params: ReloadManifestParams = decode_tool_params("reload_manifest", params)
         .map_err(|error| render_or_propagate_error(args, error, started.elapsed().as_millis()))?;
     let reload_args = build_reload_args_from_tool_call(args, &reload_params);
@@ -242,6 +268,14 @@ async fn run_reload_manifest_tool_call(args: &ToolCallArgs, started: Instant) ->
             started.elapsed().as_millis(),
         )
     })?;
+    crate::utils::tool_trace::record_tool_call(
+        "cli",
+        &args.tool_name,
+        Some(&trace_params),
+        Some(&result),
+        true,
+        elapsed_ms_to_u64(started.elapsed()),
+    );
 
     if args.json {
         let envelope = CliEnvelope::success(
@@ -326,6 +360,14 @@ fn render_or_propagate_error(
         error,
         rendered: false,
     }
+}
+
+fn trace_error_response(error: &DbtNovaError) -> JsonValue {
+    serde_json::json!({
+        "success": false,
+        "error": error.to_string(),
+        "error_code": error.error_code(),
+    })
 }
 
 fn manifest_load_args_from_tool_args(args: &ToolCallArgs) -> ManifestLoadArgs {
@@ -427,13 +469,17 @@ fn resolve_tool_entry(tool_name: &str) -> Result<ToolRegistryEntry> {
         })
 }
 
-async fn dispatch_tool(
+pub(crate) async fn dispatch_tool(
     searcher: &ManifestSearch,
     tool_name: &str,
     params: JsonValue,
 ) -> Result<JsonValue> {
     let entry = resolve_tool_entry(tool_name)?;
     (entry.dispatch)(searcher, params).await
+}
+
+fn elapsed_ms_to_u64(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
 macro_rules! typed_dispatch {

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -132,7 +132,17 @@ impl DbtNovaServer {
             Ok(searcher) => searcher,
             Err(err) => {
                 let out = Self::error_response(&err);
-                self.record_metrics(tool, persona, elapsed_ms_to_u64(start.elapsed()), success);
+                let duration_ms = elapsed_ms_to_u64(start.elapsed());
+                let parsed_trace_response = serde_json::from_str::<serde_json::Value>(&out).ok();
+                crate::utils::tool_trace::record_tool_call(
+                    "mcp",
+                    tool,
+                    None,
+                    parsed_trace_response.as_ref(),
+                    success,
+                    duration_ms,
+                );
+                self.record_metrics(tool, persona, duration_ms, success);
                 return out;
             }
         };
@@ -144,7 +154,17 @@ impl DbtNovaServer {
                 "error_code": "RATE_LIMITED",
             })
             .to_string();
-            self.record_metrics(tool, persona, elapsed_ms_to_u64(start.elapsed()), success);
+            let duration_ms = elapsed_ms_to_u64(start.elapsed());
+            let parsed_trace_response = serde_json::from_str::<serde_json::Value>(&out).ok();
+            crate::utils::tool_trace::record_tool_call(
+                "mcp",
+                tool,
+                None,
+                parsed_trace_response.as_ref(),
+                success,
+                duration_ms,
+            );
+            self.record_metrics(tool, persona, duration_ms, success);
             return out;
         }
 
@@ -158,7 +178,17 @@ impl DbtNovaServer {
             },
             Err(e) => Self::error_response(&e),
         };
-        self.record_metrics(tool, persona, elapsed_ms_to_u64(start.elapsed()), success);
+        let duration_ms = elapsed_ms_to_u64(start.elapsed());
+        let parsed_trace_response = serde_json::from_str::<serde_json::Value>(&out).ok();
+        crate::utils::tool_trace::record_tool_call(
+            "mcp",
+            tool,
+            None,
+            parsed_trace_response.as_ref(),
+            success,
+            duration_ms,
+        );
+        self.record_metrics(tool, persona, duration_ms, success);
         out
     }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,7 @@ pub mod metrics;
 pub mod persona;
 pub mod storage;
 pub mod string;
+pub mod tool_trace;
 
 pub use circuit_breaker::{CircuitBreaker, CircuitBreakerState};
 pub use gcp_auth::{

--- a/src/utils/tool_trace.rs
+++ b/src/utils/tool_trace.rs
@@ -1,0 +1,276 @@
+use std::collections::BTreeSet;
+use std::fs::{OpenOptions, create_dir_all};
+use std::io::Write;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+use serde_json::{Value, json};
+use tracing::warn;
+
+pub const TRACE_ENV: &str = "DBT_NOVA_TRACE_TOOL_CALLS_PATH";
+const MAX_PARAM_KEYS: usize = 50;
+const MAX_ARRAY_ITEMS: usize = 20;
+const MAX_SUMMARY_STRING_CHARS: usize = 256;
+const MAX_SELECTED_UNIQUE_IDS: usize = 200;
+const MAX_UNIQUE_ID_CHARS: usize = 512;
+
+#[derive(Debug, Serialize)]
+struct ToolTraceRow {
+    timestamp_ms: u128,
+    transport: String,
+    tool: String,
+    success: bool,
+    duration_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    params_summary: Option<Value>,
+    selected_unique_ids: Vec<String>,
+}
+
+/// Append a sanitized tool-call trace row when `DBT_NOVA_TRACE_TOOL_CALLS_PATH` is set.
+pub fn record_tool_call(
+    transport: &str,
+    tool: &str,
+    params: Option<&Value>,
+    response: Option<&Value>,
+    success: bool,
+    duration_ms: u64,
+) {
+    let Ok(path) = std::env::var(TRACE_ENV) else {
+        return;
+    };
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+
+    let trace_path = Path::new(trimmed);
+    if let Some(parent) = trace_path.parent()
+        && !parent.as_os_str().is_empty()
+        && let Err(error) = create_dir_all(parent)
+    {
+        warn!(path = %parent.display(), error = %error, "failed to create tool trace directory");
+        return;
+    }
+
+    let row = ToolTraceRow {
+        timestamp_ms: timestamp_ms(),
+        transport: transport.to_string(),
+        tool: tool.to_string(),
+        success,
+        duration_ms,
+        error_code: response.and_then(extract_error_code),
+        params_summary: params.map(summarize_params),
+        selected_unique_ids: response.map(extract_unique_ids).unwrap_or_default(),
+    };
+
+    let serialized = match serde_json::to_string(&row) {
+        Ok(serialized) => serialized,
+        Err(error) => {
+            warn!(error = %error, "failed to serialize tool trace row");
+            return;
+        }
+    };
+
+    match OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(trace_path)
+    {
+        Ok(mut file) => {
+            if let Err(error) = writeln!(file, "{serialized}") {
+                warn!(path = %trace_path.display(), error = %error, "failed to write tool trace row");
+            }
+        }
+        Err(error) => {
+            warn!(path = %trace_path.display(), error = %error, "failed to open tool trace file");
+        }
+    }
+}
+
+fn summarize_params(params: &Value) -> Value {
+    let Some(map) = params.as_object() else {
+        return json!({"type": params_type(params)});
+    };
+
+    let keys: Vec<Value> = map
+        .keys()
+        .take(MAX_PARAM_KEYS)
+        .map(|key| Value::String(truncate_string(key, MAX_SUMMARY_STRING_CHARS)))
+        .collect();
+    let mut summary = serde_json::Map::from_iter([(String::from("keys"), Value::Array(keys))]);
+    for key in [
+        "query",
+        "persona",
+        "id_or_name",
+        "resource_type",
+        "resource_types",
+        "recipe_id",
+        "direction",
+        "limit",
+        "offset",
+    ] {
+        if let Some(value) = map.get(key).and_then(summarize_safe_value) {
+            summary.insert(key.to_string(), value);
+        }
+    }
+    Value::Object(summary)
+}
+
+fn summarize_safe_value(value: &Value) -> Option<Value> {
+    match value {
+        Value::Null | Value::Bool(_) | Value::Number(_) => Some(value.clone()),
+        Value::String(value) => Some(Value::String(truncate_string(
+            value,
+            MAX_SUMMARY_STRING_CHARS,
+        ))),
+        Value::Array(items) => Some(Value::Array(
+            items
+                .iter()
+                .take(MAX_ARRAY_ITEMS)
+                .filter_map(summarize_safe_array_value)
+                .collect(),
+        )),
+        Value::Object(_) => None,
+    }
+}
+
+fn summarize_safe_array_value(value: &Value) -> Option<Value> {
+    match value {
+        Value::Null | Value::Bool(_) | Value::Number(_) => Some(value.clone()),
+        Value::String(value) => Some(Value::String(truncate_string(
+            value,
+            MAX_SUMMARY_STRING_CHARS,
+        ))),
+        Value::Array(_) | Value::Object(_) => None,
+    }
+}
+
+fn truncate_string(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
+}
+
+fn params_type(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn extract_error_code(response: &Value) -> Option<String> {
+    response
+        .get("error_code")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            response
+                .get("error")
+                .and_then(|error| error.get("error_code"))
+                .and_then(Value::as_str)
+        })
+        .map(ToString::to_string)
+}
+
+fn extract_unique_ids(response: &Value) -> Vec<String> {
+    let mut out = BTreeSet::new();
+    collect_unique_ids(response, &mut out);
+    out.into_iter().collect()
+}
+
+fn collect_unique_ids(value: &Value, out: &mut BTreeSet<String>) {
+    match value {
+        Value::Object(map) => {
+            if out.len() >= MAX_SELECTED_UNIQUE_IDS {
+                return;
+            }
+            for key in ["unique_id", "parent_unique_id", "root_id"] {
+                if let Some(id) = map.get(key).and_then(Value::as_str)
+                    && !id.trim().is_empty()
+                {
+                    out.insert(truncate_string(id, MAX_UNIQUE_ID_CHARS));
+                    if out.len() >= MAX_SELECTED_UNIQUE_IDS {
+                        return;
+                    }
+                }
+            }
+            for child in map.values() {
+                if out.len() >= MAX_SELECTED_UNIQUE_IDS {
+                    return;
+                }
+                collect_unique_ids(child, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                if out.len() >= MAX_SELECTED_UNIQUE_IDS {
+                    return;
+                }
+                collect_unique_ids(item, out);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+fn timestamp_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_millis())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{MAX_SELECTED_UNIQUE_IDS, extract_unique_ids, summarize_params};
+
+    #[test]
+    fn summarize_params_keeps_only_safe_context() {
+        let summary = summarize_params(&json!({
+            "query": "gmv",
+            "parameters": {"token": "secret"},
+            "limit": 5
+        }));
+        assert_eq!(summary["query"], "gmv");
+        assert_eq!(summary["limit"], 5);
+        assert!(summary.get("parameters").is_none());
+    }
+
+    #[test]
+    fn summarize_params_drops_nested_values_from_safe_arrays() {
+        let summary = summarize_params(&json!({
+            "resource_types": ["model", {"token": "secret"}]
+        }));
+        assert_eq!(summary["resource_types"], json!(["model"]));
+    }
+
+    #[test]
+    fn extract_unique_ids_finds_nested_ids() {
+        let ids = extract_unique_ids(&json!({
+            "data": [{"unique_id": "model.pkg.orders", "parent_unique_id": "model.pkg.parent"}],
+            "root_id": "model.pkg.root"
+        }));
+        assert_eq!(
+            ids,
+            vec![
+                "model.pkg.orders".to_string(),
+                "model.pkg.parent".to_string(),
+                "model.pkg.root".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_unique_ids_caps_large_responses() {
+        let data: Vec<_> = (0..(MAX_SELECTED_UNIQUE_IDS + 5))
+            .map(|index| json!({"unique_id": format!("model.pkg.entity_{index}")}))
+            .collect();
+        let ids = extract_unique_ids(&json!({"data": data}));
+        assert_eq!(ids.len(), MAX_SELECTED_UNIQUE_IDS);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `dbt-nova eval init/run` for bridge eval suites and `dbt-nova eval agent run` for provider-backed agent evals.
- Add sanitized CLI/MCP tool-call traces plus provider JSON-event fallback parsing for Codex, Claude, OpenCode, Goose, and custom commands.
- Add eval reports, documentation, changelog coverage, and CLI docs for the new workflow.

## Validation
- `git diff --check`
- `cargo fmt --check`
- `cargo test --locked --lib eval_cmd`
- `uv run mkdocs build --strict`

Additional pre-PR audit on this branch also passed `cargo clippy --locked --all-targets --all-features -- -D warnings`, `cargo test --locked --all-features --lib --bins`, `cargo build --release --locked`, and a Unified manifest bridge smoke test.
