### PR TITLE
Fix metadata audit changed no-target reporting

### DIFF
--- a/.github/workflows/nova-metadata-audit.yml
+++ b/.github/workflows/nova-metadata-audit.yml
@@ -830,11 +830,13 @@ jobs:
           scored_count="$(jq -r '.scored_count' "${report_path}")"
           required_fail_count="$(jq -r '.summary.required_fail_count' "${report_path}")"
           advisory_fail_count="$(jq -r '.summary.advisory_fail_count' "${report_path}")"
-          echo "gate_status=${gate_status}" >> "$GITHUB_OUTPUT"
-          echo "target_count=${target_count}" >> "$GITHUB_OUTPUT"
-          echo "scored_count=${scored_count}" >> "$GITHUB_OUTPUT"
-          echo "required_fail_count=${required_fail_count}" >> "$GITHUB_OUTPUT"
-          echo "advisory_fail_count=${advisory_fail_count}" >> "$GITHUB_OUTPUT"
+          {
+            echo "gate_status=${gate_status}"
+            echo "target_count=${target_count}"
+            echo "scored_count=${scored_count}"
+            echo "required_fail_count=${required_fail_count}"
+            echo "advisory_fail_count=${advisory_fail_count}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Append audit summary
         if: ${{ always() && hashFiles('out/metadata-audit-report.md') != '' }}
@@ -868,4 +870,6 @@ jobs:
       - name: Fail on audit gate
         if: ${{ steps.audit.outputs.exit_code != '0' }}
         shell: bash
-        run: exit "${{ steps.audit.outputs.exit_code }}"
+        run: |
+          echo "metadata audit failed with exit code ${{ steps.audit.outputs.exit_code }}" >&2
+          exit 1

--- a/docs/features/metadata-audit.md
+++ b/docs/features/metadata-audit.md
@@ -98,7 +98,17 @@ When `selection_mode: changed` and `changed_files_json` is omitted on
 `pull_request` events, the reusable workflow resolves changed files from the
 immutable PR event SHAs (`pull_request.base.sha` and `pull_request.head.sha`)
 instead of the moving base branch name. This keeps reruns stable even after the
-base branch has advanced.
+base branch has advanced. If the workflow cannot fetch those immutable commits,
+it fails before running the audit rather than falling back to a moving branch
+tip.
+
+Changed-mode audits match dbt manifest entities by both `original_file_path`
+and `patch_path`, so changing either a model SQL file or its YAML properties
+file selects the model when the manifest records that path. If changed files
+under `models/` look like dbt SQL or YAML model/schema files but no manifest
+entity matches, Nova records a no-target advisory by default. Set
+`fail_on_no_targets: true` to make that condition a required failure while still
+emitting the JSON and Markdown audit reports.
 
 When using `dbt_generate_manifest: true`, prefer the same secret-bundle pattern
 as the Nova assets workflow so callers can work consistently across providers
@@ -117,7 +127,11 @@ jobs:
       dbt_secret_env_map_json: >-
         {"DBT_ACCESS_TOKEN":"DBT_ACCESS_TOKEN","DBT_BIGQUERY_KEYFILE_JSON":"DBT_BIGQUERY_KEYFILE_JSON"}
       selection_mode: changed
+      # Optional. Omit on pull_request events to let the workflow resolve
+      # immutable pull_request.base.sha...pull_request.head.sha changed files.
+      # changed_files_json: '["models/marts/orders.sql","models/marts/orders.yml"]'
       resource_types_json: '["model"]'
+      fail_on_no_targets: true
       storage_instance_id: analytics-metadata-audit
     secrets:
       DBT_NOVA_SECRET_BUNDLE_JSON: ${{ secrets.DBT_NOVA_SECRET_BUNDLE_JSON }}

--- a/src/cli/audit_cmd.rs
+++ b/src/cli/audit_cmd.rs
@@ -351,7 +351,9 @@ async fn build_metadata_audit_report(
     if selected_entity_ids.is_empty() {
         if args.fail_on_no_targets {
             required_fail_count = 1;
-        } else if changed_files_include_dbt_model_or_schema_paths(&inputs.changed_files) {
+        } else if inputs.selection_mode == MetadataAuditSelectionModeArg::Changed
+            && changed_files_include_dbt_model_or_schema_paths(&inputs.changed_files)
+        {
             advisory_fail_count = 1;
         }
     }
@@ -1043,6 +1045,39 @@ mod tests {
         assert_eq!(report.gate_status, "fail");
         assert_eq!(report.summary.required_fail_count, 1);
         assert_eq!(report.summary.advisory_fail_count, 0);
+    }
+
+    #[tokio::test]
+    async fn project_selection_no_target_ignores_changed_file_advisory() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let args = MetadataAuditArgs {
+            selection_mode: MetadataAuditSelectionModeArg::Project,
+            changed_files_json: Some("[\"models/marts/missing_model.sql\"]".to_string()),
+            resource_types_json: Some("[\"model\"]".to_string()),
+            manifest_path: Some(fixture_manifest_path_string()),
+            storage_instance_id: Some("audit-project-no-target-changed-files-test".to_string()),
+            cleanup_storage_on_start: true,
+            ..MetadataAuditArgs::default()
+        };
+        let mut inputs = super::parse_audit_inputs(&args).expect("audit inputs");
+        inputs.resource_types.clear();
+        let load_args = crate::cli::args::ManifestLoadArgs {
+            manifest_path: args.manifest_path.clone(),
+            storage_instance_id: args.storage_instance_id.clone(),
+            cleanup_storage_on_start: args.cleanup_storage_on_start,
+            ..crate::cli::args::ManifestLoadArgs::default()
+        };
+        let mut config = build_manifest_load_config(&load_args).expect("config");
+        config.storage_dir = temp_dir.path().to_string_lossy().to_string();
+        let loaded = execute_manifest_load(config).await.expect("load");
+        let report = super::build_metadata_audit_report(&loaded.search, &inputs, &args)
+            .await
+            .expect("report");
+        assert_eq!(report.target_count, 0);
+        assert_eq!(report.gate_status, "pass");
+        assert_eq!(report.summary.required_fail_count, 0);
+        assert_eq!(report.summary.advisory_fail_count, 0);
+        assert_eq!(report.summary.no_target_reason, None);
     }
 
     #[test]

--- a/src/cli/audit_cmd.rs
+++ b/src/cli/audit_cmd.rs
@@ -52,6 +52,7 @@ struct AuditSummary {
     advisory_fail_count: usize,
     pass_count: usize,
     no_target: bool,
+    no_target_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -308,16 +309,11 @@ async fn build_metadata_audit_report(
     args: &MetadataAuditArgs,
 ) -> Result<MetadataAuditReport> {
     let selected_entity_ids = select_entity_ids(search, inputs)?;
-    if selected_entity_ids.is_empty() && args.fail_on_no_targets {
-        return Err(DbtNovaError::ServerError(
-            "metadata audit selected no entities".to_string(),
-        ));
-    }
-
     let mut entities = Vec::with_capacity(selected_entity_ids.len());
     let mut required_fail_count = 0usize;
     let mut advisory_fail_count = 0usize;
     let mut pass_count = 0usize;
+    let no_target_reason = no_target_reason(inputs, args.fail_on_no_targets, &selected_entity_ids);
 
     for unique_id in &selected_entity_ids {
         let entity = search
@@ -352,6 +348,14 @@ async fn build_metadata_audit_report(
         None
     };
 
+    if selected_entity_ids.is_empty() {
+        if args.fail_on_no_targets {
+            required_fail_count = 1;
+        } else if changed_files_include_dbt_model_or_schema_paths(&inputs.changed_files) {
+            advisory_fail_count = 1;
+        }
+    }
+
     let gate_status = match (required_fail_count, advisory_fail_count) {
         (required, _) if required > 0 => "fail",
         (0, advisory) if advisory > 0 => "advisory",
@@ -375,6 +379,7 @@ async fn build_metadata_audit_report(
             advisory_fail_count,
             pass_count,
             no_target: selected_entity_ids.is_empty(),
+            no_target_reason,
         },
         project_summary,
         entities,
@@ -570,6 +575,42 @@ fn entity_matches_changed_files(entity: &ArchivedEntity, changed_files: &BTreeSe
             .is_some_and(|path| changed_files.contains(&path))
 }
 
+fn no_target_reason(
+    inputs: &AuditInputs,
+    fail_on_no_targets: bool,
+    selected_entity_ids: &[String],
+) -> Option<String> {
+    if !selected_entity_ids.is_empty() {
+        return None;
+    }
+    if inputs.selection_mode == MetadataAuditSelectionModeArg::Changed
+        && changed_files_include_dbt_model_or_schema_paths(&inputs.changed_files)
+    {
+        return Some(
+            "selection_mode=changed found dbt model/schema-looking changed files, but none matched manifest original_file_path or patch_path"
+                .to_string(),
+        );
+    }
+    fail_on_no_targets.then(|| "metadata audit selected no entities".to_string())
+}
+
+fn changed_files_include_dbt_model_or_schema_paths(changed_files: &[String]) -> bool {
+    changed_files
+        .iter()
+        .map(|path| normalize_path(path))
+        .any(|path| {
+            let extension = Path::new(&path)
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .map(str::to_ascii_lowercase);
+            let is_model_path = path.starts_with("models/");
+            let is_sql_model = is_model_path && extension.as_deref() == Some("sql");
+            let is_yaml_patch =
+                is_model_path && matches!(extension.as_deref(), Some("yml" | "yaml"));
+            is_sql_model || is_yaml_patch
+        })
+}
+
 fn patch_path_from_entity(entity: &ArchivedEntity) -> Option<String> {
     entity
         .to_json_value()
@@ -640,7 +681,7 @@ fn render_markdown_report(report: &MetadataAuditReport) -> String {
     );
 
     if report.summary.no_target {
-        out.push_str("No entities matched the selection.\n");
+        append_no_target_markdown(&mut out, report);
         return out;
     }
 
@@ -732,6 +773,13 @@ fn render_markdown_report(report: &MetadataAuditReport) -> String {
     }
 
     out
+}
+
+fn append_no_target_markdown(out: &mut String, report: &MetadataAuditReport) {
+    out.push_str("No entities matched the selection.\n");
+    if let Some(reason) = &report.summary.no_target_reason {
+        let _ = writeln!(out, "Reason: {reason}");
+    }
 }
 
 fn title_case(value: &str) -> String {
@@ -927,6 +975,76 @@ mod tests {
         assert!(entity_matches_changed_files(archived, &changed));
     }
 
+    #[tokio::test]
+    async fn changed_selection_no_target_for_model_yaml_is_advisory() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let args = MetadataAuditArgs {
+            selection_mode: MetadataAuditSelectionModeArg::Changed,
+            changed_files_json: Some("[\"models/marts/missing_model.yml\"]".to_string()),
+            manifest_path: Some(fixture_manifest_path_string()),
+            storage_instance_id: Some("audit-changed-no-target-advisory-test".to_string()),
+            cleanup_storage_on_start: true,
+            ..MetadataAuditArgs::default()
+        };
+        let inputs = super::parse_audit_inputs(&args).expect("audit inputs");
+        let load_args = crate::cli::args::ManifestLoadArgs {
+            manifest_path: args.manifest_path.clone(),
+            storage_instance_id: args.storage_instance_id.clone(),
+            cleanup_storage_on_start: args.cleanup_storage_on_start,
+            ..crate::cli::args::ManifestLoadArgs::default()
+        };
+        let mut config = build_manifest_load_config(&load_args).expect("config");
+        config.storage_dir = temp_dir.path().to_string_lossy().to_string();
+        let loaded = execute_manifest_load(config).await.expect("load");
+        let report = super::build_metadata_audit_report(&loaded.search, &inputs, &args)
+            .await
+            .expect("report");
+        assert_eq!(report.target_count, 0);
+        assert_eq!(report.gate_status, "advisory");
+        assert_eq!(report.summary.required_fail_count, 0);
+        assert_eq!(report.summary.advisory_fail_count, 1);
+        assert!(
+            report
+                .summary
+                .no_target_reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains("dbt model/schema-looking changed files")
+        );
+        assert!(render_markdown_report(&report).contains("Reason:"));
+    }
+
+    #[tokio::test]
+    async fn changed_selection_no_target_respects_fail_on_no_targets() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let args = MetadataAuditArgs {
+            selection_mode: MetadataAuditSelectionModeArg::Changed,
+            changed_files_json: Some("[\"models/marts/missing_model.sql\"]".to_string()),
+            manifest_path: Some(fixture_manifest_path_string()),
+            storage_instance_id: Some("audit-changed-no-target-fail-test".to_string()),
+            cleanup_storage_on_start: true,
+            fail_on_no_targets: true,
+            ..MetadataAuditArgs::default()
+        };
+        let inputs = super::parse_audit_inputs(&args).expect("audit inputs");
+        let load_args = crate::cli::args::ManifestLoadArgs {
+            manifest_path: args.manifest_path.clone(),
+            storage_instance_id: args.storage_instance_id.clone(),
+            cleanup_storage_on_start: args.cleanup_storage_on_start,
+            ..crate::cli::args::ManifestLoadArgs::default()
+        };
+        let mut config = build_manifest_load_config(&load_args).expect("config");
+        config.storage_dir = temp_dir.path().to_string_lossy().to_string();
+        let loaded = execute_manifest_load(config).await.expect("load");
+        let report = super::build_metadata_audit_report(&loaded.search, &inputs, &args)
+            .await
+            .expect("report");
+        assert_eq!(report.target_count, 0);
+        assert_eq!(report.gate_status, "fail");
+        assert_eq!(report.summary.required_fail_count, 1);
+        assert_eq!(report.summary.advisory_fail_count, 0);
+    }
+
     #[test]
     fn markdown_report_includes_gate_status() {
         let report = MetadataAuditReport {
@@ -946,6 +1064,7 @@ mod tests {
                 advisory_fail_count: 0,
                 pass_count: 0,
                 no_target: false,
+                no_target_reason: None,
             },
             project_summary: None,
             entities: vec![super::EntityAuditReport {


### PR DESCRIPTION
## Summary

- Preserve metadata-audit changed-mode reports when no manifest entity matches changed dbt model/schema-looking files.
- Mark unmatched changed SQL/YAML files under `models/` as an advisory by default, or a required failure when `fail_on_no_targets` is enabled.
- Keep JSON/Markdown report artifacts available before the CLI exits on a failing gate.
- Document immutable PR SHA changed-file behavior, `original_file_path`/`patch_path` matching, and `fail_on_no_targets` usage.
- Clean up the reusable workflow shell snippets so `actionlint` passes.

## Validation

- `cargo fmt --check`
- `cargo test --locked audit_cmd`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `actionlint .github/workflows/nova-metadata-audit.yml`
- `uv run mkdocs build --strict`

Linear: JOE-20