### PR TITLE
Add starter eval suite fixture

### DIFF
--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -54,6 +54,40 @@ Validate suite shape before running against a manifest or provider:
 dbt-nova eval validate --suite evals/analyst-smoke.yml
 ```
 
+## Run The Packaged Starter Suite
+
+dbt-nova ships `evals/starter.yml` plus a synthetic manifest fixture at
+`tests/fixtures/starter_eval_manifest.json`. The suite is intentionally small
+and strict: it checks canonical model search, indicator discovery, context,
+lineage, recipe discovery, metadata scoring, and one provider-backed agent
+tool-use flow.
+
+Validate the starter suite:
+
+```bash
+dbt-nova eval validate --suite evals/starter.yml
+```
+
+Run the bridge evals against the packaged synthetic manifest:
+
+```bash
+dbt-nova eval run \
+  --suite evals/starter.yml \
+  --manifest-path tests/fixtures/starter_eval_manifest.json \
+  --fail-under 1.0
+```
+
+Run the starter agent case with a configured provider:
+
+```bash
+dbt-nova eval agent run \
+  --suite evals/starter.yml \
+  --provider opencode \
+  --manifest-path tests/fixtures/starter_eval_manifest.json \
+  --case-id analyst_revenue_lookup_flow \
+  --fail-under 1.0
+```
+
 ## Run Bridge Evals
 
 ```bash

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -117,6 +117,7 @@ Bridge assertions currently support:
 - `context_field_equals`
 - `context_contains`
 - `metadata_score_min`
+- `metadata_score_max`
 - `recipe_rank`
 - `recipe_has_queries`
 - `lineage_contains`

--- a/evals/starter.yml
+++ b/evals/starter.yml
@@ -1,0 +1,119 @@
+version: 1
+name: starter
+defaults:
+  persona: analyst
+  top_k: 5
+
+cases:
+  - id: canonical_revenue_discovery
+    question: Find the canonical model and measure for gross revenue.
+    assertions:
+      - type: search_rank
+        query: gross revenue orders canonical commerce
+        expected_unique_id: model.starter_eval.fct_orders
+        max_rank: 3
+        resource_types: [model]
+      - type: search_indicator_rank
+        query: gross revenue
+        expected: gross_revenue
+        max_rank: 3
+        resource_types: [model]
+        indicator_types: [measure]
+      - type: context_has
+        id_or_name: model.starter_eval.fct_orders
+        fields:
+          - data.unique_id
+          - data.entity.name
+          - data.entity.nova_summary.measures
+          - data.entity.grain_summary.primary_key
+      - type: metadata_score_min
+        id_or_name: model.starter_eval.fct_orders
+        persona: analyst
+        threshold: 90
+
+  - id: column_context_and_lineage
+    question: Verify the canonical orders model exposes date context and upstream lineage.
+    assertions:
+      - type: search_columns_rank
+        query: order date
+        expected_column: order_date
+        expected_parent_unique_id: model.starter_eval.fct_orders
+        max_rank: 5
+      - type: lineage_contains
+        id_or_name: model.starter_eval.fct_orders
+        direction: upstream
+        expected_unique_id: model.starter_eval.stg_orders
+        depth: 1
+      - type: lineage_contains
+        id_or_name: model.starter_eval.fct_orders
+        direction: upstream
+        expected_unique_id: model.starter_eval.dim_customers
+        depth: 1
+      - type: lineage_contains
+        id_or_name: model.starter_eval.fct_orders
+        direction: upstream
+        expected_unique_id: model.starter_eval.stg_customers
+        depth: 2
+
+  - id: recipe_discovery
+    question: Find the starter weekly revenue recipe and verify it has ordered SQL steps.
+    assertions:
+      - type: recipe_rank
+        query: weekly revenue commerce
+        expected_recipe_id: commerce/weekly_revenue
+        max_rank: 3
+      - type: recipe_has_queries
+        recipe_id: commerce/weekly_revenue
+        min_queries: 2
+
+  - id: sparse_metadata_floor
+    question: Sparse raw examples should remain discoverable and score as low-quality metadata.
+    assertions:
+      - type: search_rank
+        query: raw events sparse
+        expected_unique_id: model.starter_eval.raw_events_sparse
+        max_rank: 3
+        resource_types: [model]
+      - type: context_field_equals
+        id_or_name: model.starter_eval.raw_events_sparse
+        field: data.entity.name
+        expected: raw_events_sparse
+      - type: metadata_score_min
+        id_or_name: model.starter_eval.raw_events_sparse
+        persona: analyst
+        threshold: 0
+
+agent_cases:
+  - id: analyst_revenue_lookup_flow
+    task: Which canonical model and measure should an analyst use for gross revenue? Do not execute SQL.
+    expected:
+      must_call:
+        - search_indicator
+        - get_context
+      must_not_call:
+        - execute_sql
+        - get_lineage
+      ordered:
+        - before: get_context
+          must_have_called:
+            - search_indicator
+      selected_entities:
+        - model.starter_eval.fct_orders
+      selected_entity_ranks:
+        - unique_id: model.starter_eval.fct_orders
+          tool: search_indicator
+          max_rank: 3
+      called_with:
+        - tool: search_indicator
+          contains:
+            query: gross revenue
+      max_tool_calls: 4
+      max_distinct_tools: 3
+      max_total_response_bytes: 65536
+      max_response_bytes_by_tool:
+        search_indicator: 12000
+        get_context: 24000
+      final_answer:
+        must_contain:
+          - fct_orders
+          - gross_revenue

