### PR TITLE
Add JSONL eval telemetry history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   response budgets, KPI discovery, and MCP trace behavior for agent workflows.
 - Eval traces now include a monotonic `tool_call_index`, and provider fallback
   scoring captures response byte evidence for budget assertions.
+- Eval runs can now append per-assertion JSONL telemetry with
+  `--telemetry`, keep newest rows with `--telemetry-retention`, and print
+  filtered run history with `dbt-nova eval history --suite <NAME> --since
+  <YYYY-MM-DD>`.
 - Fixed release OCI publishing to build images from native Linux release binaries
   instead of compiling Rust inside the ARM64 Docker/QEMU path.
 - Fixed the Monthly workflow by refreshing advisory/dependency-watchlist review

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -288,6 +288,9 @@ Use `--telemetry` when you want eval results to accumulate across runs instead
 of only writing one-off report artifacts. Bridge and agent evals append one
 JSON object per assertion to `.nova/eval-runs/telemetry/<suite>-<hash>.jsonl`:
 
+Suites must define a non-empty `name:` to write telemetry. This keeps history
+and retention scoped to one suite instead of mixing unrelated unnamed files.
+
 ```bash
 dbt-nova eval run \
   --suite evals/agent-tokenomics-bridge.yml \

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -282,6 +282,41 @@ Available placeholders in `--provider-args-json`:
 - `{trace_path}`
 - `{manifest_path}`
 
+## Telemetry History
+
+Use `--telemetry` when you want eval results to accumulate across runs instead
+of only writing one-off report artifacts. Bridge and agent evals append one
+JSON object per assertion to `.nova/eval-runs/telemetry/<suite>-<hash>.jsonl`:
+
+```bash
+dbt-nova eval run \
+  --suite evals/agent-tokenomics-bridge.yml \
+  --manifest-path tests/fixtures/tokenomics_manifest.json \
+  --telemetry
+
+dbt-nova eval agent run \
+  --suite evals/agent-tokenomics-opencode.yml \
+  --provider opencode \
+  --manifest-path tests/fixtures/tokenomics_manifest.json \
+  --telemetry
+```
+
+Rows include the suite name/path, mode, case id, assertion name/type, status,
+run duration, output directory, git SHA when available, and manifest hash for
+bridge runs. Agent rows also include provider metadata and sanitized trace
+counters such as tool-call count, distinct tool count, response bytes, and token
+counts when a provider trace exposes them. Telemetry does not store raw SQL
+parameter maps, provider stdout/stderr, or credentials.
+
+Use `eval history` for a thin date filter over the JSONL file:
+
+```bash
+dbt-nova eval history --suite agent-tokenomics-bridge --since 2026-06-01
+```
+
+Use `--telemetry-retention <ROWS>` with `eval run` or `eval agent run` to keep
+only the newest rows for that suite after appending the current run.
+
 ## Tool Trace
 
 When `DBT_NOVA_TRACE_TOOL_CALLS_PATH` is set, dbt-nova appends sanitized JSONL

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -4,7 +4,7 @@ Use `dbt-nova` in two modes:
 
 - No subcommand: start MCP server (backward compatible behavior)
 - Subcommand: run one-shot CLI commands and exit
-- CLI surface: `16` CLI-only leaf commands, plus `tool call` access to all `33` MCP tools
+- CLI surface: `17` CLI-only leaf commands, plus `tool call` access to all `33` MCP tools
 
 ## Command Tree
 
@@ -24,8 +24,9 @@ dbt-nova
 ├── storage cleanup [--storage-instance-id] [--json]
 ├── eval init --out <PATH> [--persona] [--force]
 ├── eval validate --suite <PATH> [--json]
-├── eval run --suite <PATH> [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--case-id <ID>...] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
-├── eval agent run --suite <PATH> [--provider] [--provider-command] [--provider-args-json] [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--case-id <ID>...] [--timeout-secs] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
+├── eval run --suite <PATH> [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--telemetry] [--telemetry-retention] [--case-id <ID>...] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
+├── eval agent run --suite <PATH> [--provider] [--provider-command] [--provider-args-json] [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--telemetry] [--telemetry-retention] [--case-id <ID>...] [--timeout-secs] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
+├── eval history --suite <NAME> --since <YYYY-MM-DD>
 └── health check [--manifest-path|--manifest-uri] [--json]
 ```
 

--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -47,6 +47,13 @@ supported provider presets can also score MCP calls from JSON event streams.
 Use `--case-id <ID>` on bridge or agent eval runs to iterate on one failing case
 without re-running the whole suite.
 
