### PR TITLE
Complete post-v0.0.4 release hardening roadmap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
     timeout-minutes: 60
     env:
       DBT_NOVA_STRICT_SCHEMA: "1"
-      COVERAGE_MIN_LINES: "65"
+      COVERAGE_MIN_LINES: "70"
       CARGO_BUILD_JOBS: "1"
       RUSTFLAGS: "-C debuginfo=0"
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,9 +112,17 @@ jobs:
             target: x86_64-unknown-linux-gnu
             asset: linux-x86_64
             ext: ""
+          - os: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-gnu
+            asset: linux-arm64
+            ext: ""
           - os: macos-14
             target: aarch64-apple-darwin
             asset: macos-arm64
+            ext: ""
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+            asset: macos-x86_64
             ext: ""
 
     steps:
@@ -219,7 +227,9 @@ jobs:
       - validate
       - build
     permissions:
-      contents: read
+      attestations: write
+      contents: write
+      id-token: write
       packages: write
     steps:
       - name: Checkout
@@ -232,8 +242,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "image=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
-          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          image="ghcr.io/${GITHUB_REPOSITORY,,}"
+          commit_sha="$(git rev-parse HEAD)"
+          echo "image=${image}" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=${commit_sha}" >> "$GITHUB_OUTPUT"
+          echo "amd64_tag=${image}:sha-${commit_sha}-amd64" >> "$GITHUB_OUTPUT"
+          echo "arm64_tag=${image}:sha-${commit_sha}-arm64" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
@@ -255,9 +269,21 @@ jobs:
             org.opencontainers.image.description=dbt-nova streamable HTTP MCP server image
             org.opencontainers.image.version=${{ needs.validate.outputs.release_tag }}
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac
+        with:
+          cosign-release: "v2.4.1"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+
       - name: Build exact release image
         shell: bash
         env:
+          AMD64_IMAGE: ${{ steps.image.outputs.amd64_tag }}
           IMAGE_LABELS: ${{ steps.meta.outputs.labels }}
         run: |
           set -euo pipefail
@@ -267,7 +293,7 @@ jobs:
               label_args+=(--label "${label}")
             fi
           done <<< "${IMAGE_LABELS}"
-          docker build "${label_args[@]}" -t dbt-nova:release-smoke .
+          docker build "${label_args[@]}" -t dbt-nova:release-smoke -t "${AMD64_IMAGE}" .
 
       - name: Smoke HTTP container
         shell: bash
@@ -304,16 +330,94 @@ jobs:
           test "$health_ok" -eq 1
           test "$ready_ok" -eq 1
 
-      - name: Push exact smoke-tested image
+      - name: Scan smoke-tested image report
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: image
+          image-ref: dbt-nova:release-smoke
+          scanners: vuln
+          vuln-type: os,library
+          severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+          ignore-unfixed: true
+          trivyignores: .trivyignore.yaml
+          format: json
+          output: dbt-nova-oci-trivy.json
+          exit-code: "0"
+          timeout: 10m
+
+      - name: Gate smoke-tested image vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: image
+          image-ref: dbt-nova:release-smoke
+          scanners: vuln
+          vuln-type: os,library
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          trivyignores: .trivyignore.yaml
+          format: table
+          exit-code: "1"
+          timeout: 10m
+
+      - name: Publish OCI scan report
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
+        with:
+          tag_name: ${{ needs.validate.outputs.release_tag }}
+          files: dbt-nova-oci-trivy.json
+
+      - name: Push smoke-tested AMD64 image
         shell: bash
         env:
-          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+          AMD64_IMAGE: ${{ steps.image.outputs.amd64_tag }}
         run: |
           set -euo pipefail
