### PR TITLE
Fix release OCI image publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,15 +236,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ needs.validate.outputs.release_tag }}
+          fetch-depth: 0
 
       - name: Resolve image metadata
         id: image
         shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
         run: |
           set -euo pipefail
           image="ghcr.io/${GITHUB_REPOSITORY,,}"
-          commit_sha="$(git rev-parse HEAD)"
+          git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          commit_sha="$(git rev-list -n1 "${RELEASE_TAG}")"
           echo "image=${image}" >> "$GITHUB_OUTPUT"
           echo "commit_sha=${commit_sha}" >> "$GITHUB_OUTPUT"
           echo "amd64_tag=${image}:sha-${commit_sha}-amd64" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,7 @@ jobs:
         with:
           tag_name: ${{ needs.validate.outputs.release_tag }}
           body_path: RELEASE_NOTES.md
+          overwrite_files: true
           files: |
             dbt-nova-${{ matrix.asset }}.tar.gz
             dbt-nova-${{ matrix.asset }}.sha256
@@ -280,6 +281,26 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
+      - name: Prepare OCI binaries
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          rm -rf dist/oci
+          rm -f dbt-nova-linux-x86_64.tar.gz dbt-nova-linux-arm64.tar.gz
+          mkdir -p dist/oci/linux-amd64 dist/oci/linux-arm64
+
+          gh release download "${RELEASE_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern "dbt-nova-linux-x86_64.tar.gz" \
+            --pattern "dbt-nova-linux-arm64.tar.gz"
+
+          tar -xzf dbt-nova-linux-x86_64.tar.gz -C dist/oci/linux-amd64
+          tar -xzf dbt-nova-linux-arm64.tar.gz -C dist/oci/linux-arm64
+          chmod 0755 dist/oci/linux-amd64/dbt-nova dist/oci/linux-arm64/dbt-nova
+
       - name: Build exact release image
         shell: bash
         env:
@@ -293,7 +314,14 @@ jobs:
               label_args+=(--label "${label}")
             fi
           done <<< "${IMAGE_LABELS}"
-          docker build "${label_args[@]}" -t dbt-nova:release-smoke -t "${AMD64_IMAGE}" .
+          docker build \
+            --platform linux/amd64 \
+            -f Dockerfile.oci \
+            --build-arg TARGETARCH=amd64 \
+            "${label_args[@]}" \
+            -t dbt-nova:release-smoke \
+            -t "${AMD64_IMAGE}" \
+            .
 
       - name: Smoke HTTP container
         shell: bash
@@ -363,6 +391,7 @@ jobs:
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
         with:
           tag_name: ${{ needs.validate.outputs.release_tag }}
+          overwrite_files: true
           files: dbt-nova-oci-trivy.json
 
       - name: Push smoke-tested AMD64 image
@@ -377,10 +406,12 @@ jobs:
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
+          file: Dockerfile.oci
           platforms: linux/arm64
           push: true
           tags: ${{ steps.image.outputs.arm64_tag }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: TARGETARCH=arm64
           provenance: false
 
       - name: Publish multi-arch manifest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed release OCI publishing to build images from native Linux release binaries
+  instead of compiling Rust inside the ARM64 Docker/QEMU path.
+
 ## [0.0.5] - 2026-05-13
 
 ### Added

--- a/Dockerfile.oci
+++ b/Dockerfile.oci
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1.7
+
+FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3 AS runtime
+
+ARG TARGETARCH
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      libstdc++6 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN useradd --system --create-home --uid 10001 nova
+
+ENV DBT_NOVA_SERVER_TRANSPORT=streamable_http \
+    DBT_NOVA_HTTP_PATH=/mcp \
+    DBT_NOVA_HTTP_EXPECT_AUTH_PROXY=true \
+    DBT_NOVA_STORAGE_DIR=/tmp/dbt-nova \
+    DBT_NOVA_EMBEDDINGS_CACHE_DIR=/tmp/dbt-nova/models \
+    PORT=8080
+
+COPY dist/oci/linux-${TARGETARCH}/dbt-nova /usr/local/bin/dbt-nova
+RUN chmod 0755 /usr/local/bin/dbt-nova
+
+USER 10001:10001
+WORKDIR /home/nova
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD curl -fsS "http://127.0.0.1:${PORT:-8080}/healthz" >/dev/null || exit 1
+
+ENTRYPOINT ["/usr/local/bin/dbt-nova", "server", "start"]


### PR DESCRIPTION
## Summary
- build release OCI images from the already-published native Linux release binaries
- add a runtime-only OCI Dockerfile so ARM64 does not compile Rust under QEMU
- allow release asset/report overwrites for safe workflow dispatch reruns

## Validation
- actionlint .github/workflows/release.yml
- git diff --check

## Recovery plan
After merge, dispatch the Release workflow with tag v0.0.5 to complete the OCI image publish without retagging.