+Pass `--telemetry` on bridge or agent eval runs to append per-assertion JSONL
+rows under `.nova/eval-runs/telemetry/<suite>-<hash>.jsonl`. Use
+`dbt-nova eval history --suite <NAME> --since <YYYY-MM-DD>` to print matching
+rows when comparing whether metadata or prompt changes improved a suite over
+time. Add `--telemetry-retention <ROWS>` to keep only the newest rows for that
+suite after each run.
+
 ## Test Storage Cleanup
 
 Tests use temporary storage under `target/dbt-nova-tests` and clean up automatically.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -345,6 +345,8 @@ pub enum EvalCommand {
     Run(EvalRunArgs),
     /// Run provider-backed agent evals and score observed Nova tool use.
     Agent(EvalAgentArgs),
+    /// Print filtered JSONL eval telemetry history.
+    History(EvalHistoryArgs),
     /// Validate an eval suite without loading a manifest or running a provider.
     Validate(EvalValidateArgs),
 }
@@ -369,6 +371,7 @@ pub struct EvalInitArgs {
 }
 
 #[derive(Debug, Clone, Args, Default)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct EvalRunArgs {
     #[arg(long, value_name = "PATH", help = "YAML or JSON eval suite path")]
     pub suite: String,
@@ -394,6 +397,18 @@ pub struct EvalRunArgs {
     pub storage_instance_id: Option<String>,
     #[arg(long, value_name = "DIR", help = "Directory for eval result artifacts")]
     pub output_dir: Option<String>,
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Append per-assertion JSONL telemetry for this eval run"
+    )]
+    pub telemetry: bool,
+    #[arg(
+        long = "telemetry-retention",
+        value_name = "ROWS",
+        help = "After writing telemetry, keep only the newest ROWS rows for this suite"
+    )]
+    pub telemetry_retention: Option<usize>,
     #[arg(
         long = "case-id",
         value_name = "ID",
@@ -432,6 +447,7 @@ pub enum EvalAgentCommand {
 }
 
 #[derive(Debug, Clone, Args, Default)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct EvalAgentRunArgs {
     #[arg(long, value_name = "PATH", help = "YAML or JSON eval suite path")]
     pub suite: String,
@@ -483,6 +499,18 @@ pub struct EvalAgentRunArgs {
     #[arg(long, value_name = "DIR", help = "Directory for eval result artifacts")]
     pub output_dir: Option<String>,
     #[arg(
+        long,
+        default_value_t = false,
+        help = "Append per-assertion JSONL telemetry for this eval run"
+    )]
+    pub telemetry: bool,
+    #[arg(
+        long = "telemetry-retention",
+        value_name = "ROWS",
+        help = "After writing telemetry, keep only the newest ROWS rows for this suite"
+    )]
+    pub telemetry_retention: Option<usize>,
+    #[arg(
         long = "case-id",
         value_name = "ID",
         action = ArgAction::Append,
@@ -512,6 +540,22 @@ pub struct EvalAgentRunArgs {
     pub read_only: bool,
     #[arg(long, default_value_t = false, help = "Emit a JSON CLI envelope")]
     pub json: bool,
+}
+
+#[derive(Debug, Clone, Args, Default)]
+pub struct EvalHistoryArgs {
+    #[arg(
+        long,
+        value_name = "NAME",
+        help = "Eval suite name to read history for"
+    )]
+    pub suite: String,
+    #[arg(
+        long,
+        value_name = "YYYY-MM-DD",
+        help = "Only print telemetry rows on or after this UTC date"
+    )]
+    pub since: String,
 }
 
 #[derive(Debug, Clone, Args, Default)]
@@ -622,6 +666,30 @@ mod tests {
     }
 
     #[test]
