### PR TITLE
Harden Nova eval workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `dbt-nova eval` commands for manifest bridge evals and provider-backed
   agent evals, including sanitized CLI/MCP tool-call tracing, YAML/JSON suite
   definitions, score gates, and JSON/TSV/Markdown report artifacts.
+- Added `dbt-nova eval validate`, repeatable `--case-id` filters for bridge and
+  agent eval runs, value-aware context assertions, agent `called_with` and
+  ranked entity expectations, and ordered `top_unique_ids` trace evidence.
 
 ### Fixed
 
+- Eval `tool_success` assertions now fail when a tool returns an explicit
+  `success: false` response instead of treating any successful dispatch as a
+  passing tool result.
 - Agent evals now score Codex/Claude/OpenCode MCP tool calls from provider JSON
   event streams when a local dbt-nova trace file is empty, including MCP servers
   configured with aliases such as `dbt-nova` instead of `nova`, and Claude

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -43,6 +43,12 @@ cases:
           - data.entity.name
 ```
 
+Validate suite shape before running against a manifest or provider:
+
+```bash
+dbt-nova eval validate --suite evals/analyst-smoke.yml
+```
+
 ## Run Bridge Evals
 
 ```bash
@@ -52,6 +58,9 @@ dbt-nova eval run \
   --fail-under 1.0 \
   --json
 ```
+
+Use repeatable `--case-id <ID>` to run only specific bridge cases while
+debugging a suite.
 
 Outputs are written to `.nova/eval-runs/<timestamp>-<suite>-bridge/` by default:
 
@@ -66,11 +75,30 @@ Bridge assertions currently support:
 - `search_indicator_rank`
 - `search_columns_rank`
 - `context_has`
+- `context_field_equals`
+- `context_contains`
 - `metadata_score_min`
 - `recipe_rank`
 - `recipe_has_queries`
 - `lineage_contains`
 - `tool_success`
+
+`context_has` checks that field paths are present and non-null.
+`context_field_equals` compares a field path to an exact JSON value.
+`context_contains` checks that expected text appears either anywhere in context
+or inside a specific field:
+
+```yaml
+assertions:
+  - type: context_field_equals
+    id_or_name: model.pkg.orders
+    field: data.entity.name
+    expected: orders
+  - type: context_contains
+    id_or_name: model.pkg.orders
+    field: data.entity.description
+    expected: canonical orders
+```
 
 ## Run Agent Evals
 
@@ -102,10 +130,26 @@ agent_cases:
             - search_indicator
       selected_entities:
         - model.pkg.orders
+      selected_entity_ranks:
+        - unique_id: model.pkg.orders
+          tool: search_indicator
+          max_rank: 3
+      called_with:
+        - tool: search_indicator
+          contains:
+            query: gross merchandise
       final_answer:
         must_contain:
           - gross merchandise value
 ```
+
+`selected_entities` checks that an entity appeared anywhere in tool evidence.
+`selected_entity_ranks` checks the ordered top entities captured from tool
+responses and can be scoped to a specific tool. `called_with.params` matches
+sanitized parameter values exactly where possible, while `called_with.contains`
+checks case-insensitive substring matches against sanitized parameter summaries.
+`called_with.params` supports only scalar values or arrays of scalar values
+because trace rows intentionally drop nested objects.
 
 Run against the default `opencode` adapter:
 
@@ -118,6 +162,9 @@ dbt-nova eval agent run \
   --fail-under 0.9
 ```
 
+Use repeatable `--case-id <ID>` to run only specific agent cases while
+debugging provider behavior.
+
 Supported provider presets are `opencode`, `codex`, `claude`, and `goose`.
 Presets use each CLI's normal project/user configuration; dbt-nova injects
 `DBT_MANIFEST_PATH`, `DBT_NOVA_STORAGE_INSTANCE_ID`, and
@@ -125,7 +172,10 @@ Presets use each CLI's normal project/user configuration; dbt-nova injects
 tool servers inherit the eval manifest and trace path. Remote hosted MCP
 endpoints cannot inherit local trace environment variables, so use a provider
 that emits MCP calls in its JSON output or keep the Nova server local when
-asserting tool-use traces.
+asserting tool-use traces. Provider stdout fallback parsing is implemented for
+Codex, Claude, and OpenCode event streams; Goose is supported as a provider
+preset and should be used with local trace inheritance unless its JSON stream is
+wrapped into one of the supported event shapes.
 
 `final_answer` assertions are matched against extracted assistant final text
 from provider JSON event streams. For custom providers that do not emit JSON
@@ -161,6 +211,8 @@ rows for CLI, MCP, and eval tool calls. Rows include:
 - safe parameter summaries such as `query`, `persona`, `id_or_name`, and
   `resource_types`
 - `selected_unique_ids` extracted from the response
+- `top_unique_ids` preserving the ordered top response entities where Nova can
+  infer them
 
 Trace rows deliberately do not record SQL recipe parameter maps or credential
 values. Keep eval artifacts out of public bug reports unless you have reviewed
@@ -171,6 +223,8 @@ them for project-specific identifiers.
 Use bridge evals as a fast metadata quality gate after producing a manifest:
 
 ```bash
+dbt-nova eval validate --suite evals/analyst-smoke.yml
+
 dbt-nova eval run \
   --suite evals/analyst-smoke.yml \
   --manifest-path target/manifest.json \

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -4,7 +4,7 @@ Use `dbt-nova` in two modes:
 
 - No subcommand: start MCP server (backward compatible behavior)
 - Subcommand: run one-shot CLI commands and exit
-- CLI surface: `15` CLI-only leaf commands, plus `tool call` access to all `33` MCP tools
+- CLI surface: `16` CLI-only leaf commands, plus `tool call` access to all `33` MCP tools
 
 ## Command Tree
 
@@ -23,8 +23,9 @@ dbt-nova
 ├── storage prune [--max-keep] [--max-bytes] [--storage-instance-id] [--json]
 ├── storage cleanup [--storage-instance-id] [--json]
 ├── eval init --out <PATH> [--persona] [--force]
