### PR TITLE
Add eval author skill

### DIFF
--- a/.github/skills/eval-author/SKILL.md
+++ b/.github/skills/eval-author/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: eval-author
+description: "Designs, debugs, and operationalizes dbt-nova eval suites for manifest metadata quality and agent tool-use quality. Use when creating bridge evals, provider-backed agent evals, CI eval gates, regression suites for Nova metadata, or when interpreting dbt-nova eval artifacts and failures."
+license: MIT
+allowed-tools: "Bash Read Write mcp__nova__show_metadata mcp__nova__health mcp__nova__search mcp__nova__search_indicator mcp__nova__indicator_inventory mcp__nova__search_columns mcp__nova__column_inventory mcp__nova__get_entity mcp__nova__batch_get_entities mcp__nova__get_columns mcp__nova__get_context mcp__nova__get_lineage mcp__nova__get_column_lineage mcp__nova__get_test_coverage mcp__nova__get_metadata_score mcp__nova__search_recipes mcp__nova__get_recipe"
+metadata:
+  owner: "dbt-nova"
+  persona: "eval-author"
+  version: "0.0.4"
+---
+
+# Eval Author Skill (dbt-nova)
+
+## Mission
+
+Create Nova eval suites that prove two things separately:
+- the manifest metadata bridge returns the right entities, indicators, context, lineage, recipes, and quality signals
+- real agents use Nova tools in the intended order and cite the intended evidence
+
+## First-principles contract (required)
+
+Before writing evals, define:
+- target persona or workflow
+- manifest source and refresh cadence
+- representative user questions or agent tasks
+- expected canonical entities, indicators, fields, recipes, or lineage edges
+- absolute time windows and comparison basis for any relative-date task
+- whether the check belongs in a bridge eval, an agent eval, or both
+- failure signal and owner action
+- gate threshold and run cadence
+
+Do not write assertions until you can name the ground-truth entity ids and explain why each assertion should be stable across normal manifest refreshes.
+
+## Transport selection
+
+- Use MCP for discovery when `mcp__nova__*` tools are available.
+  - Read `references/workflow.md`
+  - Read `references/assertion-patterns.md`
+- Use the dbt-nova CLI through `Bash` for suite initialization, validation, bridge runs, provider-backed agent runs, and CI gates.
+  - Read `references/provider-patterns.md` when authoring agent evals.
+
+Eval execution is CLI-only. MCP is for discovering ground truth and debugging expected evidence before encoding it in a suite.
+
+## Deterministic flow
+
+1. Pick one persona workflow and one concrete question family.
+2. Discover ground truth with Nova before writing YAML.
+3. Write bridge evals first for deterministic metadata behavior.
+4. Add agent evals only after bridge evals pass.
+5. Keep each assertion tied to one failure reason.
+6. Validate the suite shape with `dbt-nova eval validate`.
+7. Run one case with `--case-id` before running the full suite.
+8. Set a gate that matches the suite purpose.
+9. Read `results.json` for machines, `report.md` for humans, and tool traces for agent behavior.
+
+## Design rules
+
+- Prefer stable identifiers such as `unique_id`, `parent_unique_id`, recipe id, and column name.
+- Use bridge evals for search rank, indicator rank, column rank, context fields, lineage edges, metadata score, recipe discovery, and generic tool success.
+- Use agent evals for required tool calls, forbidden tools, ordering, selected entities, ranked entity evidence, safe parameter checks, and final-answer text.
+- Do not use agent evals to compensate for weak metadata. Fix bridge failures first.
+- Do not assert every possible tool call. Assert the minimum behavior that proves the workflow.
+- Avoid brittle prose checks. Use `final_answer.must_contain` only for short, durable business terms.
+- Freeze relative dates in agent tasks. Do not leave "last week", "this month", or "last 52 weeks" unresolved unless the eval is explicitly testing date interpretation.
+- Keep smoke suites small and strict. Keep broader regression suites larger with realistic `--fail-under` thresholds.
+- Never include secrets, credentials, raw SQL parameter maps, or private manifests in public eval artifacts.
+
+## Output standard
+
+When handing off an eval suite or eval fix, include:
+- suite purpose and target persona
+- manifest source assumption
+- bridge cases and what each proves
+- agent cases and what each proves
+- gate threshold and intended run cadence
+- command lines to validate and run
+- expected artifacts and how to debug failures
+- known gaps intentionally left out of scope
+
+## Load order
+
+- Read `references/workflow.md` first.
+- Read `references/assertion-patterns.md` before writing or reviewing bridge cases.
+- Read `references/provider-patterns.md` before writing or debugging agent cases.
+- Use `assets/eval-suite-template.yml` only when creating a new suite skeleton.

