### PR TITLE
Add provenance footer to discovery payloads

### DIFF
--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -58,6 +58,25 @@ Common:
         },
         "selection_rationale": "Selection signals: includes metric definitions, declares semantic grain, has an explicit time field, 1 query-aligned dimension(s)."
       },
+      "provenance": {
+        "tier": "semantic_layer",
+        "owner": "analytics",
+        "readiness": {
+          "metadata_score": 91,
+          "metadata_grade": "A",
+          "doc_coverage_pct": 94.44,
+          "has_owner": true,
+          "has_nova_meta": true,
+          "tests_total": 6
+        },
+        "freshness": {
+          "status": "fresh",
+          "source": "manifest_generated_at",
+          "timestamp": "2026-06-16T08:00:00Z",
+          "age_days": 0,
+          "stale_after_days": 30
+        }
+      },
       "score": 12.5,
       "highlights": {
         "description": ["<em>customer</em> lifetime value calculation"]
@@ -79,6 +98,17 @@ Common:
 When omitted, `detail` uses the active result profile: `standard` for CLI/tool
 calls by default and `compact` for MCP by default. Explicit `detail` values
 override the profile.
+
+Search result rows include an additive `provenance` object for `compact`,
+`standard`, and `full` detail. `provenance.tier` is `semantic_layer` when
+canonical Nova measures or metrics are present, `curated` when owner/docs/tests
+or other meaningful metadata are present, and `raw` when metadata is sparse.
+`owner` is extracted from dbt metadata using legacy `meta` first and dbt 1.11+
+`config.meta` as fallback. `readiness` contains compact metadata score,
+documentation, owner, Nova metadata, and test-count signals. `freshness.status`
+is `fresh`, `stale`, or `unknown`; Nova uses source freshness timestamps when
+available, then manifest `metadata.generated_at`, and otherwise returns
+`unknown`.
 
 When `detail: "standard"` and the query matches Nova measures or metrics, search
 results include a compact `semantic_preview` with the matched measure/metric
@@ -392,6 +422,8 @@ One-shot context bundle. Returns lineage, columns, tests, docs, and summary stat
 
 Notes:
 - The `entity` object includes `nova_summary` and `grain_summary` when available.
+- The `entity` object and upstream/downstream lineage entities include the same
+  `provenance` object used by search results.
 - The `tests` object includes `columns_tested`, `columns_total`, and a limited `columns_without_tests` list.
 - The `tests.gaps` array includes `missing_pk_test` and `untested_column` entries (limited).
 - `analysis_hints` explains empty lineage or missing dependency metadata when detected.
@@ -414,6 +446,8 @@ Optional:
 
 Notes:
 - Response includes `lineage_status` and `lineage_hints` to explain empty lineage results.
+- Entity rows include the same additive `provenance` object used by search
+  results for `compact`, `standard`, and `full` detail.
 - Requested `depth` is capped by `DBT_NOVA_MAX_LINEAGE_DEPTH` (config `lineage_max_depth`).
 
 ```json

--- a/docs/config_defaults.json
+++ b/docs/config_defaults.json
@@ -364,5 +364,6 @@
     "require_required_fields": true,
     "require_compliance_for_pii": true,
     "block_on_failure": true
-  }
+  },
+  "provenance_stale_after_days": 30
 }

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -306,6 +306,10 @@ currently no environment overrides for these weights.
 - `DBT_NOVA_GOV_GATE_REQUIRE_COMPLIANCE_FOR_PII` – require compliance tags when PII is declared (`true`|`false`)
 - `DBT_NOVA_GOV_GATE_BLOCK_ON_FAILURE` – return blocking `fail` status on gate failure (`true`), or advisory-only status (`false`)
 
+## Provenance
+
+- `DBT_NOVA_PROVENANCE_STALE_AFTER_DAYS` – days after which source freshness or manifest-generated timestamps are marked `stale` in search, context, and lineage `provenance` blocks (default: `30`)
+
 ## Circuit Breakers
 
 - `DBT_NOVA_SEARCH_CIRCUIT_FAILURE_THRESHOLD` – failures before opening (default: `3`)

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -307,6 +307,8 @@ pub struct DbtNovaConfig {
     pub governance_required_fields: HashMap<String, Vec<String>>,
     /// Governance gate threshold policy for persona payloads
     pub governance_gate: GovernanceGateConfig,
+    /// Days after which provenance timestamps are marked stale.
+    pub provenance_stale_after_days: u64,
     /// Runtime bootstrap resolution status (not user-configurable).
     #[serde(skip)]
     pub bootstrap_status: Option<JsonValue>,
@@ -385,6 +387,7 @@ impl Default for DbtNovaConfig {
             layer_rules: Vec::new(),
             governance_required_fields: default_governance_required_fields(),
             governance_gate: GovernanceGateConfig::default(),
+            provenance_stale_after_days: 30,
             bootstrap_status: None,
             env_errors: Vec::new(),
         }
@@ -1244,6 +1247,10 @@ impl DbtNovaConfig {
         if let Some(value) = parse_bool("DBT_NOVA_GOV_GATE_BLOCK_ON_FAILURE") {
             self.governance_gate.block_on_failure = value;
         }
+
+        if let Some(value) = parse_u64("DBT_NOVA_PROVENANCE_STALE_AFTER_DAYS") {
+            self.provenance_stale_after_days = value;
+        }
     }
 }
 
@@ -1393,6 +1400,30 @@ mod tests {
         assert_eq!(config.mcp_result_profile, ResultProfile::Compact);
         assert_eq!(config.mcp_default_limit, 10);
         assert_eq!(config.mcp_max_page_size, 100);
+    }
+
+    #[test]
+    fn from_env_reads_provenance_stale_after_days() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let key = "DBT_NOVA_PROVENANCE_STALE_AFTER_DAYS";
+        let previous = std::env::var(key).ok();
+        // SAFETY: tests serialize environment mutation with `ENV_LOCK`.
+        unsafe { std::env::set_var(key, "7") };
+
+        let config = DbtNovaConfig::from_env();
+
+        match previous {
+            Some(value) => {
+                // SAFETY: tests serialize environment mutation with `ENV_LOCK`.
+                unsafe { std::env::set_var(key, value) };
+            }
+            None => {
+                // SAFETY: tests serialize environment mutation with `ENV_LOCK`.
+                unsafe { std::env::remove_var(key) };
+            }
+        }
+
+        assert_eq!(config.provenance_stale_after_days, 7);
     }
 
     #[test]

--- a/src/manifest/search/mod.rs
+++ b/src/manifest/search/mod.rs
@@ -1,5 +1,6 @@
 mod cache;
 mod core;
+mod provenance;
 mod semantic;
 mod summary;
 

--- a/src/manifest/search/provenance.rs
+++ b/src/manifest/search/provenance.rs
@@ -1,0 +1,374 @@
+use serde_json::Value as JsonValue;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::manifest::entity::{ArchivedEntity, entity_meta_field_json};
+
+use super::core::ManifestSearch;
+
+const SOURCE_FRESHNESS_PATHS: &[&str] = &[
+    "max_loaded_at",
+    "snapshotted_at",
+    "freshness.max_loaded_at",
+    "freshness.snapshotted_at",
+];
+const MANIFEST_FRESHNESS_PATHS: &[&str] = &["generated_at"];
+const SECONDS_PER_DAY: u64 = 86_400;
+const SECONDS_PER_DAY_I64: i64 = 86_400;
+
+impl ManifestSearch {
+    #[must_use]
+    pub(crate) fn provenance_for_archived(
+        &self,
+        unique_id: &str,
+        entity: &ArchivedEntity,
+    ) -> JsonValue {
+        let entity_json = entity.to_json_value();
+        self.provenance_for_archived_json(unique_id, entity, &entity_json)
+    }
+
+    #[must_use]
+    pub(crate) fn provenance_for_archived_json(
+        &self,
+        unique_id: &str,
+        entity: &ArchivedEntity,
+        entity_json: &JsonValue,
+    ) -> JsonValue {
+        let owner = owner_value(entity_json).cloned();
+        let has_owner = owner.as_ref().is_some_and(value_present);
+        let has_description = entity
+            .description_str()
+            .map(str::trim)
+            .is_some_and(|value| !value.is_empty());
+        let doc_coverage_pct = doc_coverage_pct(entity);
+        let tests_total = self.tests_total(unique_id, entity);
+        let has_nova_meta = entity.nova_meta().is_some();
+        let source_tier = source_tier(
+            entity,
+            has_owner,
+            has_description,
+            doc_coverage_pct,
+            tests_total,
+        );
+        let weights = self.config.metadata_score.persona_weights.governance;
+        let score = self.score_entity(unique_id, entity_json, false, false, weights);
+
+        let mut readiness = serde_json::Map::new();
+        readiness.insert(
+            "metadata_score".to_string(),
+            JsonValue::from(score.overall_score),
+        );
+        readiness.insert("metadata_grade".to_string(), JsonValue::String(score.grade));
+        readiness.insert(
+            "doc_coverage_pct".to_string(),
+            JsonValue::from(doc_coverage_pct),
+        );
+        readiness.insert("has_owner".to_string(), JsonValue::from(has_owner));
+        readiness.insert("has_nova_meta".to_string(), JsonValue::from(has_nova_meta));
+        readiness.insert(
+            "tests_total".to_string(),
+            JsonValue::from(tests_total as u64),
+        );
+
+        let mut obj = serde_json::Map::new();
+        obj.insert(
+            "tier".to_string(),
+            JsonValue::String(source_tier.to_string()),
+        );
+        if let Some(owner) = owner.filter(value_present) {
+            obj.insert("owner".to_string(), owner);
+        }
+        obj.insert("readiness".to_string(), JsonValue::Object(readiness));
+        obj.insert(
+            "freshness".to_string(),
+            self.freshness_provenance(entity_json),
+        );
+
+        compact_json_object(&mut obj);
+        JsonValue::Object(obj)
+    }
+
+    fn tests_total(&self, unique_id: &str, entity: &ArchivedEntity) -> usize {
+        let model_tests = self.tests_by_entity.get(unique_id).map_or(0, Vec::len);
+        let column_tests = entity
+            .column_names_iter()
+            .map(|column| {
+                let key = format!("{unique_id}:{column}");
+                self.tests_by_column.get(&key).map_or(0, Vec::len)
+            })
+            .sum::<usize>();
+        model_tests + column_tests
+    }
+
+    fn freshness_provenance(&self, entity_json: &JsonValue) -> JsonValue {
+        if let Some(timestamp) = timestamp_from_paths(entity_json, SOURCE_FRESHNESS_PATHS) {
+            return freshness_from_timestamp(
+                "source_freshness",
+                timestamp,
+                self.config.provenance_stale_after_days,
+            );
+        }
+
+        if let Some(timestamp) =
+            timestamp_from_paths(&self.manifest_metadata, MANIFEST_FRESHNESS_PATHS)
+        {
+            return freshness_from_timestamp(
+                "manifest_generated_at",
+                timestamp,
+                self.config.provenance_stale_after_days,
+            );
+        }
+
+        serde_json::json!({
+            "status": "unknown",
+            "reason": "no_freshness_timestamp"
+        })
+    }
+}
+
+fn owner_value(entity_json: &JsonValue) -> Option<&JsonValue> {
+    entity_meta_field_json(entity_json, "owner")
+        .filter(|value| value_present(value))
+        .or_else(|| {
+            entity_json
+                .get("owner")
+                .filter(|value| value_present(value))
+        })
+}
+
+fn source_tier(
+    entity: &ArchivedEntity,
+    has_owner: bool,
+    has_description: bool,
+    doc_coverage_pct: f64,
+    tests_total: usize,
+) -> &'static str {
+    if has_canonical_indicator(entity) {
+        return "semantic_layer";
+    }
+    if has_owner
+        || has_description
+        || entity.doc_blocks_present()
+        || entity.nova_meta().is_some()
+        || doc_coverage_pct > 0.0
+        || tests_total > 0
+    {
+        return "curated";
+    }
+    "raw"
+}
+
+fn has_canonical_indicator(entity: &ArchivedEntity) -> bool {
+    let Some(nova) = entity.nova_meta() else {
+        return false;
+    };
+    let has_measure = !nova.measures.is_empty();
+    let has_metric = nova.metric.is_some() || !nova.metrics.is_empty();
+    if nova.canonical && (has_measure || has_metric) {
+        return true;
+    }
+    nova.measures.iter().any(|measure| measure.canonical)
+        || nova.metric.as_ref().is_some_and(|metric| metric.canonical)
+        || nova.metrics.iter().any(|metric| metric.canonical)
+}
+
+fn doc_coverage_pct(entity: &ArchivedEntity) -> f64 {
+    let columns_total = entity.column_names_iter().count();
+    if columns_total == 0 {
+        return 0.0;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let documented = entity.columns_documented_count() as f64;
+    #[allow(clippy::cast_precision_loss)]
+    let total = columns_total as f64;
+    ((documented / total) * 10_000.0).round() / 100.0
+}
+
+fn timestamp_from_paths<'a>(root: &'a JsonValue, paths: &[&str]) -> Option<&'a str> {
+    paths.iter().find_map(|path| string_at_path(root, path))
+}
+
+fn string_at_path<'a>(root: &'a JsonValue, path: &str) -> Option<&'a str> {
+    let mut current = root;
+    for part in path.split('.') {
+        current = current.get(part)?;
+    }
+    current
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn freshness_from_timestamp(source: &str, timestamp: &str, stale_after_days: u64) -> JsonValue {
+    let Some(observed_at_secs) = parse_rfc3339_timestamp_secs(timestamp) else {
+        return serde_json::json!({
+            "status": "unknown",
+            "source": source,
+            "timestamp": timestamp,
+            "reason": "unparseable_timestamp"
+        });
+    };
+    let now_secs = now_utc_secs();
+    let age_secs = now_secs.saturating_sub(observed_at_secs);
+    let stale_after_secs = stale_after_days.saturating_mul(SECONDS_PER_DAY);
+    let status = if age_secs > stale_after_secs {
+        "stale"
+    } else {
+        "fresh"
+    };
+
+    serde_json::json!({
+        "status": status,
+        "source": source,
+        "timestamp": timestamp,
+        "age_days": age_secs / SECONDS_PER_DAY,
+        "stale_after_days": stale_after_days
+    })
+}
+
+fn now_utc_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_secs())
+}
+
+fn parse_rfc3339_timestamp_secs(value: &str) -> Option<u64> {
+    let value = value.trim();
+    if value.len() < 20 {
+        return None;
+    }
+    let year = value.get(0..4)?.parse::<i32>().ok()?;
+    let month = value.get(5..7)?.parse::<u32>().ok()?;
+    let day = value.get(8..10)?.parse::<u32>().ok()?;
+    let hour = value.get(11..13)?.parse::<u32>().ok()?;
+    let minute = value.get(14..16)?.parse::<u32>().ok()?;
+    let second = value.get(17..19)?.parse::<u32>().ok()?;
+    if value.get(4..5)? != "-"
+        || value.get(7..8)? != "-"
+        || !matches!(value.get(10..11)?, "T" | " ")
+        || value.get(13..14)? != ":"
+        || value.get(16..17)? != ":"
+        || !valid_ymdhms(year, month, day, hour, minute, second)
+    {
+        return None;
+    }
+
+    let offset = parse_offset_seconds(value.get(19..)?)?;
+    let days = days_from_civil(year, month, day);
+    let local_secs = days
+        .checked_mul(SECONDS_PER_DAY_I64)?
+        .checked_add(i64::from(hour * 3600 + minute * 60 + second))?;
+    let utc_secs = local_secs.checked_sub(offset)?;
+    u64::try_from(utc_secs).ok()
+}
+
+fn parse_offset_seconds(value: &str) -> Option<i64> {
+    let trimmed = value.trim();
+    let zone = if let Some(rest) = trimmed.strip_prefix('.') {
+        let zone_start = rest.find(['Z', '+', '-'])?;
+        &rest[zone_start..]
+    } else {
+        trimmed
+    };
+    if zone == "Z" {
+        return Some(0);
+    }
+
+    let sign = match zone.get(0..1)? {
+        "+" => 1_i64,
+        "-" => -1_i64,
+        _ => return None,
+    };
+    let hours = zone.get(1..3)?.parse::<i64>().ok()?;
+    let minutes = zone.get(4..6)?.parse::<i64>().ok()?;
+    if zone.get(3..4)? != ":" || hours > 23 || minutes > 59 {
+        return None;
+    }
+    Some(sign * (hours * 3600 + minutes * 60))
+}
+
+fn valid_ymdhms(year: i32, month: u32, day: u32, hour: u32, minute: u32, second: u32) -> bool {
+    (1..=12).contains(&month)
+        && (1..=days_in_month(year, month)).contains(&day)
+        && hour < 24
+        && minute < 60
+        && second < 60
+}
+
+fn days_in_month(year: i32, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+fn is_leap_year(year: i32) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
+fn days_from_civil(year: i32, month: u32, day: u32) -> i64 {
+    let month = i32::try_from(month).unwrap_or_default();
+    let day = i32::try_from(day).unwrap_or_default();
+    let year = year - i32::from(month <= 2);
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let year_of_era = year - era * 400;
+    let shifted_month = month + if month > 2 { -3 } else { 9 };
+    let day_of_year = (153 * shifted_month + 2) / 5 + day - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    i64::from(era) * 146_097 + i64::from(day_of_era) - 719_468
+}
+
+fn compact_json_value(value: &mut JsonValue) {
+    match value {
+        JsonValue::Object(obj) => compact_json_object(obj),
+        JsonValue::Array(arr) => {
+            for item in arr.iter_mut() {
+                compact_json_value(item);
+            }
+            arr.retain(value_present);
+        }
+        _ => {}
+    }
+}
+
+fn compact_json_object(obj: &mut serde_json::Map<String, JsonValue>) {
+    for value in obj.values_mut() {
+        compact_json_value(value);
+    }
+    obj.retain(|_, value| value_present(value));
+}
+
+fn value_present(value: &JsonValue) -> bool {
+    match value {
+        JsonValue::Null => false,
+        JsonValue::Bool(_) | JsonValue::Number(_) => true,
+        JsonValue::String(value) => !value.trim().is_empty(),
+        JsonValue::Array(values) => !values.is_empty(),
+        JsonValue::Object(values) => !values.is_empty(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_provenance_timestamp_parser_accepts_utc_and_offsets() {
+        let utc = parse_rfc3339_timestamp_secs("1970-01-01T00:00:00Z").unwrap();
+        let offset = parse_rfc3339_timestamp_secs("1970-01-01T01:30:00+01:30").unwrap();
+        let fractional = parse_rfc3339_timestamp_secs("1970-01-01T00:00:00.000Z").unwrap();
+
+        assert_eq!(utc, 0);
+        assert_eq!(offset, 0);
+        assert_eq!(fractional, 0);
+    }
+
+    #[test]
+    fn search_provenance_timestamp_parser_rejects_invalid_dates() {
+        assert!(parse_rfc3339_timestamp_secs("2025-02-29T00:00:00Z").is_none());
+        assert!(parse_rfc3339_timestamp_secs("2025-01-01T24:00:00Z").is_none());
+        assert!(parse_rfc3339_timestamp_secs("not-a-timestamp").is_none());
+    }
+}

--- a/src/manifest/search/provenance.rs
+++ b/src/manifest/search/provenance.rs
@@ -1,7 +1,7 @@
 use serde_json::Value as JsonValue;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::manifest::entity::{ArchivedEntity, entity_meta_field_json};
+use crate::manifest::entity::ArchivedEntity;
 
 use super::core::ManifestSearch;
 
@@ -126,8 +126,17 @@ impl ManifestSearch {
 }
 
 fn owner_value(entity_json: &JsonValue) -> Option<&JsonValue> {
-    entity_meta_field_json(entity_json, "owner")
+    entity_json
+        .get("meta")
+        .and_then(|meta| meta.get("owner"))
         .filter(|value| value_present(value))
+        .or_else(|| {
+            entity_json
+                .get("config")
+                .and_then(|config| config.get("meta"))
+                .and_then(|meta| meta.get("owner"))
+                .filter(|value| value_present(value))
+        })
         .or_else(|| {
             entity_json
                 .get("owner")
@@ -370,5 +379,24 @@ mod tests {
         assert!(parse_rfc3339_timestamp_secs("2025-02-29T00:00:00Z").is_none());
         assert!(parse_rfc3339_timestamp_secs("2025-01-01T24:00:00Z").is_none());
         assert!(parse_rfc3339_timestamp_secs("not-a-timestamp").is_none());
+    }
+
+    #[test]
+    fn search_provenance_owner_falls_back_when_legacy_owner_blank() {
+        let entity = serde_json::json!({
+            "meta": {
+                "owner": " "
+            },
+            "config": {
+                "meta": {
+                    "owner": "analytics"
+                }
+            }
+        });
+
+        assert_eq!(
+            owner_value(&entity).and_then(JsonValue::as_str),
+            Some("analytics")
+        );
     }
 }

--- a/src/manifest/search/summary.rs
+++ b/src/manifest/search/summary.rs
@@ -482,6 +482,11 @@ impl ManifestSearch {
         {
             obj.insert("persona_payload".to_string(), payload);
         }
+        let entity_json = entity_json_cache.get_or_insert_with(|| entity.to_json_value());
+        obj.insert(
+            "provenance".to_string(),
+            self.provenance_for_archived_json(unique_id, entity, entity_json),
+        );
 
         compact_json_object(&mut obj);
         JsonValue::Object(obj)

--- a/src/manifest/search/summary.rs
+++ b/src/manifest/search/summary.rs
@@ -482,12 +482,6 @@ impl ManifestSearch {
         {
             obj.insert("persona_payload".to_string(), payload);
         }
-        let entity_json = entity_json_cache.get_or_insert_with(|| entity.to_json_value());
-        obj.insert(
-            "provenance".to_string(),
-            self.provenance_for_archived_json(unique_id, entity, entity_json),
-        );
-
         compact_json_object(&mut obj);
         JsonValue::Object(obj)
     }

--- a/src/tests/context.rs
+++ b/src/tests/context.rs
@@ -72,7 +72,11 @@ async fn test_get_context_basic() {
         result.get("error")
     );
     let data = result.get("data").expect("response missing 'data'");
-    assert!(data.get("entity").is_some(), "Missing entity in context");
+    let entity = data.get("entity").expect("Missing entity in context");
+    assert!(
+        entity.pointer("/provenance/tier").is_some(),
+        "Missing entity provenance in context"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -95,9 +99,22 @@ async fn test_get_context_with_lineage() {
         },
     };
     let result = searcher.get_context(&params).await.json();
-    let has_entity = result.get("data").and_then(|d| d.get("entity")).is_some();
-    let has_error = result.get("error").is_some();
-    assert!(has_entity || has_error, "Should have entity or error");
+    let data = result.get("data").expect("response missing 'data'");
+    assert!(
+        data.pointer("/entity/provenance/tier").is_some(),
+        "Missing entity provenance in context"
+    );
+    let upstream_entities = data
+        .pointer("/upstream/entities")
+        .and_then(JsonValue::as_array)
+        .expect("response missing upstream entities");
+    assert!(
+        upstream_entities
+            .first()
+            .and_then(|entity| entity.pointer("/provenance/tier"))
+            .is_some(),
+        "Missing lineage entity provenance in context"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/lineage.rs
+++ b/src/tests/lineage.rs
@@ -29,6 +29,14 @@ async fn test_get_lineage_upstream() {
         .and_then(|d| d.get("entities"))
         .and_then(|d| d.as_array());
     assert!(data.is_some(), "Should return lineage data");
+    let entities = data.unwrap();
+    assert!(
+        entities
+            .first()
+            .and_then(|entity| entity.pointer("/provenance/tier"))
+            .is_some(),
+        "Should return provenance on standard lineage entities"
+    );
 }
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_lineage_downstream() {
@@ -101,6 +109,42 @@ async fn test_get_lineage_filter_by_type() {
         }
     }
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_lineage_full_detail_includes_provenance() {
+    let searcher = get_searcher();
+    let params = GetLineageParams {
+        id_or_name: "model.nova_test.int__campaign_features".to_string(),
+        direction: "upstream".to_string(),
+        depth: Some(1),
+        resource_types: vec![],
+        detail: Some(DetailLevel::Full),
+    };
+    let result = searcher.get_lineage(&params).await.json();
+    let success = result
+        .get("success")
+        .expect("response missing 'success' field")
+        .as_bool()
+        .expect("'success' field should be boolean");
+    assert!(
+        success,
+        "Expected success=true but got error: {:?}",
+        result.get("error")
+    );
+    let entities = result
+        .get("data")
+        .and_then(|data| data.get("entities"))
+        .and_then(JsonValue::as_array)
+        .expect("response missing lineage entities");
+    assert_eq!(
+        entities
+            .first()
+            .and_then(|entity| entity.pointer("/provenance/tier"))
+            .and_then(JsonValue::as_str),
+        Some("curated")
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_lineage_invalid_direction() {
     let searcher = get_searcher();

--- a/src/tests/search.rs
+++ b/src/tests/search.rs
@@ -108,6 +108,83 @@ fn indicator_row_position(
 
 // Search Tool Tests
 #[tokio::test(flavor = "multi_thread")]
+async fn test_search_summaries_include_provenance_tiers() {
+    let semantic_searcher = semantic_preview_env();
+    let semantic_result = semantic_searcher
+        .search(&search_params("gmv", None))
+        .await
+        .json();
+    let semantic_rows = result_rows(&semantic_result);
+    let semantic_row = row_by_unique_id(&semantic_rows, "model.pkg.fact_orders_canonical");
+    assert_eq!(
+        semantic_row
+            .pointer("/provenance/tier")
+            .and_then(JsonValue::as_str),
+        Some("semantic_layer")
+    );
+    assert_eq!(
+        semantic_row
+            .pointer("/provenance/freshness/status")
+            .and_then(JsonValue::as_str),
+        Some("unknown")
+    );
+    assert!(
+        semantic_row
+            .pointer("/provenance/readiness/metadata_grade")
+            .is_some()
+    );
+
+    let curated_searcher = get_searcher();
+    let curated_result = curated_searcher
+        .search(&search_params("traffic", None))
+        .await
+        .json();
+    let curated_rows = result_rows(&curated_result);
+    let curated_row = row_by_unique_id(&curated_rows, "model.nova_test.stg__traffic_sessions");
+    assert_eq!(
+        curated_row
+            .pointer("/provenance/tier")
+            .and_then(JsonValue::as_str),
+        Some("curated")
+    );
+
+    let raw_searcher = get_searcher_with_fixture("undocumented.json");
+    let raw_result = raw_searcher
+        .search(&search_params("docless", None))
+        .await
+        .json();
+    let raw_rows = result_rows(&raw_result);
+    let raw_row = row_by_unique_id(&raw_rows, "model.pkg.docless");
+    assert_eq!(
+        raw_row
+            .pointer("/provenance/tier")
+            .and_then(JsonValue::as_str),
+        Some("raw")
+    );
+    assert_eq!(
+        raw_row
+            .pointer("/provenance/freshness/status")
+            .and_then(JsonValue::as_str),
+        Some("unknown")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_search_full_detail_includes_provenance() {
+    let searcher = get_searcher_with_fixture("undocumented.json");
+    let mut params = search_params("docless", None);
+    params.detail = Some(DetailLevel::Full);
+
+    let result = searcher.search(&params).await.json();
+    let rows = result_rows(&result);
+    let row = row_by_unique_id(&rows, "model.pkg.docless");
+    assert_eq!(
+        row.pointer("/provenance/tier").and_then(JsonValue::as_str),
+        Some("raw")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_search_by_name() {
     let searcher = get_searcher();
     let params = SearchParams {

--- a/src/tools/context.rs
+++ b/src/tools/context.rs
@@ -61,6 +61,7 @@ pub struct EntityContext {
     pub nova_summary: Option<JsonValue>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub columns: Option<Vec<ColumnContext>>,
+    pub provenance: JsonValue,
 }
 
 #[derive(Debug, Serialize)]
@@ -94,6 +95,7 @@ pub struct LineageEntity {
     pub resource_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    pub provenance: JsonValue,
 }
 
 #[derive(Debug, Serialize)]
@@ -248,6 +250,18 @@ impl ManifestSearch {
         };
 
         let entity_json = entity.to_json_value();
+        let provenance = self.get_entity_archived(entity_id)?.map_or_else(
+            || {
+                serde_json::json!({
+                    "tier": "raw",
+                    "freshness": {
+                        "status": "unknown",
+                        "reason": "entity_not_archived"
+                    }
+                })
+            },
+            |archived| self.provenance_for_archived_json(entity_id, archived, &entity_json),
+        );
         let primary_key_columns = {
             let keys = primary_key_columns_from_entity(&entity_json);
             if keys.is_empty() { None } else { Some(keys) }
@@ -296,6 +310,7 @@ impl ManifestSearch {
             grain_summary,
             nova_summary,
             columns,
+            provenance,
         })
     }
 
@@ -436,6 +451,7 @@ impl ManifestSearch {
                     name: entity.name_str().unwrap_or("").to_string(),
                     resource_type: rt.to_string(),
                     description,
+                    provenance: self.provenance_for_archived(id, entity),
                 });
             }
         }

--- a/src/tools/lineage.rs
+++ b/src/tools/lineage.rs
@@ -157,11 +157,26 @@ impl ManifestSearch {
                 }
                 DetailLevel::Compact => {
                     if let Some(entity) = self.get_entity_archived(id)? {
-                        results.push(self.summary_for_compact(id, entity));
+                        let mut summary = self.summary_for_compact(id, entity);
+                        let entity_json = entity.to_json_value();
+                        let provenance =
+                            self.provenance_for_archived_json(id, entity, &entity_json);
+                        if let Some(obj) = summary.as_object_mut() {
+                            obj.insert("provenance".to_string(), provenance);
+                        }
+                        results.push(summary);
                     }
                 }
                 DetailLevel::Standard => {
-                    if let Ok(summary) = self.entity_summary(id) {
+                    if let Ok(mut summary) = self.entity_summary(id) {
+                        if let Some(entity) = self.get_entity_archived(id)? {
+                            let entity_json = entity.to_json_value();
+                            let provenance =
+                                self.provenance_for_archived_json(id, entity, &entity_json);
+                            if let Some(obj) = summary.as_object_mut() {
+                                obj.insert("provenance".to_string(), provenance);
+                            }
+                        }
                         results.push(summary);
                     } else {
                         results.push(serde_json::json!({

--- a/src/tools/lineage.rs
+++ b/src/tools/lineage.rs
@@ -143,12 +143,17 @@ impl ManifestSearch {
         for id in &result {
             match detail {
                 DetailLevel::Full => {
-                    let mut entity = self.get_entity_archived(id)?.map_or(
-                        JsonValue::Null,
-                        crate::manifest::entity::ArchivedEntity::to_json_value,
-                    );
-                    ManifestSearch::insert_unique_id(&mut entity, id);
-                    results.push(entity);
+                    if let Some(archived) = self.get_entity_archived(id)? {
+                        let mut entity = archived.to_json_value();
+                        ManifestSearch::insert_unique_id(&mut entity, id);
+                        let provenance = self.provenance_for_archived_json(id, archived, &entity);
+                        if let Some(obj) = entity.as_object_mut() {
+                            obj.insert("provenance".to_string(), provenance);
+                        }
+                        results.push(entity);
+                    } else {
+                        results.push(JsonValue::Null);
+                    }
                 }
                 DetailLevel::Compact => {
                     if let Some(entity) = self.get_entity_archived(id)? {

--- a/src/tools/lineage.rs
+++ b/src/tools/lineage.rs
@@ -67,7 +67,7 @@ impl ManifestSearch {
         if let Some(key) = cache_key.as_ref()
             && let Some(cached) = self.lineage_cache_get(key)
         {
-            return Ok(cached);
+            return self.refresh_lineage_response_provenance(cached);
         }
         let mut visited_depth: HashMap<String, usize> = HashMap::new();
         let mut result_set: HashSet<String> = HashSet::new();
@@ -230,6 +230,36 @@ impl ManifestSearch {
         Ok(response_value)
     }
 
+    fn refresh_lineage_response_provenance(&self, mut response: JsonValue) -> Result<JsonValue> {
+        let Some(entities) = response
+            .get_mut("data")
+            .and_then(|data| data.get_mut("entities"))
+            .and_then(JsonValue::as_array_mut)
+        else {
+            return Ok(response);
+        };
+
+        for entity_value in entities {
+            let Some(unique_id) = entity_value
+                .get("unique_id")
+                .and_then(JsonValue::as_str)
+                .map(str::to_string)
+            else {
+                continue;
+            };
+            let Some(entity) = self.get_entity_archived(&unique_id)? else {
+                continue;
+            };
+            let entity_json = entity.to_json_value();
+            let provenance = self.provenance_for_archived_json(&unique_id, entity, &entity_json);
+            if let Some(obj) = entity_value.as_object_mut() {
+                obj.insert("provenance".to_string(), provenance);
+            }
+        }
+
+        Ok(response)
+    }
+
     /// Analyze the downstream impact of changing an entity.
     ///
     /// # Errors
@@ -316,4 +346,46 @@ fn lineage_type_allowed(resource_type: Option<&str>, allowed: &[String]) -> bool
     allowed
         .iter()
         .any(|candidate| candidate.eq_ignore_ascii_case(resource_type))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::common::get_searcher;
+
+    #[test]
+    fn cached_lineage_response_refreshes_provenance() {
+        let searcher = get_searcher();
+        let response = serde_json::json!({
+            "success": true,
+            "data": {
+                "entities": [{
+                    "unique_id": "model.nova_test.dim__customers",
+                    "provenance": {
+                        "tier": "raw",
+                        "freshness": {
+                            "status": "fresh",
+                            "age_days": 999
+                        }
+                    }
+                }]
+            }
+        });
+
+        let refreshed = searcher
+            .refresh_lineage_response_provenance(response)
+            .expect("refresh provenance");
+        let entity = refreshed
+            .pointer("/data/entities/0")
+            .expect("lineage entity");
+
+        assert_ne!(
+            entity.pointer("/provenance/tier"),
+            Some(&JsonValue::String("raw".to_string()))
+        );
+        assert_ne!(
+            entity.pointer("/provenance/freshness/age_days"),
+            Some(&JsonValue::from(999))
+        );
+    }
 }

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -310,8 +310,14 @@ impl ManifestSearch {
                         strip_sql_fields(&mut entity_json);
                     }
                     ManifestSearch::insert_unique_id(&mut entity_json, &candidate.unique_id);
+                    let provenance = self.provenance_for_archived_json(
+                        &candidate.unique_id,
+                        entity,
+                        &entity_json,
+                    );
                     if let Some(obj) = entity_json.as_object_mut() {
                         obj.insert("score".to_string(), JsonValue::from(candidate.score));
+                        obj.insert("provenance".to_string(), provenance);
                         if let Some(highlights) = highlight_value {
                             obj.insert("highlights".to_string(), highlights);
                         }

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -339,7 +339,14 @@ impl ManifestSearch {
             } else if detail == DetailLevel::Compact {
                 if let Some(entity) = candidate.entity {
                     let mut summary = self.summary_for_compact(&candidate.unique_id, entity);
+                    let entity_json = entity.to_json_value();
+                    let provenance = self.provenance_for_archived_json(
+                        &candidate.unique_id,
+                        entity,
+                        &entity_json,
+                    );
                     if let Some(obj) = summary.as_object_mut() {
+                        obj.insert("provenance".to_string(), provenance);
                         obj.insert("score".to_string(), JsonValue::from(candidate.score));
                         if let Some(highlights) = highlight_value {
                             obj.insert("highlights".to_string(), highlights);
@@ -366,7 +373,14 @@ impl ManifestSearch {
                     persona,
                     Some(&tokens),
                 );
+                let provenance = candidate.entity.map(|entity| {
+                    let entity_json = entity.to_json_value();
+                    self.provenance_for_archived_json(&candidate.unique_id, entity, &entity_json)
+                });
                 if let Some(obj) = summary.as_object_mut() {
+                    if let Some(provenance) = provenance {
+                        obj.insert("provenance".to_string(), provenance);
+                    }
                     obj.insert("score".to_string(), JsonValue::from(candidate.score));
                     if let Some(highlights) = highlight_value {
                         obj.insert("highlights".to_string(), highlights);

--- a/tests/snapshots/snapshots__get_lineage_orders_upstream.snap
+++ b/tests/snapshots/snapshots__get_lineage_orders_upstream.snap
@@ -26,6 +26,21 @@ expression: result
         "name": "dim__customers",
         "original_file_path": "models/marts/core/dim__customers.sql",
         "package_name": "nova_test",
+        "provenance": {
+          "freshness": {
+            "reason": "no_freshness_timestamp",
+            "status": "unknown"
+          },
+          "readiness": {
+            "doc_coverage_pct": 100.0,
+            "has_nova_meta": false,
+            "has_owner": false,
+            "metadata_grade": "F",
+            "metadata_score": 2,
+            "tests_total": 0
+          },
+          "tier": "curated"
+        },
         "resource_type": "model",
         "schema": "dbt_test",
         "unique_id": "model.nova_test.dim__customers"
@@ -37,6 +52,21 @@ expression: result
         "name": "dim__products",
         "original_file_path": "models/marts/core/dim__products.sql",
         "package_name": "nova_test",
+        "provenance": {
+          "freshness": {
+            "reason": "no_freshness_timestamp",
+            "status": "unknown"
+          },
+          "readiness": {
+            "doc_coverage_pct": 100.0,
+            "has_nova_meta": false,
+            "has_owner": false,
+            "metadata_grade": "F",
+            "metadata_score": 2,
+            "tests_total": 0
+          },
+          "tier": "curated"
+        },
         "resource_type": "model",
         "schema": "dbt_test",
         "unique_id": "model.nova_test.dim__products"

--- a/tests/snapshots/snapshots__search_standard_models.snap
+++ b/tests/snapshots/snapshots__search_standard_models.snap
@@ -12,6 +12,21 @@ expression: result
       "name": "int__campaign_features",
       "original_file_path": "models/intermediate/marketing/int__campaign_features.sql",
       "package_name": "nova_test",
+      "provenance": {
+        "freshness": {
+          "reason": "no_freshness_timestamp",
+          "status": "unknown"
+        },
+        "readiness": {
+          "doc_coverage_pct": 100.0,
+          "has_nova_meta": false,
+          "has_owner": false,
+          "metadata_grade": "F",
+          "metadata_score": 4,
+          "tests_total": 0
+        },
+        "tier": "curated"
+      },
       "resource_type": "model",
       "schema": "dbt_test",
       "score": 0.032786883413791656,


### PR DESCRIPTION
## Summary
- Add a shared provenance builder for search, context, and lineage entity payloads.
- Include additive `provenance` blocks with source tier, owner, readiness signals, and freshness status.
- Add `DBT_NOVA_PROVENANCE_STALE_AFTER_DAYS` plus API/config docs and regenerated config defaults.
- Cover semantic_layer, curated, raw, and unknown freshness behavior in focused tests and update affected snapshots.

## Validation
- `cargo test --locked search`
- `cargo test --locked context`
- `cargo test --locked lineage`
- `cargo test --locked from_env_reads_provenance_stale_after_days`
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `uv run mkdocs build --strict`
- `bash scripts/check_config_reference.sh`
- `git diff --check`

Closes JOE-13