-          while IFS= read -r tag; do
-            if [ -z "${tag}" ]; then
-              continue
-            fi
-            docker tag dbt-nova:release-smoke "${tag}"
-            docker push "${tag}"
-          done <<< "${IMAGE_TAGS}"
+          docker push "${AMD64_IMAGE}"
+
+      - name: Build and push ARM64 image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.image.outputs.arm64_tag }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+
+      - name: Publish multi-arch manifest
+        id: manifest
+        shell: bash
+        env:
+          AMD64_IMAGE: ${{ steps.image.outputs.amd64_tag }}
+          ARM64_IMAGE: ${{ steps.image.outputs.arm64_tag }}
+          IMAGE: ${{ steps.image.outputs.image }}
+          RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
+          COMMIT_SHA: ${{ steps.image.outputs.commit_sha }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${RELEASE_TAG}" \
+            --tag "${IMAGE}:sha-${COMMIT_SHA}" \
+            "${AMD64_IMAGE}" \
+            "${ARM64_IMAGE}"
+          digest="$(docker buildx imagetools inspect "${IMAGE}:${RELEASE_TAG}" | awk '/^Digest:/ { print $2; exit }')"
+          if [ -z "${digest}" ]; then
+            echo "Failed to resolve OCI manifest digest."
+            exit 1
+          fi
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish OCI provenance
+        if: ${{ !github.event.repository.private }}
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be
+        with:
+          subject-name: ${{ steps.image.outputs.image }}
+          subject-digest: ${{ steps.manifest.outputs.digest }}
+          push-to-registry: true
+
+      - name: Sign OCI manifest digest
+        shell: bash
+        env:
+          COSIGN_YES: "1"
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+          IMAGE: ${{ steps.image.outputs.image }}
+        run: cosign sign "${IMAGE}@${DIGEST}"

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,19 @@
+# Trivy release-image waivers.
+#
+# Policy for future entries:
+# - keep this file empty by default;
+# - add only targeted HIGH/CRITICAL waivers needed to unblock a release;
+# - include an `expired_at` review date;
+# - include owner, reason, and remediation/review context in `statement`.
+#
+# Example:
+# vulnerabilities:
+#   - id: CVE-YYYY-NNNN
+#     purls:
+#       - "pkg:deb/debian/example"
+#     expired_at: 2026-06-30
+#     statement: "owner: @maintainer; reason: no fixed package is available; review: replace when patched"
+vulnerabilities: []
+misconfigurations: []
+secrets: []
+licenses: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `dbt-nova eval validate`, repeatable `--case-id` filters for bridge and
   agent eval runs, value-aware context assertions, agent `called_with` and
   ranked entity expectations, and ordered `top_unique_ids` trace evidence.
+- Release hardening now publishes native `linux-arm64` and `macos-x86_64`
+  binary assets, scans the release OCI image with Trivy, documents SBOM outputs
+  and crates.io posture, and adds container digest pinning plus a `/healthz`
+  Docker `HEALTHCHECK`.
 
 ### Fixed
 
@@ -42,6 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   GitHub Pages environment protection rules.
 - Release validation now fetches only the requested release tag, preventing local
   tag-clobber failures on tag-triggered release runs.
+- Release OCI publishing now produces a signed, attested multi-arch
+  `linux/amd64` + `linux/arm64` manifest while preserving a smoke-tested amd64
+  image path before publication.
+- CI coverage enforcement now ratchets the line floor to 70 percent, backed by
+  storage pruning behavior tests for release-critical artifact cache cleanup.
 
 ## [0.0.4] - 2026-04-26
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM rust:1.93-bookworm AS builder
+FROM rust:1.93-bookworm@sha256:7c4ae649a84014c467d79319bbf17ce2632ae8b8be123ac2fb2ea5be46823f31 AS builder
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -23,11 +23,12 @@ COPY vendor ./vendor
 
 RUN cargo build --locked --release --bin dbt-nova
 
-FROM debian:bookworm-slim AS runtime
+FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3 AS runtime
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       ca-certificates \
+      curl \
       libstdc++6 && \
     rm -rf /var/lib/apt/lists/*
 
@@ -46,5 +47,8 @@ USER 10001:10001
 WORKDIR /home/nova
 
 EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD curl -fsS "http://127.0.0.1:${PORT:-8080}/healthz" >/dev/null || exit 1
 
 ENTRYPOINT ["/usr/local/bin/dbt-nova", "server", "start"]

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -4,7 +4,9 @@ This repository uses GitHub Actions for CI, releases, and documentation.
 
 Operational defaults:
 
-- Linux runners are pinned to `ubuntu-22.04` for consistency.
+- Linux x86_64 runners are pinned to `ubuntu-22.04` for consistency; release
+  jobs use native ARM and Intel macOS runners where platform artifacts require
+  that architecture.
 - Jobs that execute on local runners set explicit `timeout-minutes` budgets.
 
 ## Workflows
@@ -17,7 +19,8 @@ Operational defaults:
   `cargo test --locked --all-features`, `cargo check --locked --no-default-features --all-targets`,
   `cargo check --locked --all-features` on Rust `1.93.0` (MSRV),
   `DBT_NOVA_EVAL_ENABLE_HYBRID=0 DBT_NOVA_EVAL_ENABLE_LIFECYCLE=0 DBT_NOVA_EVAL_ALLOW_EMBEDDING_DOWNLOAD=0 cargo test --locked --test search_eval compare_lexical_vs_hybrid_search_quality -- --ignored`,
-  `cargo llvm-cov --locked --all-features --workspace --summary-only`,
+  `cargo llvm-cov --locked --all-features --workspace --summary-only` with a
+  70 percent line coverage floor,
   `mkdocs build --strict` (with `docs/requirements.txt`), `scripts/check_advisory_ignores.sh`,
   `scripts/check_dependency_watchlist.sh`,
   `scripts/check_config_reference.sh`, and `cargo deny check advisories licenses sources`
@@ -124,9 +127,10 @@ Operational defaults:
   - validates tag is on `master`
   - validates `Cargo.toml` and `CHANGELOG.md` match the release tag version
   - runs one all-features Linux test gate
-  - builds and publishes **slim** assets for `linux-x86_64` and `macos-arm64`
-  - builds, smokes, and publishes a `linux/amd64` OCI image to
-    `ghcr.io/joe-broadhead/dbt-nova`
+  - builds and publishes **slim** assets for `linux-x86_64`, `linux-arm64`,
+    `macos-arm64`, and `macos-x86_64`
+  - builds, smokes, scans, signs, and publishes a multi-arch `linux/amd64` +
+    `linux/arm64` OCI image to `ghcr.io/joe-broadhead/dbt-nova`
 
 ### Docs Deploy
 

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -62,28 +62,42 @@ This repo uses four GitHub Actions workflows for releases and documentation:
      - validates tag is on `master`
      - validates the crate version and changelog entry match the tag
      - runs one all-features test gate on Linux before packaging
-     - builds and publishes slim assets for `linux-x86_64` (Cloud Run)
-       and `macos-arm64` (standard Apple Silicon macOS)
-     - builds, smokes, and publishes a `linux/amd64` OCI image to GHCR
+     - builds and publishes slim assets for `linux-x86_64`, `linux-arm64`,
+       `macos-arm64`, and `macos-x86_64`
+     - builds, smokes, scans, signs, and publishes a multi-arch
+       `linux/amd64` + `linux/arm64` OCI image to GHCR
 
 4. **Docs Deploy** (`.github/workflows/docs.yml`)
    - Trigger: `master` push or manual dispatch
    - Actions: builds MkDocs and publishes to GitHub Pages
 
-Release jobs now generate and publish checksum and cosign artifacts for every released platform,
-emit GitHub artifact provenance attestations for release files, and publish an
-OCI image to `ghcr.io/joe-broadhead/dbt-nova`.
+Release jobs generate and publish checksum, cosign, SBOM, and provenance artifacts
+for every released platform, and publish an OCI image to
+`ghcr.io/joe-broadhead/dbt-nova`.
 
 Note: GitHub provenance attestations are only emitted when supported by the repository plan/type.
 For user-owned private repositories, the attestation step is skipped.
 
 - `release.yml` emits `dbt-nova-<asset>.sha256` for each platform tarball.
+- `release.yml` emits `dbt-nova-<asset>.sbom.spdx.json` for each platform.
 - The checksum files are uploaded with slim assets.
 - Signature files are also uploaded:
   - `<tarball>.sig` / `<tarball>.crt`
   - `<checksum_file>.sig` / `<checksum_file>.crt` (for example: `dbt-nova-linux-x86_64.sha256.sig`)
+- The OCI image job uploads `dbt-nova-oci-trivy.json` with the release and fails
+  on unwaived HIGH/CRITICAL findings in the smoke-tested image.
 
 The installer validates checksum signatures by default when `DBT_NOVA_VERIFY_SIGNATURE=1`.
+
+Supported prebuilt binary targets:
+
+- `linux-x86_64`
+- `linux-arm64`
+- `macos-arm64`
+- `macos-x86_64`
+
+Windows binaries are not published in this release phase. Windows users should
+build from source until the project has a tested Windows CI/release path.
 
 Verify download integrity with:
 
@@ -118,7 +132,8 @@ gh attestation verify dbt-nova-linux-x86_64.tar.gz \
 ## Release Type
 
 - **Slim**: binary only (semantic layers are opt-in; models download only when enabled)
-- **OCI image**: hosted/server runtime image for streamable HTTP deployments
+- **OCI image**: hosted/server runtime image for streamable HTTP deployments,
+  published as a multi-arch `linux/amd64` + `linux/arm64` manifest
 
 Pull a released container image with:
 
@@ -134,6 +149,22 @@ ghcr.io/joe-broadhead/dbt-nova:sha-<git-sha>
 
 By default, releases include S3/GCS SDK support. If you need a minimal binary,
 build with `--no-default-features` and enable only the features you need.
+
+The project does not currently publish to crates.io. Supported distribution
+paths are GitHub release assets, the installer script, the GHCR OCI image, and
+source/local Cargo installs. Revisit crates.io only when the binary/native
+dependency packaging contract is intentionally supported in the release workflow.
+
+OCI scan waivers belong in `.trivyignore.yaml`. Waivers must be targeted and
+temporary: include the finding ID, optional path or package URL scope,
+`expired_at`, and a `statement` with owner, reason, and review/remediation
+context.
+
+The Dockerfile pins base image tags by digest for reproducible release rebuilds.
+Refresh digests intentionally by resolving the current manifest digest for
+`rust:1.93-bookworm` and `debian:bookworm-slim`, updating the `FROM` lines, and
+running the release container smoke path in CI. Do not update digests as part of
+unrelated code changes.
 
 ## Installer Script
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,7 +4,7 @@
 
 | Requirement | Minimum | Recommended |
 |-------------|---------|-------------|
-| **OS (prebuilt artifacts)** | Linux (x86_64), macOS (Apple Silicon) | Linux (x86_64) or macOS (Apple Silicon) |
+| **OS (prebuilt artifacts)** | Linux (x86_64/arm64), macOS (Apple Silicon/Intel) | Linux (x86_64/arm64) or macOS (Apple Silicon) |
 | **RAM** | 512 MB | 2 GB+ (4 GB with dense vectors) |
 | **Disk** | 100 MB | 500 MB+ (depends on manifest size) |
 | **Rust** | 1.93+ (edition 2024) | Latest stable |
@@ -175,9 +175,18 @@ the installer automatically falls back to slim.
 Published targets:
 
 - `linux-x86_64` (Cloud Run compatible)
+- `linux-arm64`
 - `macos-arm64` (Apple Silicon)
+- `macos-x86_64` (Intel macOS)
 
-Other platforms can build from source.
+Windows and other platforms can build from source. `cargo install dbt-nova`
+from crates.io is not currently a supported distribution path; use GitHub
+release assets, the installer script, the GHCR OCI image, or `cargo install
+--path . --locked` from a checked-out source tree.
+
+Each published target includes a `.sha256` file, cosign signature/certificate
+files for the archive and checksum, and an SPDX JSON SBOM named
+`dbt-nova-<target>.sbom.spdx.json`.
 
 Default builds include S3/GCS SDK support. If you need a minimal binary, build with
 `--no-default-features` and selectively enable `embeddings`, `s3`, and `gcs`.

--- a/docs/operations/hosted-deployment.md
+++ b/docs/operations/hosted-deployment.md
@@ -80,6 +80,9 @@ Pull the published release image instead:
 docker pull ghcr.io/joe-broadhead/dbt-nova:v<version>
 ```
 
+Release images are published as a multi-arch manifest for `linux/amd64` and
+`linux/arm64`.
+
 Run it locally:
 
 ```bash
@@ -111,6 +114,10 @@ Use one of these tags:
 
 Pin `vX.Y.Z` for downstream deployments. Use the `sha-...` tag when you need an
 immutable rollback target tied to a specific release commit.
+
+The published Dockerfile also defines a container `HEALTHCHECK` against
+`/healthz`. Platform-level probes should still be configured explicitly:
+`/healthz` for liveness and `/readyz` for traffic readiness.
 
 ## Cloud Run Notes
 

--- a/src/utils/storage.rs
+++ b/src/utils/storage.rs
@@ -119,3 +119,74 @@ fn dir_size_bytes(path: &Path) -> u64 {
 
     total
 }
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{self, File, OpenOptions};
+    use std::io::Write;
+    use std::path::Path;
+    use std::thread;
+    use std::time::Duration;
+
+    use fs4::FileExt;
+    use tempfile::TempDir;
+
+    use super::{IN_USE_LOCK_FILENAME, prune_dirs};
+
+    fn create_dir_with_file(root: &Path, name: &str, bytes: usize) -> std::path::PathBuf {
+        let dir = root.join(name);
+        fs::create_dir(&dir).expect("create storage dir");
+        let mut file = File::create(dir.join("payload.bin")).expect("create payload");
+        file.write_all(&vec![b'x'; bytes]).expect("write payload");
+        dir
+    }
+
+    #[test]
+    fn prune_dirs_respects_excludes_and_keeps_newest_entries() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = temp.path();
+
+        let old = create_dir_with_file(root, "old", 8);
+        thread::sleep(Duration::from_millis(20));
+        let keep = create_dir_with_file(root, "keep", 8);
+        thread::sleep(Duration::from_millis(20));
+        let newest = create_dir_with_file(root, "newest", 8);
+
+        prune_dirs(root, 1, 0, 0, &["keep"]).expect("prune dirs");
+
+        assert!(
+            !old.exists(),
+            "oldest non-excluded directory should be pruned"
+        );
+        assert!(keep.exists(), "excluded directory should be preserved");
+        assert!(newest.exists(), "newest directory should be preserved");
+    }
+
+    #[test]
+    fn prune_dirs_preserves_locked_storage_directories() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = temp.path();
+
+        let locked = create_dir_with_file(root, "locked", 16);
+        let lock_file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(locked.join(IN_USE_LOCK_FILENAME))
+            .expect("open lock file");
+        lock_file.try_lock_exclusive().expect("lock storage dir");
+
+        let removable = create_dir_with_file(root, "removable", 16);
+
+        prune_dirs(root, 0, 0, 1, &[]).expect("prune dirs");
+
+        assert!(locked.exists(), "locked directory should be preserved");
+        assert!(
+            !removable.exists(),
+            "unlocked directory should be pruned to satisfy byte cap"
+        );
+
+        lock_file.unlock().expect("unlock storage dir");
+    }
+}


### PR DESCRIPTION
## Summary

Completes #187 by consolidating the remaining release/distribution hardening into code, workflow, docs, and tests.

- expands release binaries to linux-x86_64, linux-arm64, macos-arm64, and macos-x86_64
- changes release OCI publication to a signed, attested linux/amd64 + linux/arm64 manifest with a smoke-tested amd64 path
- adds Trivy release-image scan/gate plus waiver policy
- pins Docker base images by digest and adds a /healthz Docker HEALTHCHECK
- documents SBOM outputs, supported targets, crates.io posture, image architectures, rollback, and digest refresh process
- raises CI line coverage floor to 70 and adds storage pruning behavior tests

## Validation

- cargo fmt
- cargo fmt --check
- actionlint .github/workflows/release.yml .github/workflows/ci.yml
- uv run mkdocs build --strict
- git diff --check
- cargo test --locked --lib prune_dirs
- cargo test --locked prune_dirs

## Notes

The first broad cargo test --locked prune_dirs attempt failed locally at link time with No space left on device while building unrelated integration test binaries. I cleaned the Cargo target directory, freed 26.6 GiB, and reran the broader filtered command successfully. Docker is not installed locally, so container smoke, Trivy, and Buildx validation are left to GitHub Actions.