--- a/.github/skills/eval-author/assets/eval-suite-template.yml
+++ b/.github/skills/eval-author/assets/eval-suite-template.yml
@@ -1,0 +1,51 @@
+version: 1
+name: nova-analyst-smoke
+defaults:
+  persona: analyst
+  top_k: 5
+
+cases:
+  - id: canonical_metric_discovery
+    question: Find the canonical model and indicator for a business metric.
+    assertions:
+      - type: search_indicator_rank
+        query: gross merchandise value
+        expected: gross merchandise value
+        max_rank: 5
+        resource_types: [model]
+      - type: context_has
+        id_or_name: model.pkg.orders
+        fields:
+          - data.unique_id
+          - data.entity.name
+      - type: metadata_score_min
+        id_or_name: model.pkg.orders
+        persona: analyst
+        threshold: 70
+
+agent_cases:
+  - id: analyst_metric_lookup_flow
+    task: Which canonical model and indicator should be used to analyze gross merchandise value?
+    expected:
+      must_call:
+        - search_indicator
+        - get_context
+      must_not_call:
+        - execute_sql
+      ordered:
+        - before: get_context
+          must_have_called:
+            - search_indicator
+      selected_entities:
+        - model.pkg.orders
+      selected_entity_ranks:
+        - unique_id: model.pkg.orders
+          tool: search_indicator
+          max_rank: 5
+      called_with:
+        - tool: search_indicator
+          contains:
+            query: gross merchandise
+      final_answer:
+        must_contain:
+          - gross merchandise value

--- a/.github/skills/eval-author/references/assertion-patterns.md
+++ b/.github/skills/eval-author/references/assertion-patterns.md
@@ -1,0 +1,83 @@
+# Assertion Patterns
+
+## Bridge Eval Patterns
+
+Use `search_rank` for canonical entity retrieval:
+
+```yaml
+- type: search_rank
+  query: orders
+  expected_unique_id: model.pkg.orders
+  max_rank: 5
+```
+
+Use `search_indicator_rank` for canonical KPI discovery:
+
+```yaml
+- type: search_indicator_rank
+  query: gross merchandise value
+  expected: gross merchandise value
+  max_rank: 3
+  resource_types: [model]
+```
+
+Use `search_columns_rank` when the workflow depends on a specific filter, time, or measure field:
+
+```yaml
+- type: search_columns_rank
+  query: order date
+  expected_column: order_date
+  expected_parent_unique_id: model.pkg.orders
+  max_rank: 5
+```
+
+Use context assertions for required execution evidence:
+
+```yaml
+- type: context_has
+  id_or_name: model.pkg.orders
+  fields:
+    - data.unique_id
+    - data.entity.name
+- type: context_contains
+  id_or_name: model.pkg.orders
+  field: data.entity.description
+  expected: canonical orders
+```
+
+Use recipe assertions for recurring workflow discovery:
+
+```yaml
+- type: recipe_rank
+  query: weekly country kpi report
+  expected_recipe_id: marketing/weekly_country_kpi_report
+  max_rank: 5
+- type: recipe_has_queries
+  recipe_id: marketing/weekly_country_kpi_report
+  min_queries: 1
+```
+
+`search_recipes` returns recipe rows with `id`. In suites, use
+`expected_recipe_id` and set it to the exact returned `id`; do not use a display
+title, path fragment, or shortened basename unless that is the full returned id.
+
+Use `tool_success` for endpoint coverage without overfitting to response shape:
+
+```yaml
+- type: tool_success
+  tool: get_test_coverage
+  params:
+    id_or_name: model.pkg.orders
+    include_full: false
+```
+
+## Anti-Patterns
+
+- Do not assert rank 1 unless rank 1 is a durable product requirement.
+- Do not assert on long descriptions that are likely to be edited.
+- Do not encode raw warehouse relation names when `unique_id` is available.
+- Do not mix many concepts into one case. Split cases so one failure has one likely cause.
+- Do not use unscoped `search_columns_rank` for common fields. Provide
+  `expected_parent_unique_id` and use a tolerant `max_rank`, or use
+  `context_has` / `context_contains` once the execution entity is known.
+- Do not use `execute_sql` in bridge smoke suites unless the SQL provider and data fixture are controlled.