+    fn eval_run_parses_telemetry_flags() {
+        let cli = Cli::parse_from([
+            "dbt-nova",
+            "eval",
+            "run",
+            "--suite",
+            "suite.yml",
+            "--telemetry",
+            "--telemetry-retention",
+            "100",
+        ]);
+        match cli.command.expect("command") {
+            Command::Eval(eval) => match eval.command {
+                EvalCommand::Run(args) => {
+                    assert!(args.telemetry);
+                    assert_eq!(args.telemetry_retention, Some(100));
+                }
+                _ => panic!("expected eval run"),
+            },
+            _ => panic!("expected eval command"),
+        }
+    }
+
+    #[test]
     fn eval_agent_run_parses_repeated_case_ids() {
         let cli = Cli::parse_from([
             "dbt-nova",
@@ -643,6 +711,29 @@ mod tests {
                     }
                 },
                 _ => panic!("expected eval agent run"),
+            },
+            _ => panic!("expected eval command"),
+        }
+    }
+
+    #[test]
+    fn eval_history_parses_suite_and_since() {
+        let cli = Cli::parse_from([
+            "dbt-nova",
+            "eval",
+            "history",
+            "--suite",
+            "starter",
+            "--since",
+            "2026-06-01",
+        ]);
+        match cli.command.expect("command") {
+            Command::Eval(eval) => match eval.command {
+                EvalCommand::History(args) => {
+                    assert_eq!(args.suite, "starter");
+                    assert_eq!(args.since, "2026-06-01");
+                }
+                _ => panic!("expected eval history"),
             },
             _ => panic!("expected eval command"),
         }

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -407,6 +407,7 @@ pub async fn run_eval_command(args: &EvalRunArgs) -> DispatchResult {
     let suite = load_suite(&args.suite)?;
     validate_fail_under(args.fail_under)?;
     validate_telemetry_retention(args.telemetry_retention)?;
+    validate_telemetry_suite_name(&suite, args.telemetry)?;
     if suite.cases.is_empty() {
         return Err(
             DbtNovaError::InvalidParams("eval suite contains no bridge cases".to_string()).into(),
@@ -462,6 +463,7 @@ pub async fn run_agent_eval_command(args: &EvalAgentRunArgs) -> DispatchResult {
     let suite = load_suite(&args.suite)?;
     validate_fail_under(args.fail_under)?;
     validate_telemetry_retention(args.telemetry_retention)?;
+    validate_telemetry_suite_name(&suite, args.telemetry)?;
     if suite.agent_cases.is_empty() {
         return Err(
             DbtNovaError::InvalidParams("eval suite contains no agent_cases".to_string()).into(),
@@ -2144,6 +2146,23 @@ fn validate_telemetry_retention(value: Option<usize>) -> crate::error::Result<()
     if value == Some(0) {
         return Err(DbtNovaError::InvalidParams(
             "--telemetry-retention must be greater than zero".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_telemetry_suite_name(
+    suite: &EvalSuite,
+    telemetry_enabled: bool,
+) -> crate::error::Result<()> {
+    if telemetry_enabled
+        && suite
+            .name
+            .as_deref()
+            .is_none_or(|name| name.trim().is_empty())
+    {
+        return Err(DbtNovaError::InvalidParams(
+            "--telemetry requires the eval suite to define a non-empty name".to_string(),
         ));
     }
     Ok(())

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -2,15 +2,18 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write as IoWrite};
 use std::path::{Path, PathBuf};
+use std::process::Command as StdCommand;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
 
 use crate::cli::args::{
-    EvalAgentRunArgs, EvalInitArgs, EvalRunArgs, EvalValidateArgs, ManifestLoadArgs,
+    EvalAgentRunArgs, EvalHistoryArgs, EvalInitArgs, EvalRunArgs, EvalValidateArgs,
+    ManifestLoadArgs,
 };
 use crate::cli::manifest::{build_manifest_load_config, execute_manifest_load};
 use crate::cli::output::{CliEnvelope, error_envelope};
@@ -21,6 +24,7 @@ use crate::manifest::ManifestSearch;
 const DEFAULT_TOP_K: usize = 5;
 const DEFAULT_FAIL_UNDER: f64 = 1.0;
 const MAX_SAFE_PATH_SEGMENT_CHARS: usize = 120;
+const DEFAULT_TELEMETRY_DIR: &str = ".nova/eval-runs/telemetry";
 
 mod provider;
 
@@ -247,6 +251,8 @@ struct EvalCaseReport {
     assertions: Vec<AssertionResult>,
     #[serde(skip_serializing_if = "Option::is_none")]
     artifacts: Option<AgentArtifacts>,
+    #[serde(skip)]
+    telemetry: Option<EvalCaseTelemetry>,
 }
 
 #[derive(Debug, Serialize)]
@@ -263,6 +269,22 @@ struct AgentArtifacts {
     stdout: String,
     stderr: String,
     tool_trace: String,
+}
+
+#[derive(Debug, Clone)]
+struct EvalCaseTelemetry {
+    tool_call_count: usize,
+    distinct_tool_count: usize,
+    total_response_bytes: Option<u64>,
+    input_tokens: Option<u64>,
+    output_tokens: Option<u64>,
+    total_tokens: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AgentTelemetryContext<'a> {
+    provider: &'a str,
+    provider_command_preset: &'a str,
 }
 
 /// Writes a starter eval suite.
@@ -342,6 +364,40 @@ pub fn run_validate_command(args: &EvalValidateArgs) -> DispatchResult {
     Ok(())
 }
 
+/// Prints filtered JSONL eval telemetry history.
+///
+/// # Errors
+/// Returns an error when `--since` is invalid or existing telemetry cannot be read.
+pub fn run_history_command(args: &EvalHistoryArgs) -> DispatchResult {
+    let since_boundary = validate_since_date(&args.since)?;
+    let path = telemetry_path_for_suite(&args.suite);
+    if !path.exists() {
+        return Ok(());
+    }
+    let file = fs::File::open(&path).map_err(|error| server_error(error.to_string()))?;
+    let reader = BufReader::new(file);
+    for (index, line) in reader.lines().enumerate() {
+        let line = line.map_err(|error| server_error(error.to_string()))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let row = serde_json::from_str::<JsonValue>(trimmed).map_err(|error| {
+            DbtNovaError::InvalidParams(format!(
+                "failed to parse telemetry line {} in '{}': {error}",
+                index + 1,
+                path.display()
+            ))
+        })?;
+        if telemetry_row_matches_since(&row, &since_boundary) {
+            let out =
+                serde_json::to_string(&row).map_err(|error| server_error(error.to_string()))?;
+            println!("{out}");
+        }
+    }
+    Ok(())
+}
+
 /// Runs deterministic Nova bridge assertions against a manifest.
 ///
 /// # Errors
@@ -350,6 +406,7 @@ pub async fn run_eval_command(args: &EvalRunArgs) -> DispatchResult {
     let started = Instant::now();
     let suite = load_suite(&args.suite)?;
     validate_fail_under(args.fail_under)?;
+    validate_telemetry_retention(args.telemetry_retention)?;
     if suite.cases.is_empty() {
         return Err(
             DbtNovaError::InvalidParams("eval suite contains no bridge cases".to_string()).into(),
@@ -381,12 +438,19 @@ pub async fn run_eval_command(args: &EvalRunArgs) -> DispatchResult {
         cases,
     );
     write_report_artifacts(&output_dir, &report, &args.suite)?;
-    finish_report(
-        "eval run",
-        &report,
-        args.json,
-        started.elapsed().as_millis(),
-    )
+    let elapsed = started.elapsed();
+    let elapsed_ms = elapsed.as_millis();
+    if args.telemetry {
+        write_eval_telemetry(
+            &report,
+            &args.suite,
+            Some(&load_result.search.manifest_hash),
+            elapsed_ms_to_u64(elapsed),
+            args.telemetry_retention,
+            None,
+        )?;
+    }
+    finish_report("eval run", &report, args.json, elapsed_ms)
 }
 
 /// Runs agent-provider evals and scores the tool-use trace.
@@ -397,6 +461,7 @@ pub async fn run_agent_eval_command(args: &EvalAgentRunArgs) -> DispatchResult {
     let started = Instant::now();
     let suite = load_suite(&args.suite)?;
     validate_fail_under(args.fail_under)?;
+    validate_telemetry_retention(args.telemetry_retention)?;
     if suite.agent_cases.is_empty() {
         return Err(
             DbtNovaError::InvalidParams("eval suite contains no agent_cases".to_string()).into(),
@@ -419,12 +484,22 @@ pub async fn run_agent_eval_command(args: &EvalAgentRunArgs) -> DispatchResult {
         cases,
     );
     write_report_artifacts(&output_dir, &report, &args.suite)?;
-    finish_report(
-        "eval agent run",
-        &report,
-        args.json,
-        started.elapsed().as_millis(),
-    )
+    let elapsed = started.elapsed();
+    let elapsed_ms = elapsed.as_millis();
+    if args.telemetry {
+        write_eval_telemetry(
+            &report,
+            &args.suite,
+            None,
+            elapsed_ms_to_u64(elapsed),
+            args.telemetry_retention,
+            Some(AgentTelemetryContext {
+                provider: &args.provider,
+                provider_command_preset: agent_provider_command_preset(args),
+            }),
+        )?;
+    }
+    finish_report("eval agent run", &report, args.json, elapsed_ms)
 }
 
 async fn evaluate_bridge_case(
@@ -786,6 +861,7 @@ async fn run_agent_case(
         &trace.rows,
         &final_answer_text,
     ));
+    let telemetry = eval_case_telemetry_from_trace(&trace.rows);
     EvalCaseReport::new(
         case.id.clone(),
         Some(case.task.clone()),
@@ -796,6 +872,7 @@ async fn run_agent_case(
             tool_trace: trace_path.display().to_string(),
         }),
     )
+    .with_telemetry(telemetry)
 }
 
 fn score_agent_expectations(
@@ -1900,6 +1977,326 @@ fn write_report_artifacts(
     Ok(())
 }
 
+fn write_eval_telemetry(
+    report: &EvalReport,
+    suite_path: &str,
+    manifest_hash: Option<&str>,
+    duration_ms: u64,
+    retention: Option<usize>,
+    agent: Option<AgentTelemetryContext<'_>>,
+) -> DispatchResult {
+    let telemetry_path = telemetry_path_for_suite(&report.suite_name);
+    if let Some(parent) = telemetry_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| server_error(error.to_string()))?;
+    }
+    let timestamp_ms = timestamp_millis();
+    let timestamp = format_utc_timestamp_millis(timestamp_ms);
+    let git_sha = current_git_sha();
+    let manifest_hash = manifest_hash
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&telemetry_path)
+        .map_err(|error| server_error(error.to_string()))?;
+    for case in &report.cases {
+        for assertion in &case.assertions {
+            let mut row = serde_json::Map::new();
+            row.insert("timestamp".to_string(), json!(&timestamp));
+            row.insert("timestamp_ms".to_string(), json!(timestamp_ms));
+            row.insert("suite_name".to_string(), json!(&report.suite_name));
+            row.insert("suite_path".to_string(), json!(suite_path));
+            row.insert("mode".to_string(), json!(report.mode));
+            row.insert("case_id".to_string(), json!(&case.id));
+            row.insert("assertion_name".to_string(), json!(&assertion.name));
+            row.insert(
+                "assertion_type".to_string(),
+                json!(assertion_type(&assertion.name)),
+            );
+            row.insert("status".to_string(), json!(assertion.status));
+            row.insert(
+                "grade_mode".to_string(),
+                json!(telemetry_grade_mode(report.mode)),
+            );
+            row.insert("duration_ms".to_string(), json!(duration_ms));
+            row.insert("output_dir".to_string(), json!(&report.output_dir));
+            if let Some(manifest_hash) = manifest_hash.as_ref() {
+                row.insert("manifest_hash".to_string(), json!(manifest_hash));
+            }
+            if let Some(git_sha) = git_sha.as_ref() {
+                row.insert("git_sha".to_string(), json!(git_sha));
+            }
+            if let Some(agent) = agent {
+                row.insert("provider".to_string(), json!(agent.provider));
+                row.insert(
+                    "provider_command_preset".to_string(),
+                    json!(agent.provider_command_preset),
+                );
+                if let Some(telemetry) = case.telemetry.as_ref() {
+                    row.insert(
+                        "tool_call_count".to_string(),
+                        json!(telemetry.tool_call_count),
+                    );
+                    row.insert(
+                        "distinct_tool_count".to_string(),
+                        json!(telemetry.distinct_tool_count),
+                    );
+                    if let Some(value) = telemetry.total_response_bytes {
+                        row.insert("total_response_bytes".to_string(), json!(value));
+                    }
+                    if let Some(value) = telemetry.input_tokens {
+                        row.insert("input_tokens".to_string(), json!(value));
+                    }
+                    if let Some(value) = telemetry.output_tokens {
+                        row.insert("output_tokens".to_string(), json!(value));
+                    }
+                    if let Some(value) = telemetry.total_tokens {
+                        row.insert("total_tokens".to_string(), json!(value));
+                    }
+                }
+            }
+            let line = serde_json::to_string(&JsonValue::Object(row))
+                .map_err(|error| server_error(error.to_string()))?;
+            file.write_all(line.as_bytes())
+                .map_err(|error| server_error(error.to_string()))?;
+            file.write_all(b"\n")
+                .map_err(|error| server_error(error.to_string()))?;
+        }
+    }
+    drop(file);
+
+    if let Some(max_rows) = retention {
+        apply_telemetry_retention(&telemetry_path, max_rows)?;
+    }
+    Ok(())
+}
+
+fn apply_telemetry_retention(path: &Path, max_rows: usize) -> DispatchResult {
+    let raw = fs::read_to_string(path).map_err(|error| server_error(error.to_string()))?;
+    let rows: Vec<&str> = raw.lines().filter(|line| !line.trim().is_empty()).collect();
+    if rows.len() <= max_rows {
+        return Ok(());
+    }
+    let keep_from = rows.len().saturating_sub(max_rows);
+    let mut out = rows[keep_from..].join("\n");
+    out.push('\n');
+    fs::write(path, out).map_err(|error| server_error(error.to_string()))?;
+    Ok(())
+}
+
+fn telemetry_path_for_suite(suite_name: &str) -> PathBuf {
+    PathBuf::from(DEFAULT_TELEMETRY_DIR).join(format!(
+        "{}-{:016x}.jsonl",
+        safe_path_segment(suite_name),
+        stable_telemetry_hash(suite_name)
+    ))
+}
+
+fn stable_telemetry_hash(value: &str) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in value.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0001_0000_01b3);
+    }
+    hash
+}
+
+fn telemetry_row_matches_since(row: &JsonValue, since_boundary: &str) -> bool {
+    row.get("timestamp")
+        .and_then(JsonValue::as_str)
+        .is_some_and(|timestamp| timestamp >= since_boundary)
+}
+
+fn validate_since_date(value: &str) -> crate::error::Result<String> {
+    let valid_shape = value.len() == 10
+        && value.as_bytes()[4] == b'-'
+        && value.as_bytes()[7] == b'-'
+        && value
+            .chars()
+            .enumerate()
+            .all(|(index, ch)| matches!(index, 4 | 7) || ch.is_ascii_digit());
+    if !valid_shape {
+        return Err(DbtNovaError::InvalidParams(
+            "--since must use YYYY-MM-DD".to_string(),
+        ));
+    }
+    let year = value[0..4]
+        .parse::<i32>()
+        .map_err(|_| DbtNovaError::InvalidParams("--since must use YYYY-MM-DD".to_string()))?;
+    let month = value[5..7]
+        .parse::<u32>()
+        .map_err(|_| DbtNovaError::InvalidParams("--since must use YYYY-MM-DD".to_string()))?;
+    let day = value[8..10]
+        .parse::<u32>()
+        .map_err(|_| DbtNovaError::InvalidParams("--since must use YYYY-MM-DD".to_string()))?;
+    if !(1..=12).contains(&month) || day == 0 || day > days_in_month(year, month) {
+        return Err(DbtNovaError::InvalidParams(
+            "--since must use a valid YYYY-MM-DD date".to_string(),
+        ));
+    }
+    Ok(format!("{value}T00:00:00.000Z"))
+}
+
+fn validate_telemetry_retention(value: Option<usize>) -> crate::error::Result<()> {
+    if value == Some(0) {
+        return Err(DbtNovaError::InvalidParams(
+            "--telemetry-retention must be greater than zero".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn telemetry_grade_mode(mode: &str) -> &'static str {
+    match mode {
+        "agent" => "provider_trace",
+        _ => "deterministic",
+    }
+}
+
+fn assertion_type(name: &str) -> &str {
+    name.split_once(':').map_or(name, |(prefix, _)| prefix)
+}
+
+fn agent_provider_command_preset(args: &EvalAgentRunArgs) -> &str {
+    if args.provider_command.is_some() || args.provider_args_json.is_some() {
+        "custom"
+    } else {
+        args.provider.as_str()
+    }
+}
+
+fn eval_case_telemetry_from_trace(trace: &[JsonValue]) -> EvalCaseTelemetry {
+    let mut distinct_tools = BTreeSet::new();
+    let mut response_bytes_seen = false;
+    let mut total_response_bytes = 0_u64;
+    for row in trace {
+        if let Some(tool) = row.get("tool").and_then(JsonValue::as_str) {
+            distinct_tools.insert(tool.to_string());
+        }
+        if let Some(bytes) = row.get("response_bytes").and_then(JsonValue::as_u64) {
+            response_bytes_seen = true;
+            total_response_bytes = total_response_bytes.saturating_add(bytes);
+        }
+    }
+    EvalCaseTelemetry {
+        tool_call_count: trace.len(),
+        distinct_tool_count: distinct_tools.len(),
+        total_response_bytes: response_bytes_seen.then_some(total_response_bytes),
+        input_tokens: sum_first_available_u64(
+            trace,
+            &[
+                &["input_tokens"],
+                &["usage", "input_tokens"],
+                &["usage", "prompt_tokens"],
+            ],
+        ),
+        output_tokens: sum_first_available_u64(
+            trace,
+            &[
+                &["output_tokens"],
+                &["usage", "output_tokens"],
+                &["usage", "completion_tokens"],
+            ],
+        ),
+        total_tokens: sum_first_available_u64(
+            trace,
+            &[&["total_tokens"], &["usage", "total_tokens"]],
+        ),
+    }
+}
+
+fn sum_first_available_u64(trace: &[JsonValue], paths: &[&[&str]]) -> Option<u64> {
+    let mut seen = false;
+    let mut total = 0_u64;
+    for row in trace {
+        for path in paths {
+            if let Some(value) = json_path_u64(row, path) {
+                seen = true;
+                total = total.saturating_add(value);
+                break;
+            }
+        }
+    }
+    seen.then_some(total)
+}
+
+fn json_path_u64(value: &JsonValue, path: &[&str]) -> Option<u64> {
+    let mut cursor = value;
+    for part in path {
+        cursor = cursor.get(*part)?;
+    }
+    cursor.as_u64()
+}
+
+fn current_git_sha() -> Option<String> {
+    let output = StdCommand::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!sha.is_empty()).then_some(sha)
+}
+
+fn timestamp_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| {
+            u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+        })
+}
+
+fn format_utc_timestamp_millis(timestamp_ms: u64) -> String {
+    let secs = timestamp_ms / 1000;
+    let millis = timestamp_ms % 1000;
+    let days = i64::try_from(secs / 86_400).unwrap_or(i64::MAX);
+    let seconds_of_day = secs % 86_400;
+    let (year, month, day) = civil_from_days(days);
+    let hour = seconds_of_day / 3_600;
+    let minute = (seconds_of_day % 3_600) / 60;
+    let second = seconds_of_day % 60;
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z")
+}
+
+fn civil_from_days(days_since_epoch: i64) -> (i32, u32, u32) {
+    let z = days_since_epoch.saturating_add(719_468);
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let mut year = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = mp + if mp < 10 { 3 } else { -9 };
+    if month <= 2 {
+        year += 1;
+    }
+    (
+        i32::try_from(year).unwrap_or(i32::MAX),
+        u32::try_from(month).unwrap_or(12),
+        u32::try_from(day).unwrap_or(31),
+    )
+}
+
+fn days_in_month(year: i32, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+fn is_leap_year(year: i32) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
 fn render_tsv(report: &EvalReport) -> String {
     let mut out = String::from("case_id\tassertion\tstatus\tmessage\n");
     for case in &report.cases {
@@ -2016,7 +2413,13 @@ impl EvalCaseReport {
             error_count,
             assertions,
             artifacts,
+            telemetry: None,
         }
+    }
+
+    fn with_telemetry(mut self, telemetry: EvalCaseTelemetry) -> Self {
+        self.telemetry = Some(telemetry);
+        self
     }
 }
 

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -7,11 +7,13 @@ use tempfile::{NamedTempFile, TempDir};
 use super::{
     AgentCalledWith, AgentEntityRank, AgentExpected, AgentOrder, AssertionResult, EvalCaseReport,
     EvalDefaults, EvalRunArgs, EvalSuite, EvalValidateArgs, FinalAnswerExpected,
-    contains_rank_assertion, context_contains_assertion, context_field_equals_assertion,
+    apply_telemetry_retention, contains_rank_assertion, context_contains_assertion,
+    context_field_equals_assertion, eval_case_telemetry_from_trace, format_utc_timestamp_millis,
     json_has_field_path, metadata_score_max_assertion, metadata_score_min_assertion,
     read_tool_trace, recipe_rank_assertion, run_eval_command, run_validate_command,
     safe_path_segment, score_agent_expectations, selected_agent_cases, selected_bridge_cases,
-    tool_response_budget_assertion, tool_success_assertion, validate_suite,
+    telemetry_path_for_suite, telemetry_row_matches_since, tool_response_budget_assertion,
+    tool_success_assertion, validate_since_date, validate_suite,
 };
 
 #[test]
@@ -298,6 +300,110 @@ fn read_tool_trace_reports_parse_errors() {
     assert!(!trace.missing);
     assert_eq!(trace.rows[0]["tool_call_index"], json!(0));
     assert_eq!(trace.rows[1]["tool_call_index"], json!(1));
+}
+
+#[test]
+fn telemetry_stats_summarize_trace_without_params() {
+    let trace = vec![
+        json!({
+            "tool": "search",
+            "response_bytes": 40,
+            "params_summary": {"query": "revenue"},
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5}
+        }),
+        json!({
+            "tool": "get_context",
+            "response_bytes": 60,
+            "usage": {"input_tokens": 4, "output_tokens": 3, "total_tokens": 7}
+        }),
+    ];
+
+    let telemetry = eval_case_telemetry_from_trace(&trace);
+
+    assert_eq!(telemetry.tool_call_count, 2);
+    assert_eq!(telemetry.distinct_tool_count, 2);
+    assert_eq!(telemetry.total_response_bytes, Some(100));
+    assert_eq!(telemetry.input_tokens, Some(14));
+    assert_eq!(telemetry.output_tokens, Some(8));
+    assert_eq!(telemetry.total_tokens, Some(7));
+}
+
+#[test]
+fn telemetry_history_since_filters_iso_timestamps() {
+    let since = validate_since_date("2026-06-01").expect("valid date");
+    assert!(telemetry_row_matches_since(
+        &json!({"timestamp": "2026-06-01T00:00:00.000Z"}),
+        &since
+    ));
+    assert!(telemetry_row_matches_since(
+        &json!({"timestamp": "2026-06-02T12:00:00.000Z"}),
+        &since
+    ));
+    assert!(!telemetry_row_matches_since(
+        &json!({"timestamp": "2026-05-31T23:59:59.999Z"}),
+        &since
+    ));
+    assert!(validate_since_date("2026-02-29").is_err());
+}
+
+#[test]
+fn telemetry_retention_keeps_newest_valid_jsonl_rows() {
+    let file = NamedTempFile::new().expect("temp file");
+    std::fs::write(
+        file.path(),
+        "{\"case_id\":\"one\"}\n{\"case_id\":\"two\"}\n{\"case_id\":\"three\"}\n",
+    )
+    .expect("write telemetry");
+
+    let result = apply_telemetry_retention(file.path(), 2);
+    assert!(
+        result.is_ok(),
+        "retention failed: {}",
+        result
+            .err()
+            .map_or_else(String::new, |error| error.error.to_string())
+    );
+
+    let raw = std::fs::read_to_string(file.path()).expect("read telemetry");
+    let lines: Vec<&str> = raw.lines().collect();
+    assert_eq!(lines.len(), 2);
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(lines[0]).unwrap()["case_id"],
+        "two"
+    );
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(lines[1]).unwrap()["case_id"],
+        "three"
+    );
+}
+
+#[test]
+fn telemetry_timestamp_format_is_utc_rfc3339_millis() {
+    assert_eq!(
+        format_utc_timestamp_millis(1_767_225_600_123),
+        "2026-01-01T00:00:00.123Z"
+    );
+}
+
+#[test]
+fn telemetry_paths_include_hash_to_avoid_sanitized_name_collisions() {
+    let spaced = telemetry_path_for_suite("sales smoke");
+    let slashed = telemetry_path_for_suite("sales/smoke");
+    let dashed = telemetry_path_for_suite("sales-smoke");
+
+    assert_ne!(spaced, slashed);
+    assert_ne!(spaced, dashed);
+    assert_ne!(slashed, dashed);
+    let file_name = dashed
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("telemetry file name");
+    assert!(file_name.starts_with("sales-smoke-"));
+    assert!(
+        dashed
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("jsonl"))
+    );
 }
 
 #[test]

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -13,7 +13,7 @@ use super::{
     read_tool_trace, recipe_rank_assertion, run_eval_command, run_validate_command,
     safe_path_segment, score_agent_expectations, selected_agent_cases, selected_bridge_cases,
     telemetry_path_for_suite, telemetry_row_matches_since, tool_response_budget_assertion,
-    tool_success_assertion, validate_since_date, validate_suite,
+    tool_success_assertion, validate_since_date, validate_suite, validate_telemetry_suite_name,
 };
 
 #[test]
@@ -404,6 +404,22 @@ fn telemetry_paths_include_hash_to_avoid_sanitized_name_collisions() {
             .extension()
             .is_some_and(|ext| ext.eq_ignore_ascii_case("jsonl"))
     );
+}
+
+#[test]
+fn telemetry_requires_named_suite() {
+    let suite = EvalSuite {
+        version: 1,
+        name: None,
+        defaults: EvalDefaults::default(),
+        cases: Vec::new(),
+        agent_cases: Vec::new(),
+    };
+
+    assert!(validate_telemetry_suite_name(&suite, false).is_ok());
+    let error = validate_telemetry_suite_name(&suite, true)
+        .expect_err("telemetry should require suite name");
+    assert!(error.to_string().contains("non-empty name"));
 }
 
 #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -89,6 +89,9 @@ pub async fn dispatch(command: args::Command) -> DispatchResult {
                     eval_cmd::run_agent_eval_command(&run_args).await
                 }
             },
+            args::EvalCommand::History(history_args) => {
+                eval_cmd::run_history_command(&history_args)
+            }
             args::EvalCommand::Validate(validate_args) => {
                 eval_cmd::run_validate_command(&validate_args)
             }


### PR DESCRIPTION
## Summary
- Adds opt-in `eval run --telemetry` and `eval agent run --telemetry` JSONL emission, one row per assertion result.
- Adds `eval history --suite <NAME> --since <YYYY-MM-DD>` for thin JSONL filtering.
- Adds `--telemetry-retention <ROWS>` to keep the newest rows per suite file.
- Uses collision-resistant telemetry filenames (`<suite>-<hash>.jsonl`) so sanitized suite names cannot share history/retention scope.
- Documents telemetry behavior and updates the changelog.

Linear: JOE-11

## Validation
- `cargo test --locked eval_cmd`
- `cargo test --locked eval_run_parses_telemetry_flags`
- `cargo test --locked eval_history_parses_suite_and_since`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `uv run mkdocs build --strict`
- `git diff --check`
- Bridge telemetry append validation: ran `evals/agent-tokenomics-bridge.yml` twice with `--telemetry`; produced 10 valid hashed JSONL rows and `eval history --suite agent-tokenomics-bridge --since 2026-06-01` returned 10 rows.
- Agent telemetry validation: ran deterministic custom provider against `evals/agent-tokenomics-opencode.yml`; produced 29 valid hashed JSONL rows with provider metadata and tool/response/token counters.
- Sanitization check: telemetry rows did not include raw params, stdout/stderr, or secret-like fields.
- Autoreview: initial finding about sanitized filename collisions fixed; rerun clean with no accepted/actionable findings.