### PR TITLE
Lock config.meta fallback behavior

### DIFF
--- a/docs/features/nova-meta-overview.md
+++ b/docs/features/nova-meta-overview.md
@@ -10,6 +10,18 @@ Nova reads `meta.nova` at two levels:
 - **Entity-level**: models, sources, metrics (the model itself).
 - **Column-level**: inside `columns[].meta.nova`.
 
+dbt 1.11+ may place metadata under `config.meta` instead of legacy `meta`.
+Nova reads both locations at entity and column level:
+
+- If only `config.meta.nova` exists, Nova treats it like `meta.nova` for search,
+  context, column metadata, metadata scoring, and metadata audit.
+- If both legacy `meta.nova` and `config.meta.nova` exist and both are objects,
+  Nova deep-merges them with legacy `meta.nova` taking precedence on conflicts.
+- Null legacy values do not block fallback to `config.meta.nova`.
+- Non-Nova metadata fields used by Nova, such as `owner` and column
+  `primary_key`, follow the same legacy-first fallback from `meta` to
+  `config.meta`.
+
 ## Quick Examples
 
 ### Model-level (canonical dataset)

--- a/src/cli/audit_cmd.rs
+++ b/src/cli/audit_cmd.rs
@@ -885,7 +885,15 @@ mod tests {
     use crate::tests::common::fixture_manifest_path_string;
     use serde_json::Value as JsonValue;
     use serde_json::json;
+    use std::path::Path;
     use tempfile::TempDir;
+
+    fn fixture_path_string(fixture_name: &str) -> String {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join(format!("tests/fixtures/{fixture_name}"))
+            .to_string_lossy()
+            .to_string()
+    }
 
     #[test]
     fn normalize_path_strips_dot_prefix_and_backslashes() {
@@ -975,6 +983,61 @@ mod tests {
                 .expect("archive");
         let changed = std::collections::BTreeSet::from(["models/marts/orders.yml".to_string()]);
         assert!(entity_matches_changed_files(archived, &changed));
+    }
+
+    #[tokio::test]
+    async fn entity_selection_scores_config_meta_only_model() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let args = MetadataAuditArgs {
+            selection_mode: MetadataAuditSelectionModeArg::Entities,
+            entity_ids_json: Some("[\"model.pkg.config_meta_model\"]".to_string()),
+            manifest_path: Some(fixture_path_string("config_meta_only.json")),
+            storage_instance_id: Some("audit-config-meta-only-test".to_string()),
+            cleanup_storage_on_start: true,
+            personas_json: Some("[\"engineer\"]".to_string()),
+            thresholds_json: Some(
+                r#"{"entity":{"engineer":{"min_score":1,"severity":"required"}}}"#.to_string(),
+            ),
+            include_recommendations: Some(false),
+            ..MetadataAuditArgs::default()
+        };
+        let inputs = super::parse_audit_inputs(&args).expect("audit inputs");
+        let load_args = crate::cli::args::ManifestLoadArgs {
+            manifest_path: args.manifest_path.clone(),
+            storage_instance_id: args.storage_instance_id.clone(),
+            cleanup_storage_on_start: args.cleanup_storage_on_start,
+            ..crate::cli::args::ManifestLoadArgs::default()
+        };
+        let mut config = build_manifest_load_config(&load_args).expect("config");
+        config.storage_dir = temp_dir.path().to_string_lossy().to_string();
+        let loaded = execute_manifest_load(config).await.expect("load");
+        let report = super::build_metadata_audit_report(&loaded.search, &inputs, &args)
+            .await
+            .expect("report");
+
+        assert_eq!(report.target_count, 1);
+        assert_eq!(report.scored_count, 1);
+        assert_eq!(report.gate_status, "pass");
+        assert_eq!(report.entities[0].unique_id, "model.pkg.config_meta_model");
+        let engineer = report.entities[0]
+            .personas
+            .get("engineer")
+            .expect("engineer score");
+        assert!(engineer.overall_score > 0);
+        assert!(
+            engineer.categories["semantic"]["score"]
+                .as_u64()
+                .is_some_and(|score| score > 0)
+        );
+        assert!(
+            engineer.categories["governance"]["score"]
+                .as_u64()
+                .is_some_and(|score| score > 0)
+        );
+        assert_eq!(
+            engineer.breakdown["quality"]["primary_key"]["present"].as_bool(),
+            Some(true)
+        );
     }
 
     #[tokio::test]

--- a/src/manifest/search/summary/persona.rs
+++ b/src/manifest/search/summary/persona.rs
@@ -2,12 +2,14 @@ use std::collections::HashSet;
 
 use serde_json::Value as JsonValue;
 
-use crate::manifest::entity::{ArchivedEntity, ArchivedNovaGrain, ArchivedNovaMeta};
+use crate::manifest::entity::{
+    ArchivedEntity, ArchivedNovaGrain, ArchivedNovaMeta, entity_meta_field_json,
+};
 use crate::manifest::lineage_sql::{extract_ref_calls, sql_for_matching};
 use crate::utils::{SearchPersona, tokenize_alnum_lowercase};
 
 use super::{
-    ManifestSearch, compact_json_object, has_apparent_malformed_ref, path_present, truncate_str,
+    ManifestSearch, compact_json_object, has_apparent_malformed_ref, truncate_str, value_present,
 };
 
 #[derive(Clone, Copy)]
@@ -197,7 +199,7 @@ impl ManifestSearch {
             .and_then(JsonValue::as_f64)
             .unwrap_or(0.0);
         let entity_json = entity.to_json_value();
-        let has_owner = path_present(&entity_json, "meta.owner");
+        let has_owner = entity_owner_present(&entity_json);
         let has_primary_key = !Self::primary_key_columns(entity).is_empty();
         let missing_required_fields = self
             .nova_required_missing_from_json(entity.resource_type_str().unwrap_or(""), &entity_json)
@@ -351,7 +353,7 @@ impl ManifestSearch {
                 .and_then(JsonValue::as_u64)
                 .unwrap_or(0);
         let gate_policy = &self.config.governance_gate;
-        let owner_present = path_present(&entity_json, "meta.owner");
+        let owner_present = entity_owner_present(&entity_json);
         let required_fields_present = missing.is_empty();
         let tests_present = tests_total > 0;
         let compliance_tags_present = !has_pii || compliance_len > 0;
@@ -895,4 +897,10 @@ impl ManifestSearch {
         }
         tools
     }
+}
+
+fn entity_owner_present(entity_json: &JsonValue) -> bool {
+    entity_meta_field_json(entity_json, "owner")
+        .or_else(|| entity_json.get("owner"))
+        .is_some_and(value_present)
 }

--- a/src/tests/config_meta.rs
+++ b/src/tests/config_meta.rs
@@ -135,6 +135,82 @@ async fn test_search_supports_mixed_legacy_and_config_column_nova_metadata() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_engineer_persona_uses_config_meta_owner() {
+    let searcher = config_meta_searcher();
+    let result = searcher
+        .search(&SearchParams {
+            query: "revenue".to_string(),
+            resource_types: vec!["model".to_string()],
+            persona: Some("engineer".to_string()),
+            detail: Some(DetailLevel::Standard),
+            min_score: None,
+            fuzzy: false,
+            include_highlights: false,
+            include_sql: false,
+            explain: false,
+            pagination: PaginationParams {
+                limit: Some(5),
+                offset: 0,
+            },
+        })
+        .await
+        .json();
+
+    assert_eq!(result["success"].as_bool(), Some(true));
+    let row = result["data"]
+        .as_array()
+        .and_then(|rows| rows.first())
+        .expect("expected search row");
+    assert_eq!(
+        row["unique_id"].as_str(),
+        Some("model.pkg.config_meta_model")
+    );
+    assert_eq!(
+        row["persona_payload"]["selection_signals"]["has_owner"].as_bool(),
+        Some(true)
+    );
+    assert!(
+        !row["persona_payload"]["selection_rationale"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("owner metadata missing")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_governance_persona_uses_config_meta_owner() {
+    let searcher = config_meta_searcher();
+    let result = searcher
+        .search(&SearchParams {
+            query: "revenue".to_string(),
+            resource_types: vec!["model".to_string()],
+            persona: Some("governance".to_string()),
+            detail: Some(DetailLevel::Standard),
+            min_score: None,
+            fuzzy: false,
+            include_highlights: false,
+            include_sql: false,
+            explain: false,
+            pagination: PaginationParams {
+                limit: Some(5),
+                offset: 0,
+            },
+        })
+        .await
+        .json();
+
+    assert_eq!(result["success"].as_bool(), Some(true));
+    let row = result["data"]
+        .as_array()
+        .and_then(|rows| rows.first())
+        .expect("expected search row");
+    assert_eq!(
+        row["persona_payload"]["gate_signals"]["owner_present"].as_bool(),
+        Some(true)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_get_context_merges_legacy_and_config_column_meta() {
     let searcher = config_meta_searcher();
     let result = searcher

--- a/tests/fixtures/config_meta_only.json
+++ b/tests/fixtures/config_meta_only.json
@@ -80,6 +80,7 @@
             "meta": {
               "primary_key": true,
               "nova": {
+                "role": "measure",
                 "semantic_type": "order_id",
                 "synonyms": ["purchase_id"]
               }


### PR DESCRIPTION
## Summary

- Route search persona owner checks through the same `meta` to `config.meta` fallback used by metadata scoring.
- Extend config-meta regression coverage for engineer/governance persona payloads, mixed legacy/config column metadata, and metadata audit scoring.
- Document the dbt 1.11+ metadata precedence rule: config-only works, legacy object values overlay config object values, and null legacy values do not block config fallback.

## Validation

- `cargo fmt --check`
- `cargo test --locked config_meta`
- `cargo test --locked metadata_score`
- `cargo test --locked audit_cmd`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `uv run mkdocs build --strict`
- `git diff --check`

Linear: JOE-19