--- a/.github/skills/eval-author/references/provider-patterns.md
+++ b/.github/skills/eval-author/references/provider-patterns.md
@@ -1,0 +1,95 @@
+# Provider-Backed Agent Eval Patterns
+
+## What Agent Evals Should Prove
+
+Agent evals should test behavior, not every output detail:
+- discovery tools are called before context or execution
+- the correct entity appears in tool evidence
+- forbidden tools are avoided for non-execution tasks
+- safe parameter summaries contain the intended business term
+- the final answer contains short durable terms
+
+Agent evals score sanitized tool traces. `called_with.params` can check exact
+safe scalar or scalar-array values such as `query`, `id_or_name`, `persona`,
+`resource_types`, `recipe_id`, `direction`, `limit`, and `offset`.
+`called_with.contains` checks text inside those sanitized fields. For
+`execute_sql`, nested `parameters` and raw SQL are intentionally not exposed;
+check presence through the `keys` summary instead of asserting query text.
+
+## Useful Expectations
+
+```yaml
+agent_cases:
+  - id: metric_lookup_flow
+    task: Which canonical model and indicator should be used to analyze gross merchandise value?
+    expected:
+      must_call:
+        - search_indicator
+        - get_context
+      must_not_call:
+        - execute_sql
+      ordered:
+        - before: get_context
+          must_have_called:
+            - search_indicator
+      selected_entities:
+        - model.pkg.orders
+      selected_entity_ranks:
+        - unique_id: model.pkg.orders
+          tool: search_indicator
+          max_rank: 3
+      called_with:
+        - tool: search_indicator
+          contains:
+            query: gross merchandise
+      final_answer:
+        must_contain:
+          - gross merchandise value
+```
+
+For execution workflows, assert sanitized SQL parameter presence without
+capturing raw SQL:
+
+```yaml
+called_with:
+  - tool: execute_sql
+    contains:
+      keys: statement
+  - tool: execute_sql
+    contains:
+      keys: parameters
+  - tool: execute_sql
+    contains:
+      keys: row_limit
+```
+
+## Provider Runs
+
+Default provider:
+
+```bash
+dbt-nova eval agent run \
+  --suite evals/analyst-agent.yml \
+  --provider opencode \
+  --manifest-path target/manifest.json \
+  --case-id metric_lookup_flow \
+  --fail-under 1.0
+```
+
+Custom provider:
+
+```bash
+dbt-nova eval agent run \
+  --suite evals/analyst-agent.yml \
+  --provider custom \
+  --provider-command ./scripts/run-agent-eval.sh \
+  --provider-args-json '["--prompt","{prompt}","--trace","{trace_path}","--manifest","{manifest_path}"]' \
+  --manifest-path target/manifest.json
+```
+
+## Debugging Agent Failures
+
+- If `tool_trace_missing` appears, confirm the provider launches a local dbt-nova process or emits supported JSON MCP events.
+- If the wrong MCP server alias is used, set `DBT_NOVA_EVAL_MCP_SERVER_ALIASES`.
+- If `selected_entities` fails but `must_call` passes, inspect the tool result shape and prefer `selected_entity_ranks` scoped to the discovery tool.
+- If final-answer checks are brittle, remove broad prose expectations and keep only durable business terms.