-├── eval run --suite <PATH> [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
-├── eval agent run --suite <PATH> [--provider] [--provider-command] [--provider-args-json] [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--timeout-secs] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
+├── eval validate --suite <PATH> [--json]
+├── eval run --suite <PATH> [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--case-id <ID>...] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
+├── eval agent run --suite <PATH> [--provider] [--provider-command] [--provider-args-json] [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--case-id <ID>...] [--timeout-secs] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
 └── health check [--manifest-path|--manifest-uri] [--json]
 ```
 
@@ -181,6 +182,7 @@ dbt-nova audit nova-meta \
 
 ```bash
 dbt-nova eval init --persona analyst --out evals/analyst-smoke.yml
+dbt-nova eval validate --suite evals/analyst-smoke.yml
 
 dbt-nova eval run \
   --suite evals/analyst-smoke.yml \

--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -18,6 +18,8 @@ Use `dbt-nova eval run` to test that a manifest exposes the right search,
 indicator, context, lineage, recipe, and metadata-score evidence to agents:
 
 ```bash
+dbt-nova eval validate --suite evals/analyst-smoke.yml
+
 dbt-nova eval run \
   --suite evals/analyst-smoke.yml \
   --manifest-path target/manifest.json \
@@ -42,6 +44,8 @@ scores required tool calls, forbidden tool calls, order constraints, selected
 entities, and final-answer text checks from sanitized local trace rows. When a
 remote hosted MCP endpoint cannot inherit `DBT_NOVA_TRACE_TOOL_CALLS_PATH`,
 supported provider presets can also score MCP calls from JSON event streams.
+Use `--case-id <ID>` on bridge or agent eval runs to iterate on one failing case
+without re-running the whole suite.
 
 ## Test Storage Cleanup
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -339,40 +339,83 @@ pub struct EvalArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum EvalCommand {
+    /// Write a starter eval suite.
     Init(EvalInitArgs),
+    /// Run deterministic Nova tool assertions against a manifest.
     Run(EvalRunArgs),
+    /// Run provider-backed agent evals and score observed Nova tool use.
     Agent(EvalAgentArgs),
+    /// Validate an eval suite without loading a manifest or running a provider.
+    Validate(EvalValidateArgs),
 }
 
 #[derive(Debug, Clone, Args, Default)]
 pub struct EvalInitArgs {
-    #[arg(long, value_name = "PERSONA", default_value = "analyst")]
+    #[arg(
+        long,
+        value_name = "PERSONA",
+        default_value = "analyst",
+        help = "Persona to use in the generated starter suite"
+    )]
     pub persona: String,
-    #[arg(long, value_name = "PATH")]
+    #[arg(long, value_name = "PATH", help = "Path to write the suite YAML")]
     pub out: String,
-    #[arg(long, default_value_t = false)]
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Overwrite an existing suite file"
+    )]
     pub force: bool,
 }
 
 #[derive(Debug, Clone, Args, Default)]
 pub struct EvalRunArgs {
-    #[arg(long, value_name = "PATH")]
+    #[arg(long, value_name = "PATH", help = "YAML or JSON eval suite path")]
     pub suite: String,
-    #[arg(long, value_name = "PATH", conflicts_with = "manifest_uri")]
+    #[arg(
+        long,
+        value_name = "PATH",
+        conflicts_with = "manifest_uri",
+        help = "Local dbt manifest.json path"
+    )]
     pub manifest_path: Option<String>,
-    #[arg(long, value_name = "URI", conflicts_with = "manifest_path")]
+    #[arg(
+        long,
+        value_name = "URI",
+        conflicts_with = "manifest_path",
+        help = "Remote manifest or prebuilt artifact URI"
+    )]
     pub manifest_uri: Option<String>,
-    #[arg(long, value_name = "INSTANCE_ID")]
+    #[arg(
+        long,
+        value_name = "INSTANCE_ID",
+        help = "Storage instance id for cached Nova assets"
+    )]
     pub storage_instance_id: Option<String>,
-    #[arg(long, value_name = "DIR")]
+    #[arg(long, value_name = "DIR", help = "Directory for eval result artifacts")]
     pub output_dir: Option<String>,
-    #[arg(long, value_name = "FLOAT")]
+    #[arg(
+        long = "case-id",
+        value_name = "ID",
+        action = ArgAction::Append,
+        help = "Only run the named bridge case; repeat for multiple cases"
+    )]
+    pub case_ids: Vec<String>,
+    #[arg(
+        long,
+        value_name = "FLOAT",
+        help = "Required pass rate between 0.0 and 1.0"
+    )]
     pub fail_under: Option<f64>,
-    #[arg(long, default_value_t = false)]
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Clear the selected storage instance before loading"
+    )]
     pub cleanup_storage_on_start: bool,
-    #[arg(long, default_value_t = false)]
+    #[arg(long, default_value_t = false, help = "Open storage in read-only mode")]
     pub read_only: bool,
-    #[arg(long, default_value_t = false)]
+    #[arg(long, default_value_t = false, help = "Emit a JSON CLI envelope")]
     pub json: bool,
 }
 
@@ -384,36 +427,92 @@ pub struct EvalAgentArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum EvalAgentCommand {
+    /// Run provider-backed agent evals and score observed Nova tool use.
     Run(EvalAgentRunArgs),
 }
 
 #[derive(Debug, Clone, Args, Default)]
 pub struct EvalAgentRunArgs {
-    #[arg(long, value_name = "PATH")]
+    #[arg(long, value_name = "PATH", help = "YAML or JSON eval suite path")]
     pub suite: String,
-    #[arg(long, value_name = "PROVIDER", default_value = "opencode")]
+    #[arg(
+        long,
+        value_name = "PROVIDER",
+        default_value = "opencode",
+        help = "Provider preset: opencode, codex, claude, goose, or custom"
+    )]
     pub provider: String,
-    #[arg(long, value_name = "COMMAND")]
+    #[arg(
+        long,
+        value_name = "COMMAND",
+        help = "Custom provider command to execute"
+    )]
     pub provider_command: Option<String>,
-    #[arg(long, value_name = "JSON_ARRAY")]
+    #[arg(
+        long,
+        value_name = "JSON_ARRAY",
+        help = "Custom provider arguments as a JSON string array with placeholders"
+    )]
     pub provider_args_json: Option<String>,
-    #[arg(long, value_name = "PATH", conflicts_with = "manifest_uri")]
+    #[arg(
+        long,
+        value_name = "PATH",
+        conflicts_with = "manifest_uri",
+        help = "Local dbt manifest.json path"
+    )]
     pub manifest_path: Option<String>,
-    #[arg(long, value_name = "URI", conflicts_with = "manifest_path")]
+    #[arg(
+        long,
+        value_name = "URI",
+        conflicts_with = "manifest_path",
+        help = "Remote manifest or prebuilt artifact URI"
+    )]
     pub manifest_uri: Option<String>,
-    #[arg(long, value_name = "INSTANCE_ID")]
+    #[arg(
+        long,
+        value_name = "INSTANCE_ID",
+        help = "Storage instance id for cached Nova assets"
+    )]
     pub storage_instance_id: Option<String>,
-    #[arg(long, value_name = "DIR")]
+    #[arg(long, value_name = "DIR", help = "Directory for eval result artifacts")]
     pub output_dir: Option<String>,
-    #[arg(long, value_name = "SECS", default_value_t = 600)]
+    #[arg(
+        long = "case-id",
+        value_name = "ID",
+        action = ArgAction::Append,
+        help = "Only run the named agent case; repeat for multiple cases"
+    )]
+    pub case_ids: Vec<String>,
+    #[arg(
+        long,
+        value_name = "SECS",
+        default_value_t = 600,
+        help = "Provider command timeout in seconds"
+    )]
     pub timeout_secs: u64,
-    #[arg(long, value_name = "FLOAT")]
+    #[arg(
+        long,
+        value_name = "FLOAT",
+        help = "Required pass rate between 0.0 and 1.0"
+    )]
     pub fail_under: Option<f64>,
-    #[arg(long, default_value_t = false)]
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Clear the selected storage instance before running the provider"
+    )]
     pub cleanup_storage_on_start: bool,
-    #[arg(long, default_value_t = false)]
+    #[arg(long, default_value_t = false, help = "Open storage in read-only mode")]
     pub read_only: bool,
-    #[arg(long, default_value_t = false)]
+    #[arg(long, default_value_t = false, help = "Emit a JSON CLI envelope")]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Args, Default)]
+pub struct EvalValidateArgs {
+    #[arg(long, value_name = "PATH", help = "YAML or JSON eval suite path")]
+    pub suite: String,
+    #[arg(long, default_value_t = false, help = "Emit a JSON CLI envelope")]
     pub json: bool,
 }
 
@@ -422,9 +521,9 @@ mod tests {
     use clap::Parser;
 
     use super::{
-        AuditCommand, Cli, Command, ConfigCommand, HealthCommand, ManifestCommand,
-        MetadataAuditSelectionModeArg, NovaMetaResourceKindArg, ServerCommand, ServerTransportArg,
-        StorageCommand, ToolCommand,
+        AuditCommand, Cli, Command, ConfigCommand, EvalAgentCommand, EvalCommand, HealthCommand,
+        ManifestCommand, MetadataAuditSelectionModeArg, NovaMetaResourceKindArg, ServerCommand,
+        ServerTransportArg, StorageCommand, ToolCommand,
     };
 
     #[test]
@@ -479,6 +578,67 @@ mod tests {
         for args in groups {
             let cli = Cli::parse_from(args);
             assert!(cli.command.is_some());
+        }
+    }
+
+    #[test]
+    fn eval_validate_parses_suite_path() {
+        let cli = Cli::parse_from(["dbt-nova", "eval", "validate", "--suite", "suite.yml"]);
+        match cli.command.expect("command") {
+            Command::Eval(eval) => match eval.command {
+                EvalCommand::Validate(args) => assert_eq!(args.suite, "suite.yml"),
+                _ => panic!("expected eval validate"),
+            },
+            _ => panic!("expected eval command"),
+        }
+    }
+
+    #[test]
+    fn eval_run_parses_repeated_case_ids() {
+        let cli = Cli::parse_from([
+            "dbt-nova",
+            "eval",
+            "run",
+            "--suite",
+            "suite.yml",
+            "--case-id",
+            "one",
+            "--case-id",
+            "two",
+        ]);
+        match cli.command.expect("command") {
+            Command::Eval(eval) => match eval.command {
+                EvalCommand::Run(args) => assert_eq!(args.case_ids, vec!["one", "two"]),
+                _ => panic!("expected eval run"),
+            },
+            _ => panic!("expected eval command"),
+        }
+    }
+
+    #[test]
+    fn eval_agent_run_parses_repeated_case_ids() {
+        let cli = Cli::parse_from([
+            "dbt-nova",
+            "eval",
+            "agent",
+            "run",
+            "--suite",
+            "suite.yml",
+            "--case-id",
+            "agent-one",
+            "--case-id",
+            "agent-two",
+        ]);
+        match cli.command.expect("command") {
+            Command::Eval(eval) => match eval.command {
+                EvalCommand::Agent(agent) => match agent.command {
+                    EvalAgentCommand::Run(args) => {
+                        assert_eq!(args.case_ids, vec!["agent-one", "agent-two"]);
+                    }
+                },
+                _ => panic!("expected eval agent run"),
+            },
+            _ => panic!("expected eval command"),
         }
     }
 

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::too_many_lines)]
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -9,9 +9,11 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
 
-use crate::cli::args::{EvalAgentRunArgs, EvalInitArgs, EvalRunArgs, ManifestLoadArgs};
+use crate::cli::args::{
+    EvalAgentRunArgs, EvalInitArgs, EvalRunArgs, EvalValidateArgs, ManifestLoadArgs,
+};
 use crate::cli::manifest::{build_manifest_load_config, execute_manifest_load};
-use crate::cli::output::CliEnvelope;
+use crate::cli::output::{CliEnvelope, error_envelope};
 use crate::cli::{DispatchError, DispatchResult};
 use crate::error::DbtNovaError;
 use crate::manifest::ManifestSearch;
@@ -91,6 +93,17 @@ enum EvalAssertion {
         id_or_name: String,
         fields: Vec<String>,
     },
+    ContextFieldEquals {
+        id_or_name: String,
+        field: String,
+        expected: JsonValue,
+    },
+    ContextContains {
+        id_or_name: String,
+        expected: String,
+        #[serde(default)]
+        field: Option<String>,
+    },
     MetadataScoreMin {
         #[serde(default)]
         id_or_name: Option<String>,
@@ -142,6 +155,10 @@ struct AgentExpected {
     #[serde(default)]
     selected_entities: Vec<String>,
     #[serde(default)]
+    selected_entity_ranks: Vec<AgentEntityRank>,
+    #[serde(default)]
+    called_with: Vec<AgentCalledWith>,
+    #[serde(default)]
     final_answer: Option<FinalAnswerExpected>,
 }
 
@@ -150,6 +167,24 @@ struct AgentOrder {
     before: String,
     #[serde(default)]
     must_have_called: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AgentEntityRank {
+    unique_id: String,
+    #[serde(default)]
+    tool: Option<String>,
+    #[serde(default)]
+    max_rank: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AgentCalledWith {
+    tool: String,
+    #[serde(default)]
+    params: BTreeMap<String, JsonValue>,
+    #[serde(default)]
+    contains: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -236,6 +271,52 @@ pub fn run_init_command(args: &EvalInitArgs) -> DispatchResult {
     Ok(())
 }
 
+/// Validates an eval suite without loading a manifest or running a provider.
+///
+/// # Errors
+/// Returns an error when the suite cannot be read or fails schema validation.
+pub fn run_validate_command(args: &EvalValidateArgs) -> DispatchResult {
+    let started = Instant::now();
+    let suite = load_suite(&args.suite).map_err(|error| {
+        if args.json {
+            let envelope = error_envelope("eval validate", &error, started.elapsed().as_millis());
+            if let Ok(out) = serde_json::to_string_pretty(&envelope) {
+                println!("{out}");
+                return DispatchError {
+                    error,
+                    rendered: true,
+                };
+            }
+        }
+        DispatchError {
+            error,
+            rendered: false,
+        }
+    })?;
+    let payload = json!({
+        "valid": true,
+        "path": args.suite,
+        "suite_name": suite.name.as_deref().unwrap_or("suite"),
+        "version": suite.version,
+        "bridge_case_count": suite.cases.len(),
+        "agent_case_count": suite.agent_cases.len(),
+    });
+    if args.json {
+        let envelope =
+            CliEnvelope::success("eval validate", payload, started.elapsed().as_millis());
+        let out = serde_json::to_string_pretty(&envelope)
+            .map_err(|error| server_error(error.to_string()))?;
+        println!("{out}");
+    } else {
+        println!("eval suite is valid");
+        println!("  suite: {}", suite.name.as_deref().unwrap_or("suite"));
+        println!("  version: {}", suite.version);
+        println!("  bridge cases: {}", suite.cases.len());
+        println!("  agent cases: {}", suite.agent_cases.len());
+    }
+    Ok(())
+}
+
 /// Runs deterministic Nova bridge assertions against a manifest.
 ///
 /// # Errors
@@ -249,6 +330,7 @@ pub async fn run_eval_command(args: &EvalRunArgs) -> DispatchResult {
             DbtNovaError::InvalidParams("eval suite contains no bridge cases".to_string()).into(),
         );
     }
+    let selected_cases = selected_bridge_cases(&suite.cases, &args.case_ids)?;
     let output_dir = resolve_output_dir(args.output_dir.as_deref(), &suite, "bridge");
     fs::create_dir_all(&output_dir).map_err(|error| server_error(error.to_string()))?;
 
@@ -262,8 +344,8 @@ pub async fn run_eval_command(args: &EvalRunArgs) -> DispatchResult {
     })?;
     let load_result = execute_manifest_load(config).await?;
 
-    let mut cases = Vec::with_capacity(suite.cases.len());
-    for case in &suite.cases {
+    let mut cases = Vec::with_capacity(selected_cases.len());
+    for case in selected_cases {
         cases.push(evaluate_bridge_case(case, &suite, &load_result.search).await);
     }
     let report = build_report(
@@ -295,12 +377,13 @@ pub async fn run_agent_eval_command(args: &EvalAgentRunArgs) -> DispatchResult {
             DbtNovaError::InvalidParams("eval suite contains no agent_cases".to_string()).into(),
         );
     }
+    let selected_cases = selected_agent_cases(&suite.agent_cases, &args.case_ids)?;
     let output_dir = resolve_output_dir(args.output_dir.as_deref(), &suite, "agent");
     fs::create_dir_all(output_dir.join("tool-calls"))
         .map_err(|error| server_error(error.to_string()))?;
 
-    let mut cases = Vec::with_capacity(suite.agent_cases.len());
-    for case in &suite.agent_cases {
+    let mut cases = Vec::with_capacity(selected_cases.len());
+    for case in selected_cases {
         cases.push(run_agent_case(case, args, &output_dir).await);
     }
     let report = build_report(
@@ -411,6 +494,28 @@ async fn evaluate_bridge_assertion(
                 Err(error) => AssertionResult::error("context_has", error.to_string()),
             }
         }
+        EvalAssertion::ContextFieldEquals {
+            id_or_name,
+            field,
+            expected,
+        } => {
+            let params = json!({"id_or_name": id_or_name});
+            match call_tool(search, "get_context", params).await {
+                Ok(response) => context_field_equals_assertion(&response, field, expected),
+                Err(error) => AssertionResult::error("context_field_equals", error.to_string()),
+            }
+        }
+        EvalAssertion::ContextContains {
+            id_or_name,
+            expected,
+            field,
+        } => {
+            let params = json!({"id_or_name": id_or_name});
+            match call_tool(search, "get_context", params).await {
+                Ok(response) => context_contains_assertion(&response, field.as_deref(), expected),
+                Err(error) => AssertionResult::error("context_contains", error.to_string()),
+            }
+        }
         EvalAssertion::MetadataScoreMin {
             id_or_name,
             threshold,
@@ -474,11 +579,7 @@ async fn evaluate_bridge_assertion(
         }
         EvalAssertion::ToolSuccess { tool, params } => {
             match call_tool(search, tool, params.clone()).await {
-                Ok(response) => AssertionResult::pass(
-                    format!("tool_success:{tool}"),
-                    "tool returned success",
-                    json!({"count": response.get("count").cloned().unwrap_or(JsonValue::Null)}),
-                ),
+                Ok(response) => tool_success_assertion(tool, &response),
                 Err(error) => {
                     AssertionResult::error(format!("tool_success:{tool}"), error.to_string())
                 }
@@ -693,6 +794,12 @@ fn score_agent_expectations(
             ));
         }
     }
+    for entity_rank in &expected.selected_entity_ranks {
+        assertions.push(selected_entity_rank_assertion(trace, entity_rank));
+    }
+    for called_with in &expected.called_with {
+        assertions.push(called_with_assertion(trace, called_with));
+    }
     if let Some(final_answer) = expected.final_answer.as_ref() {
         assertions.extend(score_final_answer(final_answer, final_answer_text));
     }
@@ -808,6 +915,146 @@ fn selected_entities(trace: &[JsonValue]) -> Vec<String> {
         }
     }
     out.into_iter().collect()
+}
+
+fn selected_entity_rank_assertion(
+    trace: &[JsonValue],
+    expected: &AgentEntityRank,
+) -> AssertionResult {
+    let rank = trace_entity_rank(trace, &expected.unique_id, expected.tool.as_deref());
+    match (rank, expected.max_rank) {
+        (Some(rank), Some(max_rank)) if rank <= max_rank => AssertionResult::pass(
+            format!("selected_entity_rank:{}", expected.unique_id),
+            format!("expected entity appeared at rank {rank}"),
+            json!({"rank": rank, "max_rank": max_rank, "tool": expected.tool}),
+        ),
+        (Some(rank), Some(max_rank)) => AssertionResult::fail(
+            format!("selected_entity_rank:{}", expected.unique_id),
+            format!("expected entity appeared at rank {rank}, above max rank {max_rank}"),
+            json!({
+                "rank": rank,
+                "max_rank": max_rank,
+                "tool": expected.tool,
+                "top_unique_ids": top_unique_ids(trace, expected.tool.as_deref()),
+            }),
+        ),
+        (Some(rank), None) => AssertionResult::pass(
+            format!("selected_entity_rank:{}", expected.unique_id),
+            format!("expected entity appeared at rank {rank}"),
+            json!({"rank": rank, "tool": expected.tool}),
+        ),
+        (None, _) => AssertionResult::fail(
+            format!("selected_entity_rank:{}", expected.unique_id),
+            "expected entity did not appear in ranked tool evidence",
+            json!({
+                "tool": expected.tool,
+                "top_unique_ids": top_unique_ids(trace, expected.tool.as_deref()),
+            }),
+        ),
+    }
+}
+
+fn trace_entity_rank(trace: &[JsonValue], entity: &str, tool: Option<&str>) -> Option<usize> {
+    trace
+        .iter()
+        .filter(|row| {
+            tool.is_none_or(|tool| row.get("tool").and_then(JsonValue::as_str) == Some(tool))
+        })
+        .filter_map(|row| {
+            row.get("top_unique_ids")
+                .and_then(JsonValue::as_array)
+                .and_then(|ids| ids.iter().position(|id| id.as_str() == Some(entity)))
+        })
+        .map(|index| index + 1)
+        .min()
+}
+
+fn top_unique_ids(trace: &[JsonValue], tool: Option<&str>) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut seen = BTreeSet::new();
+    for row in trace.iter().filter(|row| {
+        tool.is_none_or(|tool| row.get("tool").and_then(JsonValue::as_str) == Some(tool))
+    }) {
+        if let Some(ids) = row.get("top_unique_ids").and_then(JsonValue::as_array) {
+            for id in ids {
+                if let Some(id) = id.as_str() {
+                    let id = id.to_string();
+                    if seen.insert(id.clone()) {
+                        out.push(id);
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+fn called_with_assertion(trace: &[JsonValue], expected: &AgentCalledWith) -> AssertionResult {
+    if trace.iter().any(|row| called_with_matches(row, expected)) {
+        return AssertionResult::pass(
+            format!("called_with:{}", expected.tool),
+            "tool call parameters matched",
+            json!({"tool": expected.tool}),
+        );
+    }
+    AssertionResult::fail(
+        format!("called_with:{}", expected.tool),
+        "no observed tool call matched the expected safe parameters",
+        json!({
+            "expected": {
+                "params": &expected.params,
+                "contains": &expected.contains,
+            },
+            "observed": observed_params_for_tool(trace, &expected.tool),
+        }),
+    )
+}
+
+fn called_with_matches(row: &JsonValue, expected: &AgentCalledWith) -> bool {
+    if row.get("tool").and_then(JsonValue::as_str) != Some(expected.tool.as_str()) {
+        return false;
+    }
+    let Some(summary) = row.get("params_summary").and_then(JsonValue::as_object) else {
+        return expected.params.is_empty() && expected.contains.is_empty();
+    };
+    expected.params.iter().all(|(key, value)| {
+        summary
+            .get(key)
+            .is_some_and(|actual| param_value_matches(actual, value))
+    }) && expected.contains.iter().all(|(key, value)| {
+        summary
+            .get(key)
+            .is_some_and(|actual| json_contains_string(actual, value))
+    })
+}
+
+fn param_value_matches(actual: &JsonValue, expected: &JsonValue) -> bool {
+    match (actual, expected) {
+        (JsonValue::String(actual), JsonValue::String(expected)) => {
+            actual.eq_ignore_ascii_case(expected)
+        }
+        (JsonValue::Array(actual_items), JsonValue::Array(expected_items)) => {
+            expected_items.iter().all(|expected| {
+                actual_items
+                    .iter()
+                    .any(|actual| param_value_matches(actual, expected))
+            })
+        }
+        (JsonValue::Array(actual_items), expected) => actual_items
+            .iter()
+            .any(|actual| param_value_matches(actual, expected)),
+        _ => actual == expected,
+    }
+}
+
+fn observed_params_for_tool(trace: &[JsonValue], tool: &str) -> JsonValue {
+    JsonValue::Array(
+        trace
+            .iter()
+            .filter(|row| row.get("tool").and_then(JsonValue::as_str) == Some(tool))
+            .filter_map(|row| row.get("params_summary").cloned())
+            .collect(),
+    )
 }
 
 struct ToolTraceRead {
@@ -1000,6 +1247,58 @@ fn fields_assertion(name: &str, response: &JsonValue, fields: &[String]) -> Asse
     }
 }
 
+fn context_field_equals_assertion(
+    response: &JsonValue,
+    field: &str,
+    expected: &JsonValue,
+) -> AssertionResult {
+    match json_value_at_path(response, field) {
+        Some(actual) if actual == expected => AssertionResult::pass(
+            "context_field_equals",
+            "context field matched expected value",
+            json!({"field": field, "expected": expected}),
+        ),
+        Some(actual) => AssertionResult::fail(
+            "context_field_equals",
+            "context field did not match expected value",
+            json!({"field": field, "expected": expected, "actual": actual}),
+        ),
+        None => AssertionResult::fail(
+            "context_field_equals",
+            "context field was missing",
+            json!({"field": field, "expected": expected}),
+        ),
+    }
+}
+
+fn context_contains_assertion(
+    response: &JsonValue,
+    field: Option<&str>,
+    expected: &str,
+) -> AssertionResult {
+    let target = field.and_then(|field| json_value_at_path(response, field));
+    let contains = if let Some(value) = target {
+        json_contains_string(value, expected)
+    } else if field.is_some() {
+        false
+    } else {
+        json_contains_string(response, expected)
+    };
+    if contains {
+        AssertionResult::pass(
+            "context_contains",
+            "expected value appeared in context",
+            json!({"field": field, "expected": expected}),
+        )
+    } else {
+        AssertionResult::fail(
+            "context_contains",
+            "expected value did not appear in context",
+            json!({"field": field, "expected": expected}),
+        )
+    }
+}
+
 fn metadata_score_assertion(response: &JsonValue, threshold: f64) -> AssertionResult {
     let score = find_score(response);
     match score {
@@ -1054,6 +1353,60 @@ fn contains_string_assertion(name: &str, response: &JsonValue, expected: &str) -
     }
 }
 
+fn tool_success_assertion(tool: &str, response: &JsonValue) -> AssertionResult {
+    if response.get("success").and_then(JsonValue::as_bool) == Some(false) {
+        return AssertionResult::fail(
+            format!("tool_success:{tool}"),
+            "tool returned an explicit success=false response",
+            tool_failure_evidence(response),
+        );
+    }
+    AssertionResult::pass(
+        format!("tool_success:{tool}"),
+        "tool returned success",
+        json!({"count": response.get("count").cloned().unwrap_or(JsonValue::Null)}),
+    )
+}
+
+fn tool_failure_evidence(response: &JsonValue) -> JsonValue {
+    let mut evidence = serde_json::Map::new();
+    for key in ["success", "error_code", "code", "message", "count"] {
+        if let Some(value) = response.get(key).and_then(safe_evidence_scalar) {
+            evidence.insert(key.to_string(), value);
+        }
+    }
+    if let Some(error) = response.get("error").and_then(JsonValue::as_object) {
+        for key in ["error_code", "code", "message"] {
+            if let Some(value) = error.get(key).and_then(safe_evidence_scalar) {
+                evidence.insert(format!("error.{key}"), value);
+            }
+        }
+    }
+    if evidence.is_empty()
+        && let Some(map) = response.as_object()
+    {
+        evidence.insert(
+            "keys".to_string(),
+            JsonValue::Array(
+                map.keys()
+                    .take(20)
+                    .cloned()
+                    .map(JsonValue::String)
+                    .collect(),
+            ),
+        );
+    }
+    JsonValue::Object(evidence)
+}
+
+fn safe_evidence_scalar(value: &JsonValue) -> Option<JsonValue> {
+    match value {
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) => Some(value.clone()),
+        JsonValue::String(value) => Some(JsonValue::String(truncate(value, 1000))),
+        JsonValue::Array(_) | JsonValue::Object(_) => None,
+    }
+}
+
 fn data_rows(response: &JsonValue) -> &[JsonValue] {
     response
         .get("data")
@@ -1086,14 +1439,16 @@ fn json_contains_string_lower(value: &JsonValue, expected: &str) -> bool {
 }
 
 fn json_has_field_path(value: &JsonValue, field_path: &str) -> bool {
+    json_value_at_path(value, field_path).is_some_and(|value| !value.is_null())
+}
+
+fn json_value_at_path<'a>(value: &'a JsonValue, field_path: &str) -> Option<&'a JsonValue> {
     let mut current = value;
     for part in field_path.split('.') {
-        let Some(next) = current.get(part) else {
-            return false;
-        };
+        let next = current.get(part)?;
         current = next;
     }
-    !current.is_null()
+    Some(current)
 }
 
 fn find_score(value: &JsonValue) -> Option<f64> {
@@ -1376,6 +1731,8 @@ impl AgentExpected {
             || !self.must_not_call.is_empty()
             || !self.ordered.is_empty()
             || !self.selected_entities.is_empty()
+            || !self.selected_entity_ranks.is_empty()
+            || !self.called_with.is_empty()
     }
 }
 
@@ -1428,30 +1785,125 @@ fn validate_suite(suite: &EvalSuite) -> crate::error::Result<()> {
                 case.id
             )));
         }
+        validate_agent_expected(&case.expected, &case.id)?;
     }
     Ok(())
 }
 
 fn validate_assertion(assertion: &EvalAssertion, case_id: &str) -> crate::error::Result<()> {
-    if let EvalAssertion::SearchColumnsRank {
-        expected_column,
-        expected_parent_unique_id,
-        ..
-    } = assertion
-    {
-        let has_expected_column = expected_column
-            .as_ref()
-            .is_some_and(|value| !value.trim().is_empty());
-        let has_expected_parent = expected_parent_unique_id
-            .as_ref()
-            .is_some_and(|value| !value.trim().is_empty());
-        if !has_expected_column && !has_expected_parent {
+    match assertion {
+        EvalAssertion::SearchColumnsRank {
+            expected_column,
+            expected_parent_unique_id,
+            ..
+        } => {
+            let has_expected_column = expected_column
+                .as_ref()
+                .is_some_and(|value| !value.trim().is_empty());
+            let has_expected_parent = expected_parent_unique_id
+                .as_ref()
+                .is_some_and(|value| !value.trim().is_empty());
+            if !has_expected_column && !has_expected_parent {
+                return Err(DbtNovaError::InvalidParams(format!(
+                    "search_columns_rank assertion in case '{case_id}' must include expected_column or expected_parent_unique_id"
+                )));
+            }
+        }
+        EvalAssertion::ContextFieldEquals { field, .. } if field.trim().is_empty() => {
             return Err(DbtNovaError::InvalidParams(format!(
-                "search_columns_rank assertion in case '{case_id}' must include expected_column or expected_parent_unique_id"
+                "context_field_equals assertion in case '{case_id}' must include a non-empty field"
+            )));
+        }
+        EvalAssertion::ContextContains {
+            expected, field, ..
+        } => {
+            if expected.trim().is_empty() {
+                return Err(DbtNovaError::InvalidParams(format!(
+                    "context_contains assertion in case '{case_id}' must include non-empty expected text"
+                )));
+            }
+            if field.as_ref().is_some_and(|field| field.trim().is_empty()) {
+                return Err(DbtNovaError::InvalidParams(format!(
+                    "context_contains assertion in case '{case_id}' must include a non-empty field when field is set"
+                )));
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn validate_agent_expected(expected: &AgentExpected, case_id: &str) -> crate::error::Result<()> {
+    for rank in &expected.selected_entity_ranks {
+        if rank.unique_id.trim().is_empty() {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "selected_entity_ranks in agent case '{case_id}' must include non-empty unique_id values"
+            )));
+        }
+        if rank
+            .tool
+            .as_ref()
+            .is_some_and(|tool| tool.trim().is_empty())
+        {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "selected_entity_ranks in agent case '{case_id}' must include non-empty tool values when tool is set"
+            )));
+        }
+        if rank.max_rank == Some(0) {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "selected_entity_ranks in agent case '{case_id}' must use max_rank greater than zero"
+            )));
+        }
+    }
+    for called_with in &expected.called_with {
+        if called_with.tool.trim().is_empty() {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "called_with expectations in agent case '{case_id}' must include non-empty tool values"
+            )));
+        }
+        if called_with.params.is_empty() && called_with.contains.is_empty() {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "called_with expectations in agent case '{case_id}' must include params or contains constraints"
+            )));
+        }
+        if called_with
+            .contains
+            .iter()
+            .any(|(key, value)| key.trim().is_empty() || value.trim().is_empty())
+        {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "called_with contains expectations in agent case '{case_id}' must include non-empty keys and values"
+            )));
+        }
+        if called_with.params.keys().any(|key| key.trim().is_empty()) {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "called_with params expectations in agent case '{case_id}' must include non-empty keys"
+            )));
+        }
+        if called_with
+            .params
+            .values()
+            .any(|value| !is_safe_expected_param_value(value))
+        {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "called_with params expectations in agent case '{case_id}' must use scalar values or arrays of scalar values"
             )));
         }
     }
     Ok(())
+}
+
+fn is_safe_expected_param_value(value: &JsonValue) -> bool {
+    match value {
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) | JsonValue::String(_) => true,
+        JsonValue::Array(items) => items.iter().all(|item| {
+            matches!(
+                item,
+                JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) | JsonValue::String(_)
+            )
+        }),
+        JsonValue::Object(_) => false,
+    }
 }
 
 fn validate_case_ids<'a>(
@@ -1506,6 +1958,76 @@ fn validate_fail_under(value: Option<f64>) -> crate::error::Result<()> {
         ));
     }
     Ok(())
+}
+
+fn selected_bridge_cases<'a>(
+    cases: &'a [EvalCase],
+    case_ids: &[String],
+) -> crate::error::Result<Vec<&'a EvalCase>> {
+    if case_ids.is_empty() {
+        return Ok(cases.iter().collect());
+    }
+    let wanted = normalized_case_filter(case_ids)?;
+    let selected: Vec<&EvalCase> = cases
+        .iter()
+        .filter(|case| wanted.contains(case.id.as_str()))
+        .collect();
+    validate_selected_cases(
+        &wanted,
+        selected.iter().map(|case| case.id.as_str()),
+        "bridge",
+    )?;
+    Ok(selected)
+}
+
+fn selected_agent_cases<'a>(
+    cases: &'a [AgentCase],
+    case_ids: &[String],
+) -> crate::error::Result<Vec<&'a AgentCase>> {
+    if case_ids.is_empty() {
+        return Ok(cases.iter().collect());
+    }
+    let wanted = normalized_case_filter(case_ids)?;
+    let selected: Vec<&AgentCase> = cases
+        .iter()
+        .filter(|case| wanted.contains(case.id.as_str()))
+        .collect();
+    validate_selected_cases(
+        &wanted,
+        selected.iter().map(|case| case.id.as_str()),
+        "agent",
+    )?;
+    Ok(selected)
+}
+
+fn normalized_case_filter(case_ids: &[String]) -> crate::error::Result<BTreeSet<&str>> {
+    let mut wanted = BTreeSet::new();
+    for id in case_ids {
+        let trimmed = id.trim();
+        if trimmed.is_empty() {
+            return Err(DbtNovaError::InvalidParams(
+                "--case-id values must be non-empty".to_string(),
+            ));
+        }
+        wanted.insert(trimmed);
+    }
+    Ok(wanted)
+}
+
+fn validate_selected_cases<'a>(
+    wanted: &BTreeSet<&'a str>,
+    selected: impl Iterator<Item = &'a str>,
+    mode: &str,
+) -> crate::error::Result<()> {
+    let found: BTreeSet<&str> = selected.collect();
+    let missing: Vec<&str> = wanted.difference(&found).copied().collect();
+    if missing.is_empty() {
+        return Ok(());
+    }
+    Err(DbtNovaError::InvalidParams(format!(
+        "requested {mode} eval case id(s) not found: {}",
+        missing.join(", ")
+    )))
 }
 
 fn agent_prompt(case: &AgentCase) -> String {

--- a/src/cli/eval_cmd/provider.rs
+++ b/src/cli/eval_cmd/provider.rs
@@ -16,6 +16,7 @@ use super::server_error;
 const PROVIDER_MCP_SERVER_ALIASES_ENV: &str = "DBT_NOVA_EVAL_MCP_SERVER_ALIASES";
 const DEFAULT_NOVA_MCP_SERVER_ALIASES: [&str; 5] =
     ["nova", "dbt-nova", "dbt_nova", "dbtnova", "dbt-nova-mcp"];
+const MAX_PROVIDER_TOP_UNIQUE_IDS: usize = 20;
 
 #[derive(Debug)]
 pub(super) struct ProviderInvocation {
@@ -388,6 +389,7 @@ impl ProviderTraceState {
             .unwrap_or(false);
         let response = part.get("content").unwrap_or(part);
         let selected_unique_ids = provider_selected_unique_ids(Some(response));
+        let top_unique_ids = provider_top_unique_ids(Some(response));
         if let Some(row) = self
             .rows
             .get_mut(row_index)
@@ -398,6 +400,7 @@ impl ProviderTraceState {
                 "selected_unique_ids".to_string(),
                 json!(selected_unique_ids),
             );
+            row.insert("top_unique_ids".to_string(), json!(top_unique_ids));
         }
     }
 }
@@ -516,6 +519,7 @@ fn provider_tool_row(
         "duration_ms": 0,
         "params_summary": provider_params_summary(params),
         "selected_unique_ids": provider_selected_unique_ids(response),
+        "top_unique_ids": provider_top_unique_ids(response),
     })
 }
 
@@ -530,15 +534,40 @@ fn provider_params_summary(params: Option<&JsonValue>) -> JsonValue {
         .map(JsonValue::String)
         .collect();
     let mut summary = serde_json::Map::from_iter([(String::from("keys"), JsonValue::Array(keys))]);
-    for key in ["query", "persona", "id_or_name", "recipe_id", "direction"] {
-        if let Some(value) = map.get(key).and_then(provider_safe_scalar) {
+    for key in [
+        "query",
+        "persona",
+        "id_or_name",
+        "resource_type",
+        "resource_types",
+        "recipe_id",
+        "direction",
+        "limit",
+        "offset",
+    ] {
+        if let Some(value) = map.get(key).and_then(provider_safe_value) {
             summary.insert(key.to_string(), value);
         }
     }
     JsonValue::Object(summary)
 }
 
-fn provider_safe_scalar(value: &JsonValue) -> Option<JsonValue> {
+fn provider_safe_value(value: &JsonValue) -> Option<JsonValue> {
+    match value {
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) => Some(value.clone()),
+        JsonValue::String(value) => Some(JsonValue::String(value.chars().take(256).collect())),
+        JsonValue::Array(items) => Some(JsonValue::Array(
+            items
+                .iter()
+                .take(20)
+                .filter_map(provider_safe_array_value)
+                .collect(),
+        )),
+        JsonValue::Object(_) => None,
+    }
+}
+
+fn provider_safe_array_value(value: &JsonValue) -> Option<JsonValue> {
     match value {
         JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) => Some(value.clone()),
         JsonValue::String(value) => Some(JsonValue::String(value.chars().take(256).collect())),
@@ -552,6 +581,102 @@ fn provider_selected_unique_ids(response: Option<&JsonValue>) -> Vec<String> {
         collect_provider_unique_ids(response, &mut out);
     }
     out.into_iter().collect()
+}
+
+fn provider_top_unique_ids(response: Option<&JsonValue>) -> Vec<String> {
+    let Some(response) = response else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    let mut seen = BTreeSet::new();
+    if let Some(rows) = response.get("data").and_then(JsonValue::as_array) {
+        for row in rows {
+            push_provider_first_unique_id(row, &mut out, &mut seen);
+            if out.len() >= MAX_PROVIDER_TOP_UNIQUE_IDS {
+                return out;
+            }
+        }
+    }
+    if out.is_empty() {
+        collect_provider_top_unique_ids(response, &mut out, &mut seen);
+    }
+    out
+}
+
+fn push_provider_first_unique_id(
+    value: &JsonValue,
+    out: &mut Vec<String>,
+    seen: &mut BTreeSet<String>,
+) {
+    if let Some(id) = provider_first_unique_id(value) {
+        push_provider_ordered_unique_id(&id, out, seen);
+    }
+}
+
+fn collect_provider_top_unique_ids(
+    value: &JsonValue,
+    out: &mut Vec<String>,
+    seen: &mut BTreeSet<String>,
+) {
+    if out.len() >= MAX_PROVIDER_TOP_UNIQUE_IDS {
+        return;
+    }
+    match value {
+        JsonValue::Object(map) => {
+            if let Some(id) = provider_first_unique_id(value) {
+                push_provider_ordered_unique_id(&id, out, seen);
+                if out.len() >= MAX_PROVIDER_TOP_UNIQUE_IDS {
+                    return;
+                }
+            }
+            for child in map.values() {
+                collect_provider_top_unique_ids(child, out, seen);
+                if out.len() >= MAX_PROVIDER_TOP_UNIQUE_IDS {
+                    return;
+                }
+            }
+        }
+        JsonValue::Array(items) => {
+            for item in items {
+                collect_provider_top_unique_ids(item, out, seen);
+                if out.len() >= MAX_PROVIDER_TOP_UNIQUE_IDS {
+                    return;
+                }
+            }
+        }
+        JsonValue::String(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.starts_with('{')
+                && let Ok(parsed) = serde_json::from_str::<JsonValue>(trimmed)
+            {
+                collect_provider_top_unique_ids(&parsed, out, seen);
+            }
+        }
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) => {}
+    }
+}
+
+fn provider_first_unique_id(value: &JsonValue) -> Option<String> {
+    let JsonValue::Object(map) = value else {
+        return None;
+    };
+    for key in ["unique_id", "parent_unique_id", "root_id"] {
+        if let Some(id) = map.get(key).and_then(JsonValue::as_str)
+            && !id.trim().is_empty()
+        {
+            return Some(id.chars().take(512).collect());
+        }
+    }
+    None
+}
+
+fn push_provider_ordered_unique_id(id: &str, out: &mut Vec<String>, seen: &mut BTreeSet<String>) {
+    if out.len() >= MAX_PROVIDER_TOP_UNIQUE_IDS {
+        return;
+    }
+    if seen.insert(id.to_string()) {
+        out.push(id.to_string());
+    }
 }
 
 fn collect_provider_unique_ids(value: &JsonValue, out: &mut BTreeSet<String>) {
@@ -673,6 +798,28 @@ mod tests {
     }
 
     #[test]
+    fn provider_invocation_uses_goose_stream_json() {
+        let args = EvalAgentRunArgs {
+            provider: "goose".to_string(),
+            ..EvalAgentRunArgs::default()
+        };
+        let invocation = provider_invocation(&args, "hello", Path::new("/tmp/trace.jsonl"))
+            .expect("goose provider");
+        assert_eq!(invocation.command, "goose");
+        assert_eq!(
+            invocation.args,
+            vec![
+                "run",
+                "--text",
+                "hello",
+                "--output-format",
+                "stream-json",
+                "--no-session"
+            ]
+        );
+    }
+
+    #[test]
     fn provider_trace_reads_codex_mcp_tool_events() {
         let stdout = r#"{"type":"item.completed","item":{"type":"mcp_tool_call","server":"nova","tool":"search_indicator","arguments":{"query":"gmv"},"result":{"content":[{"type":"text","text":"{\"data\":[{\"parent_unique_id\":\"model.pkg.orders\"}]}"}]},"error":null,"status":"completed"}}"#;
         let trace = read_provider_tool_trace(stdout);
@@ -684,6 +831,7 @@ mod tests {
             trace.rows[0]["selected_unique_ids"],
             json!(["model.pkg.orders"])
         );
+        assert_eq!(trace.rows[0]["top_unique_ids"], json!(["model.pkg.orders"]));
     }
 
     #[test]
@@ -733,6 +881,20 @@ mod tests {
             trace.rows[0]["selected_unique_ids"],
             json!(["model.pkg.orders"])
         );
+        assert_eq!(trace.rows[0]["top_unique_ids"], json!(["model.pkg.orders"]));
+    }
+
+    #[test]
+    fn provider_trace_keeps_safe_array_params() {
+        let stdout = r#"{"type":"item.completed","item":{"type":"mcp_tool_call","server":"nova","tool":"search","arguments":{"query":"orders","resource_types":["model",{"secret":"x"}],"limit":5},"result":{"data":[]},"error":null,"status":"completed"}}"#;
+        let trace = read_provider_tool_trace(stdout);
+        assert_eq!(trace.errors, Vec::<String>::new());
+        assert_eq!(trace.rows.len(), 1);
+        assert_eq!(
+            trace.rows[0]["params_summary"]["resource_types"],
+            json!(["model"])
+        );
+        assert_eq!(trace.rows[0]["params_summary"]["limit"], 5);
     }
 
     #[test]

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -1,10 +1,16 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
 use serde_json::json;
-use tempfile::NamedTempFile;
+use tempfile::{NamedTempFile, TempDir};
 
 use super::{
-    AgentExpected, AgentOrder, AssertionResult, EvalCaseReport, EvalDefaults, EvalSuite,
-    FinalAnswerExpected, contains_rank_assertion, json_has_field_path, read_tool_trace,
-    safe_path_segment, score_agent_expectations, validate_suite,
+    AgentCalledWith, AgentEntityRank, AgentExpected, AgentOrder, AssertionResult, EvalCaseReport,
+    EvalDefaults, EvalRunArgs, EvalSuite, EvalValidateArgs, FinalAnswerExpected,
+    contains_rank_assertion, context_contains_assertion, context_field_equals_assertion,
+    json_has_field_path, read_tool_trace, run_eval_command, run_validate_command,
+    safe_path_segment, score_agent_expectations, selected_agent_cases, selected_bridge_cases,
+    tool_success_assertion, validate_suite,
 };
 
 #[test]
@@ -29,10 +35,6 @@ fn contains_rank_assertion_respects_max_rank() {
 
 #[test]
 fn agent_expectations_score_tool_trace() {
-    let trace = vec![
-        json!({"tool": "search_indicator", "selected_unique_ids": ["model.pkg.orders"]}),
-        json!({"tool": "get_context", "selected_unique_ids": ["model.pkg.orders"]}),
-    ];
     let expected = AgentExpected {
         must_call: vec!["search_indicator".to_string(), "get_context".to_string()],
         must_not_call: vec!["execute_sql".to_string()],
@@ -41,13 +43,140 @@ fn agent_expectations_score_tool_trace() {
             must_have_called: vec!["search_indicator".to_string()],
         }],
         selected_entities: vec!["model.pkg.orders".to_string()],
+        selected_entity_ranks: vec![AgentEntityRank {
+            unique_id: "model.pkg.orders".to_string(),
+            tool: Some("search_indicator".to_string()),
+            max_rank: Some(1),
+        }],
+        called_with: vec![AgentCalledWith {
+            tool: "search_indicator".to_string(),
+            params: BTreeMap::new(),
+            contains: BTreeMap::from([(String::from("query"), String::from("gmv"))]),
+        }],
         final_answer: Some(FinalAnswerExpected {
             must_contain: vec!["gmv".to_string()],
             must_not_contain: vec!["secret".to_string()],
         }),
     };
+    let trace = vec![
+        json!({
+            "tool": "search_indicator",
+            "params_summary": {"query": "gmv"},
+            "selected_unique_ids": ["model.pkg.orders"],
+            "top_unique_ids": ["model.pkg.orders"]
+        }),
+        json!({
+            "tool": "get_context",
+            "params_summary": {"id_or_name": "model.pkg.orders"},
+            "selected_unique_ids": ["model.pkg.orders"],
+            "top_unique_ids": ["model.pkg.orders"]
+        }),
+    ];
     let results = score_agent_expectations(&expected, &trace, "GMV uses model.pkg.orders");
     assert!(results.iter().all(|result| result.status == "pass"));
+}
+
+#[test]
+fn selected_entity_rank_fails_when_entity_is_below_max_rank() {
+    let expected = AgentExpected {
+        selected_entity_ranks: vec![AgentEntityRank {
+            unique_id: "model.pkg.orders".to_string(),
+            tool: Some("search".to_string()),
+            max_rank: Some(1),
+        }],
+        ..AgentExpected::default()
+    };
+    let trace = vec![json!({
+        "tool": "search",
+        "top_unique_ids": ["model.pkg.other", "model.pkg.orders"]
+    })];
+    let results = score_agent_expectations(&expected, &trace, "");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].status, "fail");
+}
+
+#[test]
+fn selected_entity_rank_can_scope_to_tool() {
+    let expected = AgentExpected {
+        selected_entity_ranks: vec![AgentEntityRank {
+            unique_id: "model.pkg.orders".to_string(),
+            tool: Some("search".to_string()),
+            max_rank: Some(1),
+        }],
+        ..AgentExpected::default()
+    };
+    let trace = vec![
+        json!({
+            "tool": "search",
+            "top_unique_ids": ["model.pkg.other", "model.pkg.orders"]
+        }),
+        json!({
+            "tool": "get_context",
+            "top_unique_ids": ["model.pkg.orders"]
+        }),
+    ];
+    let results = score_agent_expectations(&expected, &trace, "");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].status, "fail");
+}
+
+#[test]
+fn called_with_matches_safe_params() {
+    let expected = AgentExpected {
+        called_with: vec![AgentCalledWith {
+            tool: "search".to_string(),
+            params: BTreeMap::from([(String::from("resource_types"), json!(["model"]))]),
+            contains: BTreeMap::from([(String::from("query"), String::from("orders"))]),
+        }],
+        ..AgentExpected::default()
+    };
+    let trace = vec![json!({
+        "tool": "search",
+        "params_summary": {"query": "canonical orders", "resource_types": ["model", "seed"]}
+    })];
+    let results = score_agent_expectations(&expected, &trace, "");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].status, "pass");
+}
+
+#[test]
+fn context_value_assertions_check_equals_and_contains() {
+    let response = json!({
+        "data": {
+            "entity": {
+                "name": "orders",
+                "description": "Canonical orders model"
+            }
+        }
+    });
+    assert_eq!(
+        context_field_equals_assertion(&response, "data.entity.name", &json!("orders")).status,
+        "pass"
+    );
+    assert_eq!(
+        context_contains_assertion(&response, Some("data.entity.description"), "canonical").status,
+        "pass"
+    );
+    assert_eq!(
+        context_field_equals_assertion(&response, "data.entity.name", &json!("customers")).status,
+        "fail"
+    );
+}
+
+#[test]
+fn tool_success_fails_explicit_false_response() {
+    let result = tool_success_assertion(
+        "search",
+        &json!({
+            "success": false,
+            "error": {"error_code": "invalid_params", "message": "bad request"},
+            "data": [{"unique_id": "model.pkg.should_not_be_embedded"}]
+        }),
+    );
+    assert_eq!(result.status, "fail");
+    assert_eq!(result.evidence["success"], false);
+    assert_eq!(result.evidence["error.error_code"], "invalid_params");
+    assert!(result.evidence.get("data").is_none());
 }
 
 #[test]
@@ -177,10 +306,151 @@ fn validate_suite_rejects_vacuous_search_columns_rank_assertion() {
 }
 
 #[test]
+fn validate_suite_rejects_unmatchable_called_with_param_values() {
+    let suite = EvalSuite {
+        version: 1,
+        name: None,
+        defaults: EvalDefaults::default(),
+        cases: Vec::new(),
+        agent_cases: vec![super::AgentCase {
+            id: "agent".to_string(),
+            task: "use nova".to_string(),
+            expected: AgentExpected {
+                called_with: vec![AgentCalledWith {
+                    tool: "search".to_string(),
+                    params: BTreeMap::from([(String::from("query"), json!({"nested": true}))]),
+                    contains: BTreeMap::new(),
+                }],
+                ..AgentExpected::default()
+            },
+        }],
+    };
+    let error = validate_suite(&suite).expect_err("nested param expectation should fail");
+    assert!(error.to_string().contains("scalar values"));
+}
+
+#[test]
+fn selected_case_filters_reject_missing_ids() {
+    let cases = vec![super::EvalCase {
+        id: "one".to_string(),
+        question: None,
+        persona: None,
+        assertions: vec![super::EvalAssertion::ToolSuccess {
+            tool: "search".to_string(),
+            params: json!({}),
+        }],
+    }];
+    let error = selected_bridge_cases(&cases, &[String::from("missing")])
+        .expect_err("missing case id should fail");
+    assert!(error.to_string().contains("not found"));
+}
+
+#[test]
+fn selected_agent_case_filters_return_requested_cases() {
+    let cases = vec![
+        super::AgentCase {
+            id: "one".to_string(),
+            task: "task one".to_string(),
+            expected: AgentExpected::default(),
+        },
+        super::AgentCase {
+            id: "two".to_string(),
+            task: "task two".to_string(),
+            expected: AgentExpected::default(),
+        },
+    ];
+    let selected = selected_agent_cases(&cases, &[String::from("two")]).expect("filter");
+    assert_eq!(selected.len(), 1);
+    assert_eq!(selected[0].id, "two");
+}
+
+#[test]
+fn validate_command_accepts_valid_suite_without_manifest() {
+    let suite = NamedTempFile::new().expect("suite file");
+    std::fs::write(
+        suite.path(),
+        r"
+version: 1
+name: validate-smoke
+cases:
+  - id: one
+    assertions:
+      - type: tool_success
+        tool: search
+        params: {}
+",
+    )
+    .expect("write suite");
+    let result = run_validate_command(&EvalValidateArgs {
+        suite: suite.path().display().to_string(),
+        json: true,
+    });
+    assert!(
+        result.is_ok(),
+        "valid suite failed: {}",
+        result
+            .err()
+            .map_or_else(String::new, |error| error.error.to_string())
+    );
+}
+
+#[tokio::test]
+async fn bridge_eval_writes_result_artifacts() {
+    let temp_dir = TempDir::new().expect("output dir");
+    let suite_path = temp_dir.path().join("suite.yml");
+    std::fs::write(
+        &suite_path,
+        r"
+version: 1
+name: bridge-smoke
+cases:
+  - id: orders-search
+    assertions:
+      - type: search_rank
+        query: orders
+        expected_unique_id: model.nova_test.fct__orders
+        max_rank: 5
+",
+    )
+    .expect("write suite");
+    let output_dir = temp_dir.path().join("out");
+    let result = run_eval_command(&EvalRunArgs {
+        suite: suite_path.display().to_string(),
+        manifest_path: Some(
+            fixture_manifest_path("nova_manifest.json")
+                .display()
+                .to_string(),
+        ),
+        output_dir: Some(output_dir.display().to_string()),
+        fail_under: Some(1.0),
+        json: true,
+        ..EvalRunArgs::default()
+    })
+    .await;
+    assert!(
+        result.is_ok(),
+        "bridge eval failed: {}",
+        result
+            .err()
+            .map_or_else(String::new, |error| error.error.to_string())
+    );
+    assert!(output_dir.join("results.json").exists());
+    assert!(output_dir.join("results.tsv").exists());
+    assert!(output_dir.join("report.md").exists());
+    assert!(output_dir.join("suite.yml").exists());
+}
+
+#[test]
 fn safe_path_segment_blocks_dot_segments_and_caps_length() {
     assert_eq!(safe_path_segment("."), "eval");
     assert_eq!(safe_path_segment(".."), "eval");
     assert_eq!(safe_path_segment("../secret"), "secret");
     assert_eq!(safe_path_segment("a/b"), "a-b");
     assert!(safe_path_segment(&"x".repeat(200)).len() <= 120);
+}
+
+fn fixture_manifest_path(name: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -89,6 +89,9 @@ pub async fn dispatch(command: args::Command) -> DispatchResult {
                     eval_cmd::run_agent_eval_command(&run_args).await
                 }
             },
+            args::EvalCommand::Validate(validate_args) => {
+                eval_cmd::run_validate_command(&validate_args)
+            }
         },
     }
 }

--- a/src/utils/tool_trace.rs
+++ b/src/utils/tool_trace.rs
@@ -13,6 +13,7 @@ const MAX_PARAM_KEYS: usize = 50;
 const MAX_ARRAY_ITEMS: usize = 20;
 const MAX_SUMMARY_STRING_CHARS: usize = 256;
 const MAX_SELECTED_UNIQUE_IDS: usize = 200;
+const MAX_TOP_UNIQUE_IDS: usize = 20;
 const MAX_UNIQUE_ID_CHARS: usize = 512;
 
 #[derive(Debug, Serialize)]
@@ -27,6 +28,7 @@ struct ToolTraceRow {
     #[serde(skip_serializing_if = "Option::is_none")]
     params_summary: Option<Value>,
     selected_unique_ids: Vec<String>,
+    top_unique_ids: Vec<String>,
 }
 
 /// Append a sanitized tool-call trace row when `DBT_NOVA_TRACE_TOOL_CALLS_PATH` is set.
@@ -64,6 +66,7 @@ pub fn record_tool_call(
         error_code: response.and_then(extract_error_code),
         params_summary: params.map(summarize_params),
         selected_unique_ids: response.map(extract_unique_ids).unwrap_or_default(),
+        top_unique_ids: response.map(extract_top_unique_ids).unwrap_or_default(),
     };
 
     let serialized = match serde_json::to_string(&row) {
@@ -182,6 +185,83 @@ fn extract_unique_ids(response: &Value) -> Vec<String> {
     out.into_iter().collect()
 }
 
+fn extract_top_unique_ids(response: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut seen = BTreeSet::new();
+    if let Some(rows) = response.get("data").and_then(Value::as_array) {
+        for row in rows {
+            push_first_unique_id(row, &mut out, &mut seen);
+            if out.len() >= MAX_TOP_UNIQUE_IDS {
+                return out;
+            }
+        }
+    }
+    if out.is_empty() {
+        collect_top_unique_ids(response, &mut out, &mut seen);
+    }
+    out
+}
+
+fn push_first_unique_id(value: &Value, out: &mut Vec<String>, seen: &mut BTreeSet<String>) {
+    if let Some(id) = first_unique_id(value) {
+        push_ordered_unique_id(&id, out, seen);
+    }
+}
+
+fn collect_top_unique_ids(value: &Value, out: &mut Vec<String>, seen: &mut BTreeSet<String>) {
+    if out.len() >= MAX_TOP_UNIQUE_IDS {
+        return;
+    }
+    match value {
+        Value::Object(map) => {
+            if let Some(id) = first_unique_id(value) {
+                push_ordered_unique_id(&id, out, seen);
+                if out.len() >= MAX_TOP_UNIQUE_IDS {
+                    return;
+                }
+            }
+            for child in map.values() {
+                collect_top_unique_ids(child, out, seen);
+                if out.len() >= MAX_TOP_UNIQUE_IDS {
+                    return;
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_top_unique_ids(item, out, seen);
+                if out.len() >= MAX_TOP_UNIQUE_IDS {
+                    return;
+                }
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+fn first_unique_id(value: &Value) -> Option<String> {
+    let Value::Object(map) = value else {
+        return None;
+    };
+    for key in ["unique_id", "parent_unique_id", "root_id"] {
+        if let Some(id) = map.get(key).and_then(Value::as_str)
+            && !id.trim().is_empty()
+        {
+            return Some(truncate_string(id, MAX_UNIQUE_ID_CHARS));
+        }
+    }
+    None
+}
+
+fn push_ordered_unique_id(id: &str, out: &mut Vec<String>, seen: &mut BTreeSet<String>) {
+    if out.len() >= MAX_TOP_UNIQUE_IDS {
+        return;
+    }
+    if seen.insert(id.to_string()) {
+        out.push(id.to_string());
+    }
+}
+
 fn collect_unique_ids(value: &Value, out: &mut BTreeSet<String>) {
     match value {
         Value::Object(map) => {
@@ -227,7 +307,9 @@ fn timestamp_ms() -> u128 {
 mod tests {
     use serde_json::json;
 
-    use super::{MAX_SELECTED_UNIQUE_IDS, extract_unique_ids, summarize_params};
+    use super::{
+        MAX_SELECTED_UNIQUE_IDS, extract_top_unique_ids, extract_unique_ids, summarize_params,
+    };
 
     #[test]
     fn summarize_params_keeps_only_safe_context() {
@@ -272,5 +354,23 @@ mod tests {
             .collect();
         let ids = extract_unique_ids(&json!({"data": data}));
         assert_eq!(ids.len(), MAX_SELECTED_UNIQUE_IDS);
+    }
+
+    #[test]
+    fn extract_top_unique_ids_preserves_response_order() {
+        let ids = extract_top_unique_ids(&json!({
+            "data": [
+                {"unique_id": "model.pkg.first"},
+                {"unique_id": "model.pkg.second", "parent_unique_id": "model.pkg.parent"}
+            ],
+            "root_id": "model.pkg.root"
+        }));
+        assert_eq!(
+            ids,
+            vec![
+                "model.pkg.first".to_string(),
+                "model.pkg.second".to_string()
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary

Hardens the new Nova eval feature for production use.

- Adds `dbt-nova eval validate` for suite-only validation before manifest or provider execution.
- Adds repeatable `--case-id` filters for bridge and agent eval debugging.
- Improves eval CLI help text.
- Adds value-aware bridge assertions: `context_field_equals` and `context_contains`.
- Strengthens `tool_success` so explicit `success: false` responses fail with sanitized evidence.
- Adds agent `called_with` expectations and ranked `selected_entity_ranks`, including optional tool scoping.
- Adds ordered `top_unique_ids` trace evidence while preserving existing `selected_unique_ids`.
- Updates eval docs, CLI docs, operations testing docs, and changelog.

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --lib eval_cmd`
- `cargo test --locked --lib`
- `uv run mkdocs build --strict`
- `git diff --check`

## Notes

`codex.txt` is intentionally left untracked and is not part of this PR.