--- a/evals/starter.yml
+++ b/evals/starter.yml
@@ -78,10 +78,10 @@ cases:
         id_or_name: model.starter_eval.raw_events_sparse
         field: data.entity.name
         expected: raw_events_sparse
-      - type: metadata_score_min
+      - type: metadata_score_max
         id_or_name: model.starter_eval.raw_events_sparse
         persona: analyst
-        threshold: 0
+        threshold: 20
 
 agent_cases:
   - id: analyst_revenue_lookup_flow

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -111,6 +111,13 @@ enum EvalAssertion {
         #[serde(default)]
         persona: Option<String>,
     },
+    MetadataScoreMax {
+        #[serde(default)]
+        id_or_name: Option<String>,
+        threshold: f64,
+        #[serde(default)]
+        persona: Option<String>,
+    },
     RecipeRank {
         query: String,
         expected_recipe_id: String,
@@ -538,6 +545,11 @@ async fn evaluate_bridge_assertion(
             id_or_name,
             threshold,
             persona,
+        }
+        | EvalAssertion::MetadataScoreMax {
+            id_or_name,
+            threshold,
+            persona,
         } => {
             let params = json!({
                 "id_or_name": id_or_name,
@@ -545,8 +557,23 @@ async fn evaluate_bridge_assertion(
                 "limit": 20,
             });
             match call_tool(search, "get_metadata_score", params).await {
-                Ok(response) => metadata_score_assertion(&response, *threshold),
-                Err(error) => AssertionResult::error("metadata_score_min", error.to_string()),
+                Ok(response) => match assertion {
+                    EvalAssertion::MetadataScoreMin { .. } => {
+                        metadata_score_min_assertion(&response, *threshold)
+                    }
+                    EvalAssertion::MetadataScoreMax { .. } => {
+                        metadata_score_max_assertion(&response, *threshold)
+                    }
+                    _ => unreachable!("matched metadata score assertion"),
+                },
+                Err(error) => AssertionResult::error(
+                    match assertion {
+                        EvalAssertion::MetadataScoreMin { .. } => "metadata_score_min",
+                        EvalAssertion::MetadataScoreMax { .. } => "metadata_score_max",
+                        _ => unreachable!("matched metadata score assertion"),
+                    },
+                    error.to_string(),
+                ),
             }
         }
         EvalAssertion::RecipeRank {
@@ -1516,7 +1543,7 @@ fn context_contains_assertion(
     }
 }
 
-fn metadata_score_assertion(response: &JsonValue, threshold: f64) -> AssertionResult {
+fn metadata_score_min_assertion(response: &JsonValue, threshold: f64) -> AssertionResult {
     let score = find_score(response);
     match score {
         Some(score) if score >= threshold => AssertionResult::pass(
@@ -1531,6 +1558,27 @@ fn metadata_score_assertion(response: &JsonValue, threshold: f64) -> AssertionRe
         ),
         None => AssertionResult::fail(
             "metadata_score_min",
+            "metadata score response did not contain a numeric score",
+            JsonValue::Null,
+        ),
+    }
+}
+
+fn metadata_score_max_assertion(response: &JsonValue, threshold: f64) -> AssertionResult {
+    let score = find_score(response);
+    match score {
+        Some(score) if score <= threshold => AssertionResult::pass(
+            "metadata_score_max",
+            format!("metadata score {score:.3} did not exceed threshold {threshold:.3}"),
+            json!({"score": score, "threshold": threshold}),
+        ),
+        Some(score) => AssertionResult::fail(
+            "metadata_score_max",
+            format!("metadata score {score:.3} exceeded threshold {threshold:.3}"),
+            json!({"score": score, "threshold": threshold}),
+        ),
+        None => AssertionResult::fail(
+            "metadata_score_max",
             "metadata score response did not contain a numeric score",
             JsonValue::Null,
         ),

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -8,9 +8,10 @@ use super::{
     AgentCalledWith, AgentEntityRank, AgentExpected, AgentOrder, AssertionResult, EvalCaseReport,
     EvalDefaults, EvalRunArgs, EvalSuite, EvalValidateArgs, FinalAnswerExpected,
     contains_rank_assertion, context_contains_assertion, context_field_equals_assertion,
-    json_has_field_path, read_tool_trace, recipe_rank_assertion, run_eval_command,
-    run_validate_command, safe_path_segment, score_agent_expectations, selected_agent_cases,
-    selected_bridge_cases, tool_response_budget_assertion, tool_success_assertion, validate_suite,
+    json_has_field_path, metadata_score_max_assertion, metadata_score_min_assertion,
+    read_tool_trace, recipe_rank_assertion, run_eval_command, run_validate_command,
+    safe_path_segment, score_agent_expectations, selected_agent_cases, selected_bridge_cases,
+    tool_response_budget_assertion, tool_success_assertion, validate_suite,
 };
 
 #[test]
@@ -213,6 +214,20 @@ fn context_value_assertions_check_equals_and_contains() {
         context_field_equals_assertion(&response, "data.entity.name", &json!("customers")).status,
         "fail"
     );
+}
+
+#[test]
+fn metadata_score_bounds_check_min_and_max() {
+    let response = json!({
+        "data": {
+            "overall_score": 12.0
+        }
+    });
+
+    assert_eq!(metadata_score_min_assertion(&response, 10.0).status, "pass");
+    assert_eq!(metadata_score_min_assertion(&response, 20.0).status, "fail");
+    assert_eq!(metadata_score_max_assertion(&response, 20.0).status, "pass");
+    assert_eq!(metadata_score_max_assertion(&response, 10.0).status, "fail");
 }
 
 #[test]

--- a/tests/fixtures/starter_eval_manifest.json
+++ b/tests/fixtures/starter_eval_manifest.json
@@ -1,0 +1,782 @@
+{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    "dbt_version": "1.10.2",
+    "project_name": "starter_eval",
+    "generated_at": "2026-06-01T00:00:00Z"
+  },
+  "selectors": {},
+  "nodes": {
+    "model.starter_eval.stg_orders": {
+      "unique_id": "model.starter_eval.stg_orders",
+      "name": "stg_orders",
+      "resource_type": "model",
+      "package_name": "starter_eval",
+      "description": "Cleaned order events from the synthetic raw orders source.",
+      "database": "analytics",
+      "schema": "starter",
+      "path": "models/staging/stg_orders.sql",
+      "original_file_path": "models/staging/stg_orders.sql",
+      "alias": "stg_orders",
+      "relation_name": "analytics.starter.stg_orders",
+      "config": {
+        "enabled": true,
+        "materialized": "view"
+      },
+      "tags": ["commerce", "staging"],
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "description": "Order identifier from the source system.",
+          "data_type": "string",
+          "meta": {
+            "primary_key": true,
+            "nova": {
+              "role": "identifier",
+              "semantic_type": "order_id",
+              "synonyms": ["order key"]
+            }
+          }
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "description": "Customer identifier associated with the order.",
+          "data_type": "string",
+          "meta": {
+            "nova": {
+              "role": "identifier",
+              "semantic_type": "customer_id"
+            }
+          }
+        },
+        "order_date": {
+          "name": "order_date",
+          "description": "Date on which the order was placed.",
+          "data_type": "date",
+          "meta": {
+            "nova": {
+              "role": "time",
+              "semantic_type": "date",
+              "synonyms": ["order day"]
+            }
+          }
+        },
+        "gross_amount": {
+          "name": "gross_amount",
+          "description": "Gross order amount before refunds.",
+          "data_type": "numeric",
+          "meta": {
+            "nova": {
+              "role": "measure",
+              "semantic_type": "money"
+            }
+          }
+        },
+        "status": {
+          "name": "status",
+          "description": "Order status such as completed or refunded.",
+          "data_type": "string",
+          "meta": {
+            "nova": {
+              "role": "dimension",
+              "semantic_type": "status"
+            }
+          }
+        }
+      },
+      "meta": {
+        "owner": "analytics-platform",
+        "nova": {
+          "domains": ["commerce"],
+          "use_cases": ["order_normalization"],
+          "synonyms": ["orders staging", "order events"],
+          "tier": "silver",
+          "governance": {
+            "sensitivity": "internal",
+            "pii": "none",
+            "compliance": ["synthetic"]
+          }
+        }
+      },
+      "depends_on": {
+        "nodes": ["source.starter_eval.raw.orders"],
+        "macros": []
+      },
+      "raw_code": "select order_id, customer_id, order_date, gross_amount, status from {{ source('raw', 'orders') }}",
+      "compiled_code": "select order_id, customer_id, order_date, gross_amount, status from raw.orders"
+    },
+    "model.starter_eval.stg_customers": {
+      "unique_id": "model.starter_eval.stg_customers",
+      "name": "stg_customers",
+      "resource_type": "model",
+      "package_name": "starter_eval",
+      "description": "Cleaned customer records from the synthetic raw customers source.",
+      "database": "analytics",
+      "schema": "starter",
+      "path": "models/staging/stg_customers.sql",
+      "original_file_path": "models/staging/stg_customers.sql",
+      "alias": "stg_customers",
+      "relation_name": "analytics.starter.stg_customers",
+      "config": {
+        "enabled": true,
+        "materialized": "view"
+      },
+      "tags": ["commerce", "staging"],
+      "columns": {
+        "customer_id": {
+          "name": "customer_id",
+          "description": "Customer identifier from the source system.",
+          "data_type": "string",
+          "meta": {
+            "primary_key": true
+          }
+        },
+        "signup_date": {
+          "name": "signup_date",
+          "description": "Date the customer first signed up.",
+          "data_type": "date"
+        },
+        "customer_segment": {
+          "name": "customer_segment",
+          "description": "Synthetic lifecycle segment assigned to the customer.",
+          "data_type": "string"
+        },
+        "country_code": {
+          "name": "country_code",
+          "description": "Two-letter country code for the customer.",
+          "data_type": "string"
+        }
+      },
+      "meta": {
+        "owner": "analytics-platform",
+        "nova": {
+          "domains": ["commerce"],
+          "use_cases": ["customer_dimension"],
+          "synonyms": ["customer staging"],
+          "tier": "silver",
+          "governance": {
+            "sensitivity": "internal",
+            "pii": "indirect",
+            "compliance": ["synthetic"]
+          }
+        }
+      },
+      "depends_on": {
+        "nodes": ["source.starter_eval.raw.customers"],
+        "macros": []
+      },
+      "raw_code": "select customer_id, signup_date, customer_segment, country_code from {{ source('raw', 'customers') }}",
+      "compiled_code": "select customer_id, signup_date, customer_segment, country_code from raw.customers"
+    },
+    "model.starter_eval.dim_customers": {
+      "unique_id": "model.starter_eval.dim_customers",
+      "name": "dim_customers",
+      "resource_type": "model",
+      "package_name": "starter_eval",
+      "description": "Curated customer dimension used for commerce reporting.",
+      "database": "analytics",
+      "schema": "starter",
+      "path": "models/marts/dim_customers.sql",
+      "original_file_path": "models/marts/dim_customers.sql",
+      "alias": "dim_customers",
+      "relation_name": "analytics.starter.dim_customers",
+      "config": {
+        "enabled": true,
+        "materialized": "table"
+      },
+      "tags": ["commerce", "dimension"],
+      "columns": {
+        "customer_id": {
+          "name": "customer_id",
+          "description": "Primary customer identifier.",
+          "data_type": "string",
+          "meta": {
+            "primary_key": true,
+            "nova": {
+              "role": "identifier",
+              "semantic_type": "customer_id"
+            }
+          }
+        },
+        "signup_date": {
+          "name": "signup_date",
+          "description": "Date the customer joined.",
+          "data_type": "date",
+          "meta": {
+            "nova": {
+              "role": "time",
+              "semantic_type": "date"
+            }
+          }
+        },
+        "customer_segment": {
+          "name": "customer_segment",
+          "description": "Customer lifecycle segment for reporting.",
+          "data_type": "string",
+          "meta": {
+            "nova": {
+              "role": "dimension",
+              "semantic_type": "customer_segment",
+              "synonyms": ["segment"]
+            }
+          }
+        },
+        "country_code": {
+          "name": "country_code",
+          "description": "Customer country code.",
+          "data_type": "string",
+          "meta": {
+            "nova": {
+              "role": "dimension",
+              "semantic_type": "country_code",
+              "synonyms": ["market"]
+            }
+          }
+        }
+      },
+      "meta": {
+        "owner": "analytics-platform",
+        "nova": {
+          "role": "dimension",
+          "domains": ["commerce"],
+          "use_cases": ["customer_reporting"],
+          "synonyms": ["customer dimension", "buyer dimension"],
+          "tier": "gold",
+          "grain": {
+            "primary_key": ["customer_id"],
+            "dimensions": ["country_code", "customer_segment"]
+          },
+          "governance": {
+            "sensitivity": "internal",
+            "pii": "indirect",
+            "compliance": ["synthetic"]
+          }
+        }
+      },
+      "depends_on": {
+        "nodes": ["model.starter_eval.stg_customers"],
+        "macros": []
+      },
+      "raw_code": "select customer_id, signup_date, customer_segment, country_code from {{ ref('stg_customers') }}",
+      "compiled_code": "select customer_id, signup_date, customer_segment, country_code from analytics.starter.stg_customers"
+    },
+    "model.starter_eval.fct_orders": {
+      "unique_id": "model.starter_eval.fct_orders",
+      "name": "fct_orders",
+      "resource_type": "model",
+      "package_name": "starter_eval",
+      "description": "Canonical orders fact table for gross revenue and order reporting.",
+      "database": "analytics",
+      "schema": "starter",
+      "path": "models/marts/fct_orders.sql",
+      "original_file_path": "models/marts/fct_orders.sql",
+      "alias": "fct_orders",
+      "relation_name": "analytics.starter.fct_orders",
+      "config": {
+        "enabled": true,
+        "materialized": "table"
+      },
+      "tags": ["commerce", "fact", "canonical"],
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "description": "Primary order identifier at the canonical order fact grain for revenue analysis.",
+          "data_type": "string",
+          "constraints": [
+            {"type": "not_null"},
+            {"type": "unique"}
+          ],
+          "meta": {
+            "primary_key": true,
+            "nova": {
+              "role": "identifier",
+              "semantic_type": "order_id",
+              "synonyms": ["order key"]
+            }
+          }
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "description": "Customer identifier used to join each order to the curated customer dimension.",
+          "data_type": "string",
+          "constraints": [
+            {"type": "not_null"},
+            {"type": "foreign_key"}
+          ],
+          "meta": {
+            "nova": {
+              "role": "identifier",
+              "semantic_type": "customer_id"
+            }
+          }
+        },
+        "order_date": {
+          "name": "order_date",
+          "description": "Order date used as the default reporting time field for weekly revenue cuts.",
+          "data_type": "date",
+          "constraints": [
+            {"type": "not_null"}
+          ],
+          "meta": {
+            "nova": {
+              "role": "time",
+              "semantic_type": "date",
+              "synonyms": ["order day", "reporting date"]
+            }
+          }
+        },
+        "gross_amount": {
+          "name": "gross_amount",
+          "description": "Gross revenue amount before refunds and cancellations, stored in reporting currency.",
+          "data_type": "numeric",
+          "constraints": [
+            {"type": "not_null"}
+          ],
+          "meta": {
+            "nova": {
+              "role": "measure",
+              "semantic_type": "money",
+              "synonyms": ["gross revenue", "gross sales"]
+            }
+          }
+        },
+        "status": {
+          "name": "status",
+          "description": "Final order status such as completed or refunded for filtering revenue metrics.",
+          "data_type": "string",
+          "meta": {
+            "nova": {
+              "role": "dimension",
+              "semantic_type": "status"
+            }
+          }
+        },
+        "country_code": {
+          "name": "country_code",
+          "description": "Customer country code carried onto the order fact for market-level reporting.",
+          "data_type": "string",
+          "meta": {
+            "nova": {
+              "role": "dimension",
+              "semantic_type": "country_code",
+              "synonyms": ["market"]
+            }
+          }
+        }
+      },
+      "meta": {
+        "owner": "analytics-platform",
+        "nova": {
+          "role": "fact",
+          "canonical": true,
+          "domains": ["commerce"],
+          "use_cases": ["gross_revenue_reporting", "order_reporting"],
+          "synonyms": ["orders fact", "gross revenue orders", "sales fact"],
+          "tier": "gold",
+          "grain": {
+            "primary_key": ["order_id"],
+            "time_field": "order_date",
+            "dimensions": ["country_code", "status"]
+          },
+          "measures": [
+            {
+              "name": "gross_revenue",
+              "canonical": true,
+              "description": "Gross revenue before refunds and cancellations.",
+              "expression": "sum(gross_amount)",
+              "type": "sum",
+              "field": "gross_amount",
+              "synonyms": ["gross sales", "gross merchandise revenue"]
+            },
+            {
+              "name": "order_count",
+              "description": "Count of distinct orders.",
+              "expression": "count(distinct order_id)",
+              "type": "count_distinct",
+              "field": "order_id",
+              "synonyms": ["orders"]
+            }
+          ],
+          "metrics": [
+            {
+              "name": "average_order_value",
+              "description": "Average gross revenue per order.",
+              "expression": "sum(gross_amount) / nullif(count(distinct order_id), 0)",
+              "canonical": true,
+              "synonyms": ["aov"],
+              "grain": {
+                "primary_key": ["order_id"],
+                "time_field": "order_date",
+                "dimensions": ["country_code", "status"]
+              }
+            }
+          ],
+          "governance": {
+            "sensitivity": "internal",
+            "pii": "none",
+            "compliance": ["synthetic", "contract-reviewed", "owner-approved"]
+          },
+          "search": {
+            "candidates": {
+              "analyst": true,
+              "engineer": true,
+              "governance": true
+            }
+          }
+        }
+      },
+      "depends_on": {
+        "nodes": [
+          "model.starter_eval.stg_orders",
+          "model.starter_eval.dim_customers"
+        ],
+        "macros": []
+      },
+      "raw_code": "select o.order_id, o.customer_id, o.order_date, o.gross_amount, o.status, c.country_code from {{ ref('stg_orders') }} o left join {{ ref('dim_customers') }} c using (customer_id)",
+      "compiled_code": "select o.order_id, o.customer_id, o.order_date, o.gross_amount, o.status, c.country_code from analytics.starter.stg_orders o left join analytics.starter.dim_customers c using (customer_id)"
+    },
+    "model.starter_eval.raw_events_sparse": {
+      "unique_id": "model.starter_eval.raw_events_sparse",
+      "name": "raw_events_sparse",
+      "resource_type": "model",
+      "package_name": "starter_eval",
+      "database": "analytics",
+      "schema": "starter",
+      "path": "models/raw/raw_events_sparse.sql",
+      "original_file_path": "models/raw/raw_events_sparse.sql",
+      "alias": "raw_events_sparse",
+      "relation_name": "analytics.starter.raw_events_sparse",
+      "config": {
+        "enabled": true,
+        "materialized": "view"
+      },
+      "tags": ["raw"],
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "data_type": "string",
+          "description": ""
+        },
+        "payload": {
+          "name": "payload",
+          "data_type": "variant",
+          "description": ""
+        }
+      },
+      "depends_on": {
+        "nodes": [],
+        "macros": []
+      },
+      "raw_code": "select event_id, payload from raw.events",
+      "compiled_code": "select event_id, payload from raw.events"
+    },
+    "analysis.starter_eval.analysis__orders_summary__01": {
+      "unique_id": "analysis.starter_eval.analysis__orders_summary__01",
+      "name": "analysis__orders_summary__01",
+      "resource_type": "analysis",
+      "package_name": "starter_eval",
+      "description": "First step of the weekly revenue recipe.",
+      "original_file_path": "analyses/recipes/commerce/weekly_revenue/analysis__orders_summary__01.sql",
+      "path": "analyses/recipes/commerce/weekly_revenue/analysis__orders_summary__01.sql",
+      "meta": {
+        "nova": {
+          "recipe": {
+            "parameters": {
+              "START_DATE": {
+                "type": "date",
+                "required": false,
+                "default": "2026-06-01",
+                "description": "Inclusive start date"
+              },
+              "END_DATE": {
+                "type": "date",
+                "required": false,
+                "default": "2026-06-07",
+                "description": "Inclusive end date"
+              }
+            }
+          }
+        }
+      },
+      "depends_on": {
+        "nodes": ["model.starter_eval.fct_orders"],
+        "macros": []
+      },
+      "raw_code": "select order_date, sum(gross_amount) as gross_revenue from {{ ref('fct_orders') }} where order_date between '__START_DATE__' and '__END_DATE__' group by 1",
+      "compiled_code": "select order_date, sum(gross_amount) as gross_revenue from analytics.starter.fct_orders where order_date between '__START_DATE__' and '__END_DATE__' group by 1"
+    },
+    "analysis.starter_eval.analysis__orders_summary__02": {
+      "unique_id": "analysis.starter_eval.analysis__orders_summary__02",
+      "name": "analysis__orders_summary__02",
+      "resource_type": "analysis",
+      "package_name": "starter_eval",
+      "description": "Second step of the weekly revenue recipe.",
+      "original_file_path": "analyses/recipes/commerce/weekly_revenue/analysis__orders_summary__02.sql",
+      "path": "analyses/recipes/commerce/weekly_revenue/analysis__orders_summary__02.sql",
+      "depends_on": {
+        "nodes": ["model.starter_eval.fct_orders"],
+        "macros": []
+      },
+      "raw_code": "select country_code, sum(gross_amount) as gross_revenue from {{ ref('fct_orders') }} group by 1 order by 2 desc",
+      "compiled_code": "select country_code, sum(gross_amount) as gross_revenue from analytics.starter.fct_orders group by 1 order by 2 desc"
+    },
+    "test.starter_eval.not_null_fct_orders_order_id": {
+      "unique_id": "test.starter_eval.not_null_fct_orders_order_id",
+      "name": "not_null_fct_orders_order_id",
+      "resource_type": "test",
+      "package_name": "starter_eval",
+      "path": "tests/fct_orders.yml",
+      "original_file_path": "models/marts/fct_orders.yml",
+      "attached_node": "model.starter_eval.fct_orders",
+      "column_name": "order_id",
+      "test_metadata": {
+        "name": "not_null"
+      },
+      "depends_on": {
+        "nodes": ["model.starter_eval.fct_orders"],
+        "macros": []
+      }
+    },
+    "test.starter_eval.unique_fct_orders_order_id": {
+      "unique_id": "test.starter_eval.unique_fct_orders_order_id",
+      "name": "unique_fct_orders_order_id",
+      "resource_type": "test",
+      "package_name": "starter_eval",
+      "path": "tests/fct_orders.yml",
+      "original_file_path": "models/marts/fct_orders.yml",
+      "attached_node": "model.starter_eval.fct_orders",
+      "column_name": "order_id",
+      "test_metadata": {
+        "name": "unique"
+      },
+      "depends_on": {
+        "nodes": ["model.starter_eval.fct_orders"],
+        "macros": []
+      }
+    },
+    "test.starter_eval.not_null_fct_orders_gross_amount": {
+      "unique_id": "test.starter_eval.not_null_fct_orders_gross_amount",
+      "name": "not_null_fct_orders_gross_amount",
+      "resource_type": "test",
+      "package_name": "starter_eval",
+      "path": "tests/fct_orders.yml",
+      "original_file_path": "models/marts/fct_orders.yml",
+      "attached_node": "model.starter_eval.fct_orders",
+      "column_name": "gross_amount",
+      "test_metadata": {
+        "name": "not_null"
+      },
+      "depends_on": {
+        "nodes": ["model.starter_eval.fct_orders"],
+        "macros": []
+      }
+    },
+    "test.starter_eval.not_null_fct_orders_customer_id": {
+      "unique_id": "test.starter_eval.not_null_fct_orders_customer_id",
+      "name": "not_null_fct_orders_customer_id",
+      "resource_type": "test",
+      "package_name": "starter_eval",
+      "path": "tests/fct_orders.yml",
+      "original_file_path": "models/marts/fct_orders.yml",
+      "attached_node": "model.starter_eval.fct_orders",
+      "column_name": "customer_id",
+      "test_metadata": {
+        "name": "not_null"
+      },
+      "depends_on": {
+        "nodes": ["model.starter_eval.fct_orders"],
+        "macros": []
+      }
+    },
+    "test.starter_eval.not_null_fct_orders_order_date": {
+      "unique_id": "test.starter_eval.not_null_fct_orders_order_date",
+      "name": "not_null_fct_orders_order_date",
+      "resource_type": "test",
+      "package_name": "starter_eval",
+      "path": "tests/fct_orders.yml",
+      "original_file_path": "models/marts/fct_orders.yml",
+      "attached_node": "model.starter_eval.fct_orders",
+      "column_name": "order_date",
+      "test_metadata": {
+        "name": "not_null"
+      },
+      "depends_on": {
+        "nodes": ["model.starter_eval.fct_orders"],
+        "macros": []
+      }
+    },
+    "test.starter_eval.accepted_values_fct_orders_status": {
+      "unique_id": "test.starter_eval.accepted_values_fct_orders_status",
+      "name": "accepted_values_fct_orders_status",
+      "resource_type": "test",
+      "package_name": "starter_eval",
+      "path": "tests/fct_orders.yml",
+      "original_file_path": "models/marts/fct_orders.yml",
+      "attached_node": "model.starter_eval.fct_orders",
+      "column_name": "status",
+      "test_metadata": {
+        "name": "accepted_values"
+      },
+      "depends_on": {
+        "nodes": ["model.starter_eval.fct_orders"],
+        "macros": []
+      }
+    },
+    "test.starter_eval.not_null_fct_orders_country_code": {
+      "unique_id": "test.starter_eval.not_null_fct_orders_country_code",
+      "name": "not_null_fct_orders_country_code",
+      "resource_type": "test",
+      "package_name": "starter_eval",
+      "path": "tests/fct_orders.yml",
+      "original_file_path": "models/marts/fct_orders.yml",
+      "attached_node": "model.starter_eval.fct_orders",
+      "column_name": "country_code",
+      "test_metadata": {
+        "name": "not_null"
+      },
+      "depends_on": {
+        "nodes": ["model.starter_eval.fct_orders"],
+        "macros": []
+      }
+    },
+    "test.starter_eval.expression_is_true_fct_orders_gross_amount": {
+      "unique_id": "test.starter_eval.expression_is_true_fct_orders_gross_amount",
+      "name": "expression_is_true_fct_orders_gross_amount",
+      "resource_type": "test",
+      "package_name": "starter_eval",
+      "path": "tests/fct_orders.yml",
+      "original_file_path": "models/marts/fct_orders.yml",
+      "attached_node": "model.starter_eval.fct_orders",
+      "test_metadata": {
+        "name": "expression_is_true"
+      },
+      "depends_on": {
+        "nodes": ["model.starter_eval.fct_orders"],
+        "macros": []
+      }
+    }
+  },
+  "sources": {
+    "source.starter_eval.raw.orders": {
+      "unique_id": "source.starter_eval.raw.orders",
+      "name": "orders",
+      "source_name": "raw",
+      "resource_type": "source",
+      "package_name": "starter_eval",
+      "description": "Synthetic raw orders source.",
+      "source_description": "Synthetic raw commerce source.",
+      "database": "raw",
+      "schema": "starter",
+      "identifier": "orders",
+      "relation_name": "raw.starter.orders",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "description": "Raw order identifier.",
+          "data_type": "string"
+        }
+      },
+      "meta": {
+        "owner": "data-ingest",
+        "nova": {
+          "domains": ["commerce"],
+          "governance": {
+            "sensitivity": "internal",
+            "pii": "none",
+            "compliance": ["synthetic"]
+          }
+        }
+      }
+    },
+    "source.starter_eval.raw.customers": {
+      "unique_id": "source.starter_eval.raw.customers",
+      "name": "customers",
+      "source_name": "raw",
+      "resource_type": "source",
+      "package_name": "starter_eval",
+      "description": "Synthetic raw customers source.",
+      "source_description": "Synthetic raw commerce source.",
+      "database": "raw",
+      "schema": "starter",
+      "identifier": "customers",
+      "relation_name": "raw.starter.customers",
+      "columns": {
+        "customer_id": {
+          "name": "customer_id",
+          "description": "Raw customer identifier.",
+          "data_type": "string"
+        }
+      },
+      "meta": {
+        "owner": "data-ingest",
+        "nova": {
+          "domains": ["commerce"],
+          "governance": {
+            "sensitivity": "internal",
+            "pii": "indirect",
+            "compliance": ["synthetic"]
+          }
+        }
+      }
+    }
+  },
+  "macros": {},
+  "docs": {},
+  "groups": {},
+  "exposures": {},
+  "metrics": {},
+  "saved_queries": {},
+  "semantic_models": {},
+  "parent_map": {
+    "model.starter_eval.stg_orders": ["source.starter_eval.raw.orders"],
+    "model.starter_eval.stg_customers": ["source.starter_eval.raw.customers"],
+    "model.starter_eval.dim_customers": ["model.starter_eval.stg_customers"],
+    "model.starter_eval.fct_orders": [
+      "model.starter_eval.stg_orders",
+      "model.starter_eval.dim_customers"
+    ],
+    "model.starter_eval.raw_events_sparse": [],
+    "analysis.starter_eval.analysis__orders_summary__01": ["model.starter_eval.fct_orders"],
+    "analysis.starter_eval.analysis__orders_summary__02": ["model.starter_eval.fct_orders"],
+    "test.starter_eval.not_null_fct_orders_order_id": ["model.starter_eval.fct_orders"],
+    "test.starter_eval.unique_fct_orders_order_id": ["model.starter_eval.fct_orders"],
+    "test.starter_eval.not_null_fct_orders_gross_amount": ["model.starter_eval.fct_orders"],
+    "test.starter_eval.not_null_fct_orders_customer_id": ["model.starter_eval.fct_orders"],
+    "test.starter_eval.not_null_fct_orders_order_date": ["model.starter_eval.fct_orders"],
+    "test.starter_eval.accepted_values_fct_orders_status": ["model.starter_eval.fct_orders"],
+    "test.starter_eval.not_null_fct_orders_country_code": ["model.starter_eval.fct_orders"],
+    "test.starter_eval.expression_is_true_fct_orders_gross_amount": ["model.starter_eval.fct_orders"],
+    "source.starter_eval.raw.orders": [],
+    "source.starter_eval.raw.customers": []
+  },
+  "child_map": {
+    "source.starter_eval.raw.orders": ["model.starter_eval.stg_orders"],
+    "source.starter_eval.raw.customers": ["model.starter_eval.stg_customers"],
+    "model.starter_eval.stg_orders": ["model.starter_eval.fct_orders"],
+    "model.starter_eval.stg_customers": ["model.starter_eval.dim_customers"],
+    "model.starter_eval.dim_customers": ["model.starter_eval.fct_orders"],
+    "model.starter_eval.fct_orders": [
+      "analysis.starter_eval.analysis__orders_summary__01",
+      "analysis.starter_eval.analysis__orders_summary__02",
+      "test.starter_eval.not_null_fct_orders_order_id",
+      "test.starter_eval.unique_fct_orders_order_id",
+      "test.starter_eval.not_null_fct_orders_gross_amount",
+      "test.starter_eval.not_null_fct_orders_customer_id",
+      "test.starter_eval.not_null_fct_orders_order_date",
+      "test.starter_eval.accepted_values_fct_orders_status",
+      "test.starter_eval.not_null_fct_orders_country_code",
+      "test.starter_eval.expression_is_true_fct_orders_gross_amount"
+    ],
+    "model.starter_eval.raw_events_sparse": [],
+    "analysis.starter_eval.analysis__orders_summary__01": [],
+    "analysis.starter_eval.analysis__orders_summary__02": [],
+    "test.starter_eval.not_null_fct_orders_order_id": [],
+    "test.starter_eval.unique_fct_orders_order_id": [],
+    "test.starter_eval.not_null_fct_orders_gross_amount": [],
+    "test.starter_eval.not_null_fct_orders_customer_id": [],
+    "test.starter_eval.not_null_fct_orders_order_date": [],
+    "test.starter_eval.accepted_values_fct_orders_status": [],
+    "test.starter_eval.not_null_fct_orders_country_code": [],
+    "test.starter_eval.expression_is_true_fct_orders_gross_amount": []
+  }
+}


### PR DESCRIPTION
## Summary
- Add `evals/starter.yml` with bridge assertions across search, indicator discovery, context, lineage, recipe discovery, and metadata scoring.
- Add one starter agent case that requires `search_indicator` before `get_context` and forbids SQL execution.
- Add a synthetic starter manifest fixture with five models, varied metadata quality, sources, tests, lineage, and a two-step `commerce/weekly_revenue` recipe.
- Document starter validate, bridge-run, and agent-run commands.

## Validation
- `jq empty tests/fixtures/starter_eval_manifest.json`
- `cargo run --locked -- eval validate --suite evals/starter.yml --json`
- `cargo run --locked -- eval run --suite evals/starter.yml --manifest-path tests/fixtures/starter_eval_manifest.json --output-dir <tmp> --fail-under 1.0 --json` (13/13 pass)
- `cargo test --locked eval_cmd`
- `uv run mkdocs build --strict`
- `cargo fmt --check`
- `git diff --check`

Closes JOE-18