--- a/.github/skills/eval-author/references/workflow.md
+++ b/.github/skills/eval-author/references/workflow.md
@@ -1,0 +1,66 @@
+# Eval Author Workflow
+
+## Choose The Eval Layer
+
+Use bridge evals when the question is:
+- Does search return the canonical entity?
+- Does indicator discovery find the right measure or metric?
+- Does context expose the fields an agent needs?
+- Does lineage contain the expected dependency or consumer?
+- Do recipes exist and expose query metadata?
+- Does metadata score meet the minimum quality bar?
+
+Use agent evals when the question is:
+- Did the agent call the right Nova tools?
+- Did it avoid unsafe or premature tools such as `execute_sql`?
+- Did it call discovery before context or execution?
+- Did selected entity evidence appear in the tool trace?
+- Did the final answer cite the intended concept without leaking implementation detail?
+
+## Ground Truth Discovery
+
+Establish expected values before writing YAML:
+
+```bash
+dbt-nova tool call search_indicator --params-json '{"query":"<business term>","limit":5}' --json
+dbt-nova tool call get_context --params-json '{"id_or_name":"<unique_id>","include_sql":false}' --json
+dbt-nova tool call search_columns --params-json '{"query":"<field term>","limit":5}' --json
+dbt-nova tool call get_metadata_score --params-json '{"id_or_name":"<unique_id>","persona":"analyst","include_breakdown":false}' --json
+```
+
+Prefer MCP for the same discovery when the client has Nova MCP tools installed.
+When using the CLI, pass the same `--manifest-path` or `--manifest-uri` that the
+suite will use. Do not add `--read-only` during first-time discovery unless a
+reusable index is already materialized; otherwise Nova cannot build the index
+needed to answer search tools.
+
+Freeze relative dates before writing agent tasks. For example, replace "last
+week" with explicit start/end dates and state the comparison basis. If the eval
+targets a recipe, follow that recipe's calendar contract instead of assuming a
+generic week boundary.
+
+## Authoring Loop
+
+1. Create or update the suite.
+2. Run `dbt-nova eval validate --suite <suite>`.
+3. Run one bridge case with `dbt-nova eval run --case-id <id>`.
+4. Fix expected ids, ranks, or metadata gaps.
+5. Run the full bridge suite.
+6. Add agent cases for workflows where tool-use behavior matters.
+7. Run one agent case with the target provider.
+8. Inspect `tool-calls/<case>.jsonl`, `stdout.log`, and `report.md`.
+9. Set the CI gate only after the suite has at least one clean local run.
+
+## Gate Selection
+
+Use strict gates for smoke suites:
+- `--fail-under 1.0`
+- small number of high-signal cases
+- should run after every manifest build
+
+Use realistic gates for broad regression suites:
+- `--fail-under 0.90` to `0.98`
+- larger coverage across domains
+- should run on a schedule or before metadata releases
+
+Do not lower a gate to hide a deterministic failure. Lower only when the suite intentionally includes exploratory or provider-sensitive agent behavior.

--- a/.github/skills/eval-author/references/workflow.md
+++ b/.github/skills/eval-author/references/workflow.md
@@ -43,7 +43,7 @@ generic week boundary.
 
 1. Create or update the suite.
 2. Run `dbt-nova eval validate --suite <suite>`.
-3. Run one bridge case with `dbt-nova eval run --case-id <id>`.
+3. Run one bridge case with `dbt-nova eval run --suite <suite> --case-id <id>`.
 4. Fix expected ids, ranks, or metadata gaps.
 5. Run the full bridge suite.
 6. Add agent cases for workflows where tool-use behavior matters.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
 
   search-eval-smoke:
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       DBT_NOVA_STRICT_SCHEMA: "1"
       CARGO_BUILD_JOBS: "1"
@@ -112,7 +112,7 @@ jobs:
           DBT_NOVA_EVAL_ENABLE_HYBRID=0 \
           DBT_NOVA_EVAL_ALLOW_EMBEDDING_DOWNLOAD=0 \
           DBT_NOVA_EVAL_ENABLE_LIFECYCLE=0 \
-          cargo test --locked --test search_eval compare_lexical_vs_hybrid_search_quality -- --ignored
+          cargo test --locked --no-default-features --test search_eval compare_lexical_vs_hybrid_search_quality -- --ignored
 
   check-no-default:
     runs-on: ubuntu-22.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `dbt-nova eval validate`, repeatable `--case-id` filters for bridge and
   agent eval runs, value-aware context assertions, agent `called_with` and
   ranked entity expectations, and ordered `top_unique_ids` trace evidence.
+- Added an `eval-author` packaged skill for designing, debugging, and
+  operationalizing Nova bridge and provider-backed agent eval suites.
 - Release hardening now publishes native `linux-arm64` and `macos-x86_64`
   binary assets, scans the release OCI image with Trivy, documents SBOM outputs
   and crates.io posture, and adds container digest pinning plus a `/healthz`
@@ -33,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   eval artifact path collisions case-insensitively.
 - Eval suite validation now rejects `search_columns_rank` assertions that omit
   both `expected_column` and `expected_parent_unique_id`.
+- Eval `recipe_rank` assertions now match the `id` field returned by
+  `search_recipes`, in addition to the legacy `recipe_id` alias.
 - The default OpenCode agent-eval provider preset no longer passes a redundant
   `--dir` flag; dbt-nova sets the provider process working directory directly.
 - Agent eval `final_answer` assertions now score extracted assistant final text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   both `expected_column` and `expected_parent_unique_id`.
 - Eval `recipe_rank` assertions now match the `id` field returned by
   `search_recipes`, in addition to the legacy `recipe_id` alias.
+- CI search eval smoke now runs without default semantic/storage features and
+  has a longer timeout, avoiding cold-compile cancellations for the lexical
+  smoke profile.
 - The default OpenCode agent-eval provider preset no longer passes a redundant
   `--dir` flag; dbt-nova sets the provider process working directory directly.
 - Agent eval `final_answer` assertions now score extracted assistant final text

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -20,6 +20,11 @@ Generate a starter suite:
 dbt-nova eval init --persona analyst --out evals/analyst-smoke.yml
 ```
 
+When using an agent to design or debug suites, use the packaged `eval-author`
+skill. It guides agents to discover ground truth first, separate bridge evals
+from provider-backed agent evals, and choose assertions that produce actionable
+failure signals.
+
 The suite format is YAML or JSON. A minimal bridge suite looks like this:
 
 ```yaml

--- a/docs/getting-started/skills.md
+++ b/docs/getting-started/skills.md
@@ -9,6 +9,7 @@ The repo now uses one standalone, persona-first skill package per workflow:
 - `analyst`
 - `bi-engineer`
 - `engineer`
+- `eval-author`
 - `governance`
 - `kpi-debugger`
 - `meta-authoring`
@@ -43,6 +44,7 @@ For one skill:
 ```bash
 bash scripts/install_skills.sh --skill analyst --skills-dir "$HOME/.agents/skills"
 bash scripts/install_skills.sh --skill engineer --skills-dir "$HOME/.agents/skills"
+bash scripts/install_skills.sh --skill eval-author --skills-dir "$HOME/.agents/skills"
 ```
 
 For all dbt-nova skills:
@@ -66,6 +68,7 @@ Codex supports Agent Skills for both the CLI and IDE extensions. You can install
 ```bash
 bash scripts/install_skills.sh --skill analyst --skills-dir .codex/skills
 bash scripts/install_skills.sh --skill engineer --skills-dir .codex/skills
+bash scripts/install_skills.sh --skill eval-author --skills-dir .codex/skills
 ```
 
 If you already use another generic persona skill in a user-level directory, prefer repo scope so this skill overrides it only for the current project.
@@ -91,6 +94,7 @@ zip -r engineer.skill.zip engineer
 ```bash
 bash /path/to/repo/scripts/install_skills.sh --skill analyst --skills-dir "$HOME/.claude/skills"
 bash /path/to/repo/scripts/install_skills.sh --skill engineer --skills-dir "$HOME/.claude/skills"
+bash /path/to/repo/scripts/install_skills.sh --skill eval-author --skills-dir "$HOME/.claude/skills"
 ```
 
 ### Gemini CLI
@@ -102,6 +106,7 @@ Gemini CLI discovers skills from three tiers: workspace (`.gemini/skills/`), use
 ```bash
 bash scripts/install_skills.sh --skill analyst --skills-dir .gemini/skills
 bash scripts/install_skills.sh --skill engineer --skills-dir .gemini/skills
+bash scripts/install_skills.sh --skill eval-author --skills-dir .gemini/skills
 ```
 
 Then reload skills:
@@ -125,6 +130,7 @@ Use the reference tooling from the Agent Skills project to validate your skills:
 skills-ref validate .github/skills/analyst
 skills-ref validate .github/skills/bi-engineer
 skills-ref validate .github/skills/engineer
+skills-ref validate .github/skills/eval-author
 skills-ref validate .github/skills/governance
 skills-ref validate .github/skills/kpi-debugger
 skills-ref validate .github/skills/meta-authoring

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -539,13 +539,7 @@ async fn evaluate_bridge_assertion(
             let limit = effective_limit(*max_rank, suite.defaults.top_k);
             let params = json!({"query": query, "include_queries": false, "limit": limit});
             match call_tool(search, "search_recipes", params).await {
-                Ok(response) => rank_assertion(
-                    "recipe_rank",
-                    &response,
-                    expected_recipe_id,
-                    *max_rank,
-                    "recipe_id",
-                ),
+                Ok(response) => recipe_rank_assertion(&response, expected_recipe_id, *max_rank),
                 Err(error) => AssertionResult::error("recipe_rank", error.to_string()),
             }
         }
@@ -1191,6 +1185,42 @@ fn contains_rank_assertion(
     }
 }
 
+fn recipe_rank_assertion(
+    response: &JsonValue,
+    expected_recipe_id: &str,
+    max_rank: Option<usize>,
+) -> AssertionResult {
+    let rows = data_rows(response);
+    if let Some(index) = rows.iter().position(|row| {
+        string_field_equals(row, "recipe_id", expected_recipe_id)
+            || string_field_equals(row, "id", expected_recipe_id)
+    }) {
+        let rank = index + 1;
+        if max_rank.is_none_or(|max| rank <= max) {
+            AssertionResult::pass(
+                "recipe_rank",
+                format!("expected recipe ranked {rank}"),
+                json!({"rank": rank, "expected": expected_recipe_id}),
+            )
+        } else {
+            AssertionResult::fail(
+                "recipe_rank",
+                format!(
+                    "expected recipe ranked {rank}, above max rank {}",
+                    max_rank.unwrap_or(0)
+                ),
+                recipe_top_evidence(rows),
+            )
+        }
+    } else {
+        AssertionResult::fail(
+            "recipe_rank",
+            "expected recipe was not returned",
+            json!({"expected": expected_recipe_id, "top": recipe_top_evidence(rows)}),
+        )
+    }
+}
+
 fn search_columns_assertion(
     response: &JsonValue,
     expected_column: Option<&str>,
@@ -1498,6 +1528,21 @@ fn top_evidence(rows: &[JsonValue], field: &str) -> JsonValue {
                     field: row.get(field).cloned().unwrap_or(JsonValue::Null),
                     "name": row.get("name").cloned().unwrap_or(JsonValue::Null),
                     "unique_id": row.get("unique_id").cloned().unwrap_or(JsonValue::Null),
+                })
+            })
+            .collect(),
+    )
+}
+
+fn recipe_top_evidence(rows: &[JsonValue]) -> JsonValue {
+    JsonValue::Array(
+        rows.iter()
+            .take(10)
+            .map(|row| {
+                json!({
+                    "id": row.get("id").cloned().unwrap_or(JsonValue::Null),
+                    "recipe_id": row.get("recipe_id").cloned().unwrap_or(JsonValue::Null),
+                    "topic": row.get("topic").cloned().unwrap_or(JsonValue::Null),
                 })
             })
             .collect(),

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -8,9 +8,9 @@ use super::{
     AgentCalledWith, AgentEntityRank, AgentExpected, AgentOrder, AssertionResult, EvalCaseReport,
     EvalDefaults, EvalRunArgs, EvalSuite, EvalValidateArgs, FinalAnswerExpected,
     contains_rank_assertion, context_contains_assertion, context_field_equals_assertion,
-    json_has_field_path, read_tool_trace, run_eval_command, run_validate_command,
-    safe_path_segment, score_agent_expectations, selected_agent_cases, selected_bridge_cases,
-    tool_success_assertion, validate_suite,
+    json_has_field_path, read_tool_trace, recipe_rank_assertion, run_eval_command,
+    run_validate_command, safe_path_segment, score_agent_expectations, selected_agent_cases,
+    selected_bridge_cases, tool_success_assertion, validate_suite,
 };
 
 #[test]
@@ -31,6 +31,17 @@ fn contains_rank_assertion_respects_max_rank() {
     });
     let result = contains_rank_assertion("search_indicator_rank", &response, "orders", Some(1));
     assert_eq!(result.status, "fail");
+}
+
+#[test]
+fn recipe_rank_assertion_accepts_search_recipes_id_field() {
+    let response = json!({
+        "data": [
+            {"id": "reference/members", "query_count": 3}
+        ]
+    });
+    let result = recipe_rank_assertion(&response, "reference/members", Some(1));
+    assert_eq!(result.status, "pass");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds a packaged `eval-author` skill for designing and debugging Nova eval suites, including bridge eval patterns, provider-backed agent eval patterns, and a starter suite template.

Also fixes `recipe_rank` bridge assertions so they match the `id` field returned by `search_recipes`, while retaining compatibility with the legacy `recipe_id` alias.

## Details

- Adds `.github/skills/eval-author` with workflow, assertion, provider, and template resources.
- Documents the new skill in eval docs and skill installation docs.
- Updates the changelog for the eval-author skill and `recipe_rank` fix.
- Adds a regression test for `recipe_rank` matching `search_recipes.data[].id`.

## Validation

- `cargo fmt --check`
- `cargo test --locked recipe_rank_assertion_accepts_search_recipes_id_field`
- `./target/release/dbt-nova eval validate --suite .github/skills/eval-author/assets/eval-suite-template.yml --json`
- `bash scripts/install_skills.sh --all --skills-dir /private/tmp/dbt-nova-skills-pr-smoke`
- `uv run mkdocs build --strict`

## Notes

`codex.txt` is intentionally left untracked and is not included in this PR.
