### PR TITLE
Add eval readiness gates

### DIFF
--- a/.github/skills/analyst/SKILL.md
+++ b/.github/skills/analyst/SKILL.md
@@ -70,6 +70,7 @@ Rules:
 - Do not assume friendly labels map directly to raw warehouse values without validation.
 - Keep validation probes close to the target slice. Do not scan a year-plus range just to confirm one filter member.
 - Do not front-load every trust tool by default. Escalate only when the answer is high-stakes or the entity choice is ambiguous.
+- For high-stakes, launch-readiness, or recurring production workflows, check the relevant eval suite gate with `dbt-nova eval gate <suite_name> --json` when CLI access and suite ownership are known. Treat blocked gates as advisory warnings to surface before final analysis, not as permission to hide the answer.
 
 ## Analysis discipline
 

--- a/.github/skills/eval-author/SKILL.md
+++ b/.github/skills/eval-author/SKILL.md
@@ -51,7 +51,9 @@ Eval execution is CLI-only. MCP is for discovering ground truth and debugging ex
 6. Validate the suite shape with `dbt-nova eval validate`.
 7. Run one case with `--case-id` before running the full suite.
 8. Set a gate that matches the suite purpose.
-9. Read `results.json` for machines, `report.md` for humans, and tool traces for agent behavior.
+9. Run the full suite with `--telemetry` before checking readiness gates.
+10. Check readiness with `dbt-nova eval gate <suite_name> --json` for high-stakes, launch-readiness, or recurring production suites.
+11. Read `results.json` for machines, `report.md` for humans, and tool traces for agent behavior.
 
 ## Design rules
 
@@ -63,6 +65,7 @@ Eval execution is CLI-only. MCP is for discovering ground truth and debugging ex
 - Avoid brittle prose checks. Use `final_answer.must_contain` only for short, durable business terms.
 - Freeze relative dates in agent tasks. Do not leave "last week", "this month", or "last 52 weeks" unresolved unless the eval is explicitly testing date interpretation.
 - Keep smoke suites small and strict. Keep broader regression suites larger with realistic `--fail-under` thresholds.
+- Put advisory launch-readiness thresholds in suite YAML as `gate: { threshold: <0.0-1.0> }`, then verify the latest full-suite telemetry with `dbt-nova eval gate <suite_name> --json`. Filtered `--case-id` runs are for iteration and do not satisfy configured gates.
 - Never include secrets, credentials, raw SQL parameter maps, or private manifests in public eval artifacts.
 
 ## Output standard

--- a/.github/skills/eval-author/references/workflow.md
+++ b/.github/skills/eval-author/references/workflow.md
@@ -45,21 +45,24 @@ generic week boundary.
 2. Run `dbt-nova eval validate --suite <suite>`.
 3. Run one bridge case with `dbt-nova eval run --suite <suite> --case-id <id>`.
 4. Fix expected ids, ranks, or metadata gaps.
-5. Run the full bridge suite.
+5. Run the full bridge suite with `--telemetry` when the suite will be readiness-gated.
 6. Add agent cases for workflows where tool-use behavior matters.
-7. Run one agent case with the target provider.
+7. Run one agent case with the target provider for iteration; run the full agent suite with `--telemetry` before checking a readiness gate.
 8. Inspect `tool-calls/<case>.jsonl`, `stdout.log`, and `report.md`.
 9. Set the CI gate only after the suite has at least one clean local run.
+10. For high-stakes, launch-readiness, or recurring production suites, check `dbt-nova eval gate <suite_name> --json` after full-suite telemetry-producing runs.
 
 ## Gate Selection
 
 Use strict gates for smoke suites:
 - `--fail-under 1.0`
+- `gate.threshold: 1.0`
 - small number of high-signal cases
 - should run after every manifest build
 
 Use realistic gates for broad regression suites:
 - `--fail-under 0.90` to `0.98`
+- `gate.threshold: 0.90` to `0.98`
 - larger coverage across domains
 - should run on a schedule or before metadata releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--telemetry`, keep newest rows with `--telemetry-retention`, and print
   filtered run history with `dbt-nova eval history --suite <NAME> --since
   <YYYY-MM-DD>`.
+- Eval suites can now declare advisory readiness gates with `gate.threshold`;
+  `dbt-nova eval gate <NAME> --json` reads the latest full-suite telemetry and
+  reports allowed/blocked status, pass rate, and failed case/assertion ids,
+  blocking stale suite-file telemetry before allowing configured gates.
 - Fixed release OCI publishing to build images from native Linux release binaries
   instead of compiling Rust inside the ARM64 Docker/QEMU path.
 - Fixed the Monthly workflow by refreshing advisory/dependency-watchlist review

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   response budgets, KPI discovery, and MCP trace behavior for agent workflows.
 - Eval traces now include a monotonic `tool_call_index`, and provider fallback
   scoring captures response byte evidence for budget assertions.
+- Eval runs can now append per-assertion JSONL telemetry with
+  `--telemetry`, keep newest rows with `--telemetry-retention`, and print
+  filtered run history with `dbt-nova eval history --suite <NAME> --since
+  <YYYY-MM-DD>`.
 - Fixed release OCI publishing to build images from native Linux release binaries
   instead of compiling Rust inside the ARM64 Docker/QEMU path.
 - Fixed the Monthly workflow by refreshing advisory/dependency-watchlist review

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -253,6 +253,9 @@ Use `--telemetry` when you want eval results to accumulate across runs instead
 of only writing one-off report artifacts. Bridge and agent evals append one
 JSON object per assertion to `.nova/eval-runs/telemetry/<suite>-<hash>.jsonl`:
 
+Suites must define a non-empty `name:` to write telemetry. This keeps history
+and retention scoped to one suite instead of mixing unrelated unnamed files.
+
 ```bash
 dbt-nova eval run \
   --suite evals/agent-tokenomics-bridge.yml \

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -269,12 +269,13 @@ dbt-nova eval agent run \
   --telemetry
 ```
 
-Rows include the suite name/path, mode, case id, assertion name/type, status,
-run duration, output directory, git SHA when available, and manifest hash for
-bridge runs. Agent rows also include provider metadata and sanitized trace
-counters such as tool-call count, distinct tool count, response bytes, and token
-counts when a provider trace exposes them. Telemetry does not store raw SQL
-parameter maps, provider stdout/stderr, or credentials.
+Rows include a run id, run/suite case counts, run assertion count, suite
+name/path/hash, mode, case id, assertion name/type, status, run duration, output
+directory, git SHA when available, and manifest hash for bridge runs. Agent rows
+also include provider metadata and sanitized trace counters such as tool-call
+count, distinct tool count, response bytes, and token counts when a provider
+trace exposes them. Telemetry does not store raw SQL parameter maps, provider
+stdout/stderr, or credentials.
 
 Use `eval history` for a thin date filter over the JSONL file:
 
@@ -284,6 +285,40 @@ dbt-nova eval history --suite agent-tokenomics-bridge --since 2026-06-01
 
 Use `--telemetry-retention <ROWS>` with `eval run` or `eval agent run` to keep
 only the newest rows for that suite after appending the current run.
+
+## Readiness Gates
+
+Suites can declare an advisory readiness threshold:
+
+```yaml
+version: 1
+name: analyst-smoke
+gate:
+  threshold: 0.9
+```
+
+After running the full suite with `--telemetry`, check the latest run:
+
+```bash
+dbt-nova eval gate analyst-smoke --json
+```
+
+The gate scans the suite telemetry JSONL, selects the latest run, computes its
+pass rate, and reports `allowed`, `blocked`, `gate_configured`, `pass_rate`,
+`total_evals`, `failed_evals`, `failed_eval_ids`, `failed_case_ids`, and the
+telemetry timestamp. Configured gates require the latest telemetry to match the
+current suite file hash, cover the full suite, and include every assertion row
+for that run, so stale suite files, filtered `--case-id` runs, and row-trimmed
+telemetry are blocked with rerun guidance. If the suite has no
+`gate.threshold`, the command returns `allowed=true` with
+`gate_configured=false`. If telemetry is missing, the command returns an
+actionable message to run the suite with `--telemetry` first. If the latest
+telemetry points at a suite file that cannot be read, the gate is blocked
+because the threshold cannot be verified.
+
+Gate results are advisory in this release. Use them to warn before
+launch-readiness checks or high-stakes analysis; they do not hard-block MCP
+tooling or hosted server startup.
 
 ## Tool Trace
 

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -247,6 +247,41 @@ Available placeholders in `--provider-args-json`:
 - `{trace_path}`
 - `{manifest_path}`
 
+## Telemetry History
+
+Use `--telemetry` when you want eval results to accumulate across runs instead
+of only writing one-off report artifacts. Bridge and agent evals append one
+JSON object per assertion to `.nova/eval-runs/telemetry/<suite>-<hash>.jsonl`:
+
+```bash
+dbt-nova eval run \
+  --suite evals/agent-tokenomics-bridge.yml \
+  --manifest-path tests/fixtures/tokenomics_manifest.json \
+  --telemetry
+
+dbt-nova eval agent run \
+  --suite evals/agent-tokenomics-opencode.yml \
+  --provider opencode \
+  --manifest-path tests/fixtures/tokenomics_manifest.json \
+  --telemetry
+```
+
+Rows include the suite name/path, mode, case id, assertion name/type, status,
+run duration, output directory, git SHA when available, and manifest hash for
+bridge runs. Agent rows also include provider metadata and sanitized trace
+counters such as tool-call count, distinct tool count, response bytes, and token
+counts when a provider trace exposes them. Telemetry does not store raw SQL
+parameter maps, provider stdout/stderr, or credentials.
+
+Use `eval history` for a thin date filter over the JSONL file:
+
+```bash
+dbt-nova eval history --suite agent-tokenomics-bridge --since 2026-06-01
+```
+
+Use `--telemetry-retention <ROWS>` with `eval run` or `eval agent run` to keep
+only the newest rows for that suite after appending the current run.
+
 ## Tool Trace
 
 When `DBT_NOVA_TRACE_TOOL_CALLS_PATH` is set, dbt-nova appends sanitized JSONL

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -4,7 +4,7 @@ Use `dbt-nova` in two modes:
 
 - No subcommand: start MCP server (backward compatible behavior)
 - Subcommand: run one-shot CLI commands and exit
-- CLI surface: `16` CLI-only leaf commands, plus `tool call` access to all `33` MCP tools
+- CLI surface: `17` CLI-only leaf commands, plus `tool call` access to all `33` MCP tools
 
 ## Command Tree
 
@@ -24,8 +24,9 @@ dbt-nova
 ├── storage cleanup [--storage-instance-id] [--json]
 ├── eval init --out <PATH> [--persona] [--force]
 ├── eval validate --suite <PATH> [--json]
-├── eval run --suite <PATH> [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--case-id <ID>...] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
-├── eval agent run --suite <PATH> [--provider] [--provider-command] [--provider-args-json] [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--case-id <ID>...] [--timeout-secs] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
+├── eval run --suite <PATH> [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--telemetry] [--telemetry-retention] [--case-id <ID>...] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
+├── eval agent run --suite <PATH> [--provider] [--provider-command] [--provider-args-json] [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--telemetry] [--telemetry-retention] [--case-id <ID>...] [--timeout-secs] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
+├── eval history --suite <NAME> --since <YYYY-MM-DD>
 └── health check [--manifest-path|--manifest-uri] [--json]
 ```
 

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -4,7 +4,7 @@ Use `dbt-nova` in two modes:
 
 - No subcommand: start MCP server (backward compatible behavior)
 - Subcommand: run one-shot CLI commands and exit
-- CLI surface: `17` CLI-only leaf commands, plus `tool call` access to all `33` MCP tools
+- CLI surface: `18` CLI-only leaf commands, plus `tool call` access to all `33` MCP tools
 
 ## Command Tree
 
@@ -26,6 +26,7 @@ dbt-nova
 ├── eval validate --suite <PATH> [--json]
 ├── eval run --suite <PATH> [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--telemetry] [--telemetry-retention] [--case-id <ID>...] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
 ├── eval agent run --suite <PATH> [--provider] [--provider-command] [--provider-args-json] [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--telemetry] [--telemetry-retention] [--case-id <ID>...] [--timeout-secs] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
+├── eval gate <NAME> [--json]
 ├── eval history --suite <NAME> --since <YYYY-MM-DD>
 └── health check [--manifest-path|--manifest-uri] [--json]
 ```

--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -54,6 +54,13 @@ rows when comparing whether metadata or prompt changes improved a suite over
 time. Add `--telemetry-retention <ROWS>` to keep only the newest rows for that
 suite after each run.
 
+When a suite declares `gate.threshold`, run the full suite with `--telemetry`
+and then run `dbt-nova eval gate <NAME> --json`. Configured gates reject latest
+telemetry from stale suite files, filtered `--case-id` runs, or row-retention
+truncation, because those runs do not prove current full-suite readiness. Gates
+are advisory in v1: use blocked results to warn before high-stakes analysis or
+launch-readiness claims, then inspect the reported failed case/assertion ids.
+
 ## Test Storage Cleanup
 
 Tests use temporary storage under `target/dbt-nova-tests` and clean up automatically.

--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -47,6 +47,13 @@ supported provider presets can also score MCP calls from JSON event streams.
 Use `--case-id <ID>` on bridge or agent eval runs to iterate on one failing case
 without re-running the whole suite.
 
+Pass `--telemetry` on bridge or agent eval runs to append per-assertion JSONL
+rows under `.nova/eval-runs/telemetry/<suite>-<hash>.jsonl`. Use
+`dbt-nova eval history --suite <NAME> --since <YYYY-MM-DD>` to print matching
+rows when comparing whether metadata or prompt changes improved a suite over
+time. Add `--telemetry-retention <ROWS>` to keep only the newest rows for that
+suite after each run.
+
 ## Test Storage Cleanup
 
 Tests use temporary storage under `target/dbt-nova-tests` and clean up automatically.

--- a/evals/agent-tokenomics-bridge.yml
+++ b/evals/agent-tokenomics-bridge.yml
@@ -1,5 +1,7 @@
 version: 1
 name: agent-tokenomics-bridge
+gate:
+  threshold: 1.0
 defaults:
   persona: analyst
   top_k: 5

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -345,6 +345,8 @@ pub enum EvalCommand {
     Run(EvalRunArgs),
     /// Run provider-backed agent evals and score observed Nova tool use.
     Agent(EvalAgentArgs),
+    /// Report readiness from the latest eval telemetry for a suite.
+    Gate(EvalGateArgs),
     /// Print filtered JSONL eval telemetry history.
     History(EvalHistoryArgs),
     /// Validate an eval suite without loading a manifest or running a provider.
@@ -559,6 +561,14 @@ pub struct EvalHistoryArgs {
 }
 
 #[derive(Debug, Clone, Args, Default)]
+pub struct EvalGateArgs {
+    #[arg(value_name = "NAME", help = "Eval suite name to check")]
+    pub suite: String,
+    #[arg(long, default_value_t = false, help = "Emit a JSON CLI envelope")]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Args, Default)]
 pub struct EvalValidateArgs {
     #[arg(long, value_name = "PATH", help = "YAML or JSON eval suite path")]
     pub suite: String,
@@ -734,6 +744,21 @@ mod tests {
                     assert_eq!(args.since, "2026-06-01");
                 }
                 _ => panic!("expected eval history"),
+            },
+            _ => panic!("expected eval command"),
+        }
+    }
+
+    #[test]
+    fn eval_gate_parses_suite_and_json() {
+        let cli = Cli::parse_from(["dbt-nova", "eval", "gate", "starter", "--json"]);
+        match cli.command.expect("command") {
+            Command::Eval(eval) => match eval.command {
+                EvalCommand::Gate(args) => {
+                    assert_eq!(args.suite, "starter");
+                    assert!(args.json);
+                }
+                _ => panic!("expected eval gate"),
             },
             _ => panic!("expected eval command"),
         }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -345,6 +345,8 @@ pub enum EvalCommand {
     Run(EvalRunArgs),
     /// Run provider-backed agent evals and score observed Nova tool use.
     Agent(EvalAgentArgs),
+    /// Print filtered JSONL eval telemetry history.
+    History(EvalHistoryArgs),
     /// Validate an eval suite without loading a manifest or running a provider.
     Validate(EvalValidateArgs),
 }
@@ -369,6 +371,7 @@ pub struct EvalInitArgs {
 }
 
 #[derive(Debug, Clone, Args, Default)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct EvalRunArgs {
     #[arg(long, value_name = "PATH", help = "YAML or JSON eval suite path")]
     pub suite: String,
@@ -394,6 +397,18 @@ pub struct EvalRunArgs {
     pub storage_instance_id: Option<String>,
     #[arg(long, value_name = "DIR", help = "Directory for eval result artifacts")]
     pub output_dir: Option<String>,
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Append per-assertion JSONL telemetry for this eval run"
+    )]
+    pub telemetry: bool,
+    #[arg(
+        long = "telemetry-retention",
+        value_name = "ROWS",
+        help = "After writing telemetry, keep only the newest ROWS rows for this suite"
+    )]
+    pub telemetry_retention: Option<usize>,
     #[arg(
         long = "case-id",
         value_name = "ID",
@@ -432,6 +447,7 @@ pub enum EvalAgentCommand {
 }
 
 #[derive(Debug, Clone, Args, Default)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct EvalAgentRunArgs {
     #[arg(long, value_name = "PATH", help = "YAML or JSON eval suite path")]
     pub suite: String,
@@ -483,6 +499,18 @@ pub struct EvalAgentRunArgs {
     #[arg(long, value_name = "DIR", help = "Directory for eval result artifacts")]
     pub output_dir: Option<String>,
     #[arg(
+        long,
+        default_value_t = false,
+        help = "Append per-assertion JSONL telemetry for this eval run"
+    )]
+    pub telemetry: bool,
+    #[arg(
+        long = "telemetry-retention",
+        value_name = "ROWS",
+        help = "After writing telemetry, keep only the newest ROWS rows for this suite"
+    )]
+    pub telemetry_retention: Option<usize>,
+    #[arg(
         long = "case-id",
         value_name = "ID",
         action = ArgAction::Append,
@@ -512,6 +540,22 @@ pub struct EvalAgentRunArgs {
     pub read_only: bool,
     #[arg(long, default_value_t = false, help = "Emit a JSON CLI envelope")]
     pub json: bool,
+}
+
+#[derive(Debug, Clone, Args, Default)]
+pub struct EvalHistoryArgs {
+    #[arg(
+        long,
+        value_name = "NAME",
+        help = "Eval suite name to read history for"
+    )]
+    pub suite: String,
+    #[arg(
+        long,
+        value_name = "YYYY-MM-DD",
+        help = "Only print telemetry rows on or after this UTC date"
+    )]
+    pub since: String,
 }
 
 #[derive(Debug, Clone, Args, Default)]
@@ -622,6 +666,30 @@ mod tests {
     }
 
     #[test]
+    fn eval_run_parses_telemetry_flags() {
+        let cli = Cli::parse_from([
+            "dbt-nova",
+            "eval",
+            "run",
+            "--suite",
+            "suite.yml",
+            "--telemetry",
+            "--telemetry-retention",
+            "100",
+        ]);
+        match cli.command.expect("command") {
+            Command::Eval(eval) => match eval.command {
+                EvalCommand::Run(args) => {
+                    assert!(args.telemetry);
+                    assert_eq!(args.telemetry_retention, Some(100));
+                }
+                _ => panic!("expected eval run"),
+            },
+            _ => panic!("expected eval command"),
+        }
+    }
+
+    #[test]
     fn eval_agent_run_parses_repeated_case_ids() {
         let cli = Cli::parse_from([
             "dbt-nova",
@@ -643,6 +711,29 @@ mod tests {
                     }
                 },
                 _ => panic!("expected eval agent run"),
+            },
+            _ => panic!("expected eval command"),
+        }
+    }
+
+    #[test]
+    fn eval_history_parses_suite_and_since() {
+        let cli = Cli::parse_from([
+            "dbt-nova",
+            "eval",
+            "history",
+            "--suite",
+            "starter",
+            "--since",
+            "2026-06-01",
+        ]);
+        match cli.command.expect("command") {
+            Command::Eval(eval) => match eval.command {
+                EvalCommand::History(args) => {
+                    assert_eq!(args.suite, "starter");
+                    assert_eq!(args.since, "2026-06-01");
+                }
+                _ => panic!("expected eval history"),
             },
             _ => panic!("expected eval command"),
         }

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -400,6 +400,7 @@ pub async fn run_eval_command(args: &EvalRunArgs) -> DispatchResult {
     let suite = load_suite(&args.suite)?;
     validate_fail_under(args.fail_under)?;
     validate_telemetry_retention(args.telemetry_retention)?;
+    validate_telemetry_suite_name(&suite, args.telemetry)?;
     if suite.cases.is_empty() {
         return Err(
             DbtNovaError::InvalidParams("eval suite contains no bridge cases".to_string()).into(),
@@ -455,6 +456,7 @@ pub async fn run_agent_eval_command(args: &EvalAgentRunArgs) -> DispatchResult {
     let suite = load_suite(&args.suite)?;
     validate_fail_under(args.fail_under)?;
     validate_telemetry_retention(args.telemetry_retention)?;
+    validate_telemetry_suite_name(&suite, args.telemetry)?;
     if suite.agent_cases.is_empty() {
         return Err(
             DbtNovaError::InvalidParams("eval suite contains no agent_cases".to_string()).into(),
@@ -2096,6 +2098,23 @@ fn validate_telemetry_retention(value: Option<usize>) -> crate::error::Result<()
     if value == Some(0) {
         return Err(DbtNovaError::InvalidParams(
             "--telemetry-retention must be greater than zero".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_telemetry_suite_name(
+    suite: &EvalSuite,
+    telemetry_enabled: bool,
+) -> crate::error::Result<()> {
+    if telemetry_enabled
+        && suite
+            .name
+            .as_deref()
+            .is_none_or(|name| name.trim().is_empty())
+    {
+        return Err(DbtNovaError::InvalidParams(
+            "--telemetry requires the eval suite to define a non-empty name".to_string(),
         ));
     }
     Ok(())

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
 
 use crate::cli::args::{
-    EvalAgentRunArgs, EvalHistoryArgs, EvalInitArgs, EvalRunArgs, EvalValidateArgs,
+    EvalAgentRunArgs, EvalGateArgs, EvalHistoryArgs, EvalInitArgs, EvalRunArgs, EvalValidateArgs,
     ManifestLoadArgs,
 };
 use crate::cli::manifest::{build_manifest_load_config, execute_manifest_load};
@@ -34,11 +34,18 @@ struct EvalSuite {
     #[serde(default)]
     name: Option<String>,
     #[serde(default)]
+    gate: Option<EvalGateConfig>,
+    #[serde(default)]
     defaults: EvalDefaults,
     #[serde(default)]
     cases: Vec<EvalCase>,
     #[serde(default)]
     agent_cases: Vec<AgentCase>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+struct EvalGateConfig {
+    threshold: f64,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -280,6 +287,48 @@ struct AgentTelemetryContext<'a> {
     provider_command_preset: &'a str,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct EvalTelemetryRunContext<'a> {
+    suite_path: &'a str,
+    suite_hash: &'a str,
+    suite_case_count: usize,
+    manifest_hash: Option<&'a str>,
+    duration_ms: u64,
+    retention: Option<usize>,
+    agent: Option<AgentTelemetryContext<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct EvalGateReport {
+    suite_name: String,
+    allowed: bool,
+    blocked: bool,
+    gate_configured: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    threshold: Option<f64>,
+    pass_rate: f64,
+    total_evals: usize,
+    failed_evals: usize,
+    failed_eval_ids: Vec<String>,
+    failed_case_ids: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    telemetry_timestamp: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    suite_path: Option<String>,
+    message: String,
+}
+
+enum GateConfigStatus {
+    Configured {
+        gate: EvalGateConfig,
+        suite_hash: String,
+    },
+    Unconfigured,
+    Unavailable(String),
+}
+
 /// Writes a starter eval suite.
 ///
 /// # Errors
@@ -357,31 +406,33 @@ pub fn run_validate_command(args: &EvalValidateArgs) -> DispatchResult {
     Ok(())
 }
 
+/// Reports readiness from the latest eval telemetry for a suite.
+///
+/// # Errors
+/// Returns an error when existing telemetry or suite configuration cannot be parsed.
+pub fn run_gate_command(args: &EvalGateArgs) -> DispatchResult {
+    let started = Instant::now();
+    let rows = read_telemetry_rows_for_suite(&args.suite)?;
+    let report = build_eval_gate_report(&args.suite, &rows)?;
+    if args.json {
+        let envelope = CliEnvelope::success("eval gate", &report, started.elapsed().as_millis());
+        let out = serde_json::to_string_pretty(&envelope)
+            .map_err(|error| server_error(error.to_string()))?;
+        println!("{out}");
+    } else {
+        print_gate_report(&report);
+    }
+    Ok(())
+}
+
 /// Prints filtered JSONL eval telemetry history.
 ///
 /// # Errors
 /// Returns an error when `--since` is invalid or existing telemetry cannot be read.
 pub fn run_history_command(args: &EvalHistoryArgs) -> DispatchResult {
     let since_boundary = validate_since_date(&args.since)?;
-    let path = telemetry_path_for_suite(&args.suite);
-    if !path.exists() {
-        return Ok(());
-    }
-    let file = fs::File::open(&path).map_err(|error| server_error(error.to_string()))?;
-    let reader = BufReader::new(file);
-    for (index, line) in reader.lines().enumerate() {
-        let line = line.map_err(|error| server_error(error.to_string()))?;
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let row = serde_json::from_str::<JsonValue>(trimmed).map_err(|error| {
-            DbtNovaError::InvalidParams(format!(
-                "failed to parse telemetry line {} in '{}': {error}",
-                index + 1,
-                path.display()
-            ))
-        })?;
+    let rows = read_telemetry_rows_for_suite(&args.suite)?;
+    for row in rows {
         if telemetry_row_matches_since(&row, &since_boundary) {
             let out =
                 serde_json::to_string(&row).map_err(|error| server_error(error.to_string()))?;
@@ -397,7 +448,7 @@ pub fn run_history_command(args: &EvalHistoryArgs) -> DispatchResult {
 /// Returns an error when the suite is invalid, manifest loading fails, assertions error, or the score gate fails.
 pub async fn run_eval_command(args: &EvalRunArgs) -> DispatchResult {
     let started = Instant::now();
-    let suite = load_suite(&args.suite)?;
+    let (suite, suite_hash) = load_suite_with_hash(&args.suite)?;
     validate_fail_under(args.fail_under)?;
     validate_telemetry_retention(args.telemetry_retention)?;
     validate_telemetry_suite_name(&suite, args.telemetry)?;
@@ -437,11 +488,15 @@ pub async fn run_eval_command(args: &EvalRunArgs) -> DispatchResult {
     if args.telemetry {
         write_eval_telemetry(
             &report,
-            &args.suite,
-            Some(&load_result.search.manifest_hash),
-            elapsed_ms_to_u64(elapsed),
-            args.telemetry_retention,
-            None,
+            EvalTelemetryRunContext {
+                suite_path: &args.suite,
+                suite_hash: &suite_hash,
+                suite_case_count: suite.cases.len(),
+                manifest_hash: Some(&load_result.search.manifest_hash),
+                duration_ms: elapsed_ms_to_u64(elapsed),
+                retention: args.telemetry_retention,
+                agent: None,
+            },
         )?;
     }
     finish_report("eval run", &report, args.json, elapsed_ms)
@@ -453,7 +508,7 @@ pub async fn run_eval_command(args: &EvalRunArgs) -> DispatchResult {
 /// Returns an error when the suite is invalid, a provider command cannot be run, or the score gate fails.
 pub async fn run_agent_eval_command(args: &EvalAgentRunArgs) -> DispatchResult {
     let started = Instant::now();
-    let suite = load_suite(&args.suite)?;
+    let (suite, suite_hash) = load_suite_with_hash(&args.suite)?;
     validate_fail_under(args.fail_under)?;
     validate_telemetry_retention(args.telemetry_retention)?;
     validate_telemetry_suite_name(&suite, args.telemetry)?;
@@ -484,14 +539,18 @@ pub async fn run_agent_eval_command(args: &EvalAgentRunArgs) -> DispatchResult {
     if args.telemetry {
         write_eval_telemetry(
             &report,
-            &args.suite,
-            None,
-            elapsed_ms_to_u64(elapsed),
-            args.telemetry_retention,
-            Some(AgentTelemetryContext {
-                provider: &args.provider,
-                provider_command_preset: agent_provider_command_preset(args),
-            }),
+            EvalTelemetryRunContext {
+                suite_path: &args.suite,
+                suite_hash: &suite_hash,
+                suite_case_count: suite.agent_cases.len(),
+                manifest_hash: None,
+                duration_ms: elapsed_ms_to_u64(elapsed),
+                retention: args.telemetry_retention,
+                agent: Some(AgentTelemetryContext {
+                    provider: &args.provider,
+                    provider_command_preset: agent_provider_command_preset(args),
+                }),
+            },
         )?;
     }
     finish_report("eval agent run", &report, args.json, elapsed_ms)
@@ -1931,13 +1990,340 @@ fn write_report_artifacts(
     Ok(())
 }
 
+fn read_telemetry_rows_for_suite(suite_name: &str) -> crate::error::Result<Vec<JsonValue>> {
+    let path = telemetry_path_for_suite(suite_name);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let file = fs::File::open(&path).map_err(|error| server_error(error.to_string()))?;
+    let reader = BufReader::new(file);
+    let mut rows = Vec::new();
+    for (index, line) in reader.lines().enumerate() {
+        let line = line.map_err(|error| server_error(error.to_string()))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let row = serde_json::from_str::<JsonValue>(trimmed).map_err(|error| {
+            DbtNovaError::InvalidParams(format!(
+                "failed to parse telemetry line {} in '{}': {error}",
+                index + 1,
+                path.display()
+            ))
+        })?;
+        if row
+            .get("suite_name")
+            .and_then(JsonValue::as_str)
+            .is_some_and(|value| value == suite_name)
+        {
+            rows.push(row);
+        }
+    }
+    Ok(rows)
+}
+
+fn build_eval_gate_report(
+    suite_name: &str,
+    rows: &[JsonValue],
+) -> crate::error::Result<EvalGateReport> {
+    let latest_rows = latest_telemetry_rows(rows);
+    if latest_rows.is_empty() {
+        return Ok(EvalGateReport {
+            suite_name: suite_name.to_string(),
+            allowed: false,
+            blocked: true,
+            gate_configured: false,
+            threshold: None,
+            pass_rate: 0.0,
+            total_evals: 0,
+            failed_evals: 0,
+            failed_eval_ids: Vec::new(),
+            failed_case_ids: Vec::new(),
+            telemetry_timestamp: None,
+            output_dir: None,
+            suite_path: None,
+            message: format!(
+                "no eval telemetry found for suite '{suite_name}'; run the suite with --telemetry first"
+            ),
+        });
+    }
+
+    let total_evals = latest_rows.len();
+    let pass_count = latest_rows
+        .iter()
+        .filter(|row| row.get("status").and_then(JsonValue::as_str) == Some("pass"))
+        .count();
+    let failed_rows: Vec<&JsonValue> = latest_rows
+        .iter()
+        .copied()
+        .filter(|row| row.get("status").and_then(JsonValue::as_str) != Some("pass"))
+        .collect();
+    let failed_eval_ids: Vec<String> = failed_rows
+        .iter()
+        .map(|row| telemetry_eval_id(row))
+        .collect();
+    let failed_case_ids: Vec<String> = failed_rows
+        .iter()
+        .filter_map(|row| row.get("case_id").and_then(JsonValue::as_str))
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let pass_rate = ratio(pass_count, total_evals);
+    let first = latest_rows[0];
+    let suite_path = first
+        .get("suite_path")
+        .and_then(JsonValue::as_str)
+        .map(str::to_string);
+    let gate = gate_config_status_from_suite_path(suite_path.as_deref())?;
+    let telemetry_timestamp = first
+        .get("timestamp")
+        .and_then(JsonValue::as_str)
+        .map(str::to_string);
+    let output_dir = first
+        .get("output_dir")
+        .and_then(JsonValue::as_str)
+        .map(str::to_string);
+
+    let (gate_configured, threshold, current_suite_hash, unavailable_message) = match gate {
+        GateConfigStatus::Configured { gate, suite_hash } => {
+            (true, Some(gate.threshold), Some(suite_hash), None)
+        }
+        GateConfigStatus::Unconfigured => (false, None, None, None),
+        GateConfigStatus::Unavailable(message) => (false, None, None, Some(message)),
+    };
+    let incomplete_message = threshold
+        .is_some()
+        .then(|| {
+            latest_run_incomplete_message(
+                &latest_rows,
+                current_suite_hash.as_deref().unwrap_or_default(),
+            )
+        })
+        .flatten();
+    if let Some(message) = unavailable_message.or(incomplete_message) {
+        return Ok(EvalGateReport {
+            suite_name: suite_name.to_string(),
+            allowed: false,
+            blocked: true,
+            gate_configured,
+            threshold,
+            pass_rate,
+            total_evals,
+            failed_evals: failed_eval_ids.len(),
+            failed_eval_ids,
+            failed_case_ids,
+            telemetry_timestamp,
+            output_dir,
+            suite_path,
+            message,
+        });
+    }
+
+    let (allowed, message) = if let Some(threshold) = threshold {
+        let allowed = pass_rate >= threshold;
+        let message = if allowed {
+            format!("latest eval telemetry passed gate threshold {threshold:.3}")
+        } else {
+            format!(
+                "latest eval telemetry below gate threshold {threshold:.3}; inspect failed_eval_ids before relying on this suite"
+            )
+        };
+        (allowed, message)
+    } else {
+        (
+            true,
+            "no gate threshold configured; advisory gate allowed by default".to_string(),
+        )
+    };
+
+    Ok(EvalGateReport {
+        suite_name: suite_name.to_string(),
+        allowed,
+        blocked: !allowed,
+        gate_configured,
+        threshold,
+        pass_rate,
+        total_evals,
+        failed_evals: failed_eval_ids.len(),
+        failed_eval_ids,
+        failed_case_ids,
+        telemetry_timestamp,
+        output_dir,
+        suite_path,
+        message,
+    })
+}
+
+fn latest_telemetry_rows(rows: &[JsonValue]) -> Vec<&JsonValue> {
+    let Some(latest) = rows.iter().max_by_key(|row| {
+        row.get("timestamp_ms")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0)
+    }) else {
+        return Vec::new();
+    };
+    if let Some(run_id) = latest
+        .get("run_id")
+        .and_then(JsonValue::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        return rows
+            .iter()
+            .filter(|row| row.get("run_id").and_then(JsonValue::as_str) == Some(run_id))
+            .collect();
+    }
+    let latest_timestamp = latest
+        .get("timestamp_ms")
+        .and_then(JsonValue::as_u64)
+        .unwrap_or(0);
+    if let Some(output_dir) = latest
+        .get("output_dir")
+        .and_then(JsonValue::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        rows.iter()
+            .filter(|row| {
+                row.get("timestamp_ms").and_then(JsonValue::as_u64) == Some(latest_timestamp)
+                    && row.get("output_dir").and_then(JsonValue::as_str) == Some(output_dir)
+            })
+            .collect()
+    } else {
+        rows.iter()
+            .filter(|row| {
+                row.get("timestamp_ms").and_then(JsonValue::as_u64) == Some(latest_timestamp)
+            })
+            .collect()
+    }
+}
+
+fn latest_run_incomplete_message(rows: &[&JsonValue], current_suite_hash: &str) -> Option<String> {
+    let Some(recorded_suite_hash) = rows
+        .first()
+        .and_then(|row| row.get("suite_hash"))
+        .and_then(JsonValue::as_str)
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return Some(
+            "latest eval telemetry does not include suite_hash; rerun the full suite with --telemetry before checking the gate"
+                .to_string(),
+        );
+    };
+    if recorded_suite_hash != current_suite_hash {
+        return Some(
+            "latest eval telemetry was produced from a different suite file version; rerun the full suite with --telemetry before checking the gate"
+                .to_string(),
+        );
+    }
+    let Some(run_case_count) = rows
+        .first()
+        .and_then(|row| row.get("run_case_count"))
+        .and_then(JsonValue::as_u64)
+    else {
+        return Some(
+            "latest eval telemetry does not include run_case_count; rerun the full suite with --telemetry before checking the gate"
+                .to_string(),
+        );
+    };
+    let Some(suite_case_count) = rows
+        .first()
+        .and_then(|row| row.get("suite_case_count"))
+        .and_then(JsonValue::as_u64)
+    else {
+        return Some(
+            "latest eval telemetry does not include suite_case_count; rerun the full suite with --telemetry before checking the gate"
+                .to_string(),
+        );
+    };
+    if run_case_count != suite_case_count {
+        return Some(format!(
+            "latest eval telemetry covers {run_case_count} of {suite_case_count} suite cases; rerun the full suite with --telemetry before checking the gate"
+        ));
+    }
+    let Some(expected) = rows
+        .first()
+        .and_then(|row| row.get("run_assertion_count"))
+        .and_then(JsonValue::as_u64)
+    else {
+        return Some(
+            "latest eval telemetry does not include run_assertion_count; rerun the suite with --telemetry before checking the gate"
+                .to_string(),
+        );
+    };
+    let observed = u64::try_from(rows.len()).unwrap_or(u64::MAX);
+    if expected == observed {
+        return None;
+    }
+    Some(format!(
+        "latest eval telemetry is incomplete: found {observed} of {expected} assertion rows; rerun the suite with --telemetry or increase --telemetry-retention"
+    ))
+}
+
+fn gate_config_status_from_suite_path(
+    path: Option<&str>,
+) -> crate::error::Result<GateConfigStatus> {
+    let Some(path) = path.filter(|value| !value.trim().is_empty()) else {
+        return Ok(GateConfigStatus::Unavailable(
+            "latest telemetry did not include suite_path; rerun the suite with --telemetry"
+                .to_string(),
+        ));
+    };
+    if !Path::new(path).exists() {
+        return Ok(GateConfigStatus::Unavailable(format!(
+            "suite config '{path}' could not be read; rerun the suite with --telemetry from the current checkout"
+        )));
+    }
+    let (suite, suite_hash) = load_suite_with_hash(path)?;
+    Ok(match suite.gate {
+        Some(gate) => GateConfigStatus::Configured { gate, suite_hash },
+        None => GateConfigStatus::Unconfigured,
+    })
+}
+
+#[cfg(test)]
+fn suite_file_hash(path: &str) -> crate::error::Result<String> {
+    let raw = fs::read(path).map_err(|error| {
+        DbtNovaError::InvalidParams(format!(
+            "failed to read eval suite '{path}' for hash: {error}"
+        ))
+    })?;
+    Ok(blake3::hash(&raw).to_hex().to_string())
+}
+
+fn telemetry_eval_id(row: &JsonValue) -> String {
+    let case_id = row
+        .get("case_id")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("unknown_case");
+    let assertion_name = row
+        .get("assertion_name")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("unknown_assertion");
+    format!("{case_id}::{assertion_name}")
+}
+
+fn print_gate_report(report: &EvalGateReport) {
+    let status = if report.allowed { "allowed" } else { "blocked" };
+    println!("Nova eval gate {}: {status}", report.suite_name);
+    println!("  gate_configured: {}", report.gate_configured);
+    if let Some(threshold) = report.threshold {
+        println!("  threshold: {threshold:.3}");
+    }
+    println!("  pass_rate: {:.3}", report.pass_rate);
+    println!("  total_evals: {}", report.total_evals);
+    println!("  failed_evals: {}", report.failed_evals);
+    if let Some(timestamp) = report.telemetry_timestamp.as_ref() {
+        println!("  telemetry_timestamp: {timestamp}");
+    }
+    println!("  message: {}", report.message);
+    if !report.failed_eval_ids.is_empty() {
+        println!("  failed_eval_ids: {}", report.failed_eval_ids.join(", "));
+    }
+}
+
 fn write_eval_telemetry(
     report: &EvalReport,
-    suite_path: &str,
-    manifest_hash: Option<&str>,
-    duration_ms: u64,
-    retention: Option<usize>,
-    agent: Option<AgentTelemetryContext<'_>>,
+    context: EvalTelemetryRunContext<'_>,
 ) -> DispatchResult {
     let telemetry_path = telemetry_path_for_suite(&report.suite_name);
     if let Some(parent) = telemetry_path.parent() {
@@ -1945,8 +2331,14 @@ fn write_eval_telemetry(
     }
     let timestamp_ms = timestamp_millis();
     let timestamp = format_utc_timestamp_millis(timestamp_ms);
+    let run_id = format!(
+        "{}-{}-{timestamp_ms}",
+        report.mode,
+        safe_path_segment(&report.suite_name)
+    );
     let git_sha = current_git_sha();
-    let manifest_hash = manifest_hash
+    let manifest_hash = context
+        .manifest_hash
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string);
@@ -1961,8 +2353,19 @@ fn write_eval_telemetry(
             let mut row = serde_json::Map::new();
             row.insert("timestamp".to_string(), json!(&timestamp));
             row.insert("timestamp_ms".to_string(), json!(timestamp_ms));
+            row.insert("run_id".to_string(), json!(&run_id));
+            row.insert("run_case_count".to_string(), json!(report.cases.len()));
+            row.insert(
+                "suite_case_count".to_string(),
+                json!(context.suite_case_count),
+            );
+            row.insert(
+                "run_assertion_count".to_string(),
+                json!(report.assertion_count),
+            );
             row.insert("suite_name".to_string(), json!(&report.suite_name));
-            row.insert("suite_path".to_string(), json!(suite_path));
+            row.insert("suite_path".to_string(), json!(context.suite_path));
+            row.insert("suite_hash".to_string(), json!(context.suite_hash));
             row.insert("mode".to_string(), json!(report.mode));
             row.insert("case_id".to_string(), json!(&case.id));
             row.insert("assertion_name".to_string(), json!(&assertion.name));
@@ -1975,7 +2378,7 @@ fn write_eval_telemetry(
                 "grade_mode".to_string(),
                 json!(telemetry_grade_mode(report.mode)),
             );
-            row.insert("duration_ms".to_string(), json!(duration_ms));
+            row.insert("duration_ms".to_string(), json!(context.duration_ms));
             row.insert("output_dir".to_string(), json!(&report.output_dir));
             if let Some(manifest_hash) = manifest_hash.as_ref() {
                 row.insert("manifest_hash".to_string(), json!(manifest_hash));
@@ -1983,7 +2386,7 @@ fn write_eval_telemetry(
             if let Some(git_sha) = git_sha.as_ref() {
                 row.insert("git_sha".to_string(), json!(git_sha));
             }
-            if let Some(agent) = agent {
+            if let Some(agent) = context.agent {
                 row.insert("provider".to_string(), json!(agent.provider));
                 row.insert(
                     "provider_command_preset".to_string(),
@@ -2022,7 +2425,7 @@ fn write_eval_telemetry(
     }
     drop(file);
 
-    if let Some(max_rows) = retention {
+    if let Some(max_rows) = context.retention {
         apply_telemetry_retention(&telemetry_path, max_rows)?;
     }
     Ok(())
@@ -2439,29 +2842,46 @@ impl AgentExpected {
 }
 
 fn load_suite(path: &str) -> crate::error::Result<EvalSuite> {
-    let raw = fs::read_to_string(path).map_err(|error| {
+    load_suite_with_hash(path).map(|(suite, _hash)| suite)
+}
+
+fn load_suite_with_hash(path: &str) -> crate::error::Result<(EvalSuite, String)> {
+    let raw = fs::read(path).map_err(|error| {
         DbtNovaError::InvalidParams(format!("failed to read eval suite '{path}': {error}"))
+    })?;
+    let suite_hash = blake3::hash(&raw).to_hex().to_string();
+    let raw = std::str::from_utf8(&raw).map_err(|error| {
+        DbtNovaError::InvalidParams(format!(
+            "failed to read eval suite '{path}' as UTF-8: {error}"
+        ))
     })?;
     let suite: EvalSuite = if Path::new(path)
         .extension()
         .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
     {
-        serde_json::from_str(&raw).map_err(|error| {
+        serde_json::from_str(raw).map_err(|error| {
             DbtNovaError::InvalidParams(format!("failed to parse eval suite JSON: {error}"))
         })?
     } else {
-        serde_yaml::from_str(&raw).map_err(|error| {
+        serde_yaml::from_str(raw).map_err(|error| {
             DbtNovaError::InvalidParams(format!("failed to parse eval suite YAML: {error}"))
         })?
     };
     validate_suite(&suite)?;
-    Ok(suite)
+    Ok((suite, suite_hash))
 }
 
 fn validate_suite(suite: &EvalSuite) -> crate::error::Result<()> {
     if suite.version == 0 {
         return Err(DbtNovaError::InvalidParams(
             "eval suite version must be greater than zero".to_string(),
+        ));
+    }
+    if let Some(gate) = suite.gate
+        && !(0.0..=1.0).contains(&gate.threshold)
+    {
+        return Err(DbtNovaError::InvalidParams(
+            "eval suite gate.threshold must be between 0.0 and 1.0".to_string(),
         ));
     }
     validate_case_ids(suite.cases.iter().map(|case| case.id.as_str()), "cases")?;

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -2,15 +2,18 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write as IoWrite};
 use std::path::{Path, PathBuf};
+use std::process::Command as StdCommand;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
 
 use crate::cli::args::{
-    EvalAgentRunArgs, EvalInitArgs, EvalRunArgs, EvalValidateArgs, ManifestLoadArgs,
+    EvalAgentRunArgs, EvalHistoryArgs, EvalInitArgs, EvalRunArgs, EvalValidateArgs,
+    ManifestLoadArgs,
 };
 use crate::cli::manifest::{build_manifest_load_config, execute_manifest_load};
 use crate::cli::output::{CliEnvelope, error_envelope};
@@ -21,6 +24,7 @@ use crate::manifest::ManifestSearch;
 const DEFAULT_TOP_K: usize = 5;
 const DEFAULT_FAIL_UNDER: f64 = 1.0;
 const MAX_SAFE_PATH_SEGMENT_CHARS: usize = 120;
+const DEFAULT_TELEMETRY_DIR: &str = ".nova/eval-runs/telemetry";
 
 mod provider;
 
@@ -240,6 +244,8 @@ struct EvalCaseReport {
     assertions: Vec<AssertionResult>,
     #[serde(skip_serializing_if = "Option::is_none")]
     artifacts: Option<AgentArtifacts>,
+    #[serde(skip)]
+    telemetry: Option<EvalCaseTelemetry>,
 }
 
 #[derive(Debug, Serialize)]
@@ -256,6 +262,22 @@ struct AgentArtifacts {
     stdout: String,
     stderr: String,
     tool_trace: String,
+}
+
+#[derive(Debug, Clone)]
+struct EvalCaseTelemetry {
+    tool_call_count: usize,
+    distinct_tool_count: usize,
+    total_response_bytes: Option<u64>,
+    input_tokens: Option<u64>,
+    output_tokens: Option<u64>,
+    total_tokens: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AgentTelemetryContext<'a> {
+    provider: &'a str,
+    provider_command_preset: &'a str,
 }
 
 /// Writes a starter eval suite.
@@ -335,6 +357,40 @@ pub fn run_validate_command(args: &EvalValidateArgs) -> DispatchResult {
     Ok(())
 }
 
+/// Prints filtered JSONL eval telemetry history.
+///
+/// # Errors
+/// Returns an error when `--since` is invalid or existing telemetry cannot be read.
+pub fn run_history_command(args: &EvalHistoryArgs) -> DispatchResult {
+    let since_boundary = validate_since_date(&args.since)?;
+    let path = telemetry_path_for_suite(&args.suite);
+    if !path.exists() {
+        return Ok(());
+    }
+    let file = fs::File::open(&path).map_err(|error| server_error(error.to_string()))?;
+    let reader = BufReader::new(file);
+    for (index, line) in reader.lines().enumerate() {
+        let line = line.map_err(|error| server_error(error.to_string()))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let row = serde_json::from_str::<JsonValue>(trimmed).map_err(|error| {
+            DbtNovaError::InvalidParams(format!(
+                "failed to parse telemetry line {} in '{}': {error}",
+                index + 1,
+                path.display()
+            ))
+        })?;
+        if telemetry_row_matches_since(&row, &since_boundary) {
+            let out =
+                serde_json::to_string(&row).map_err(|error| server_error(error.to_string()))?;
+            println!("{out}");
+        }
+    }
+    Ok(())
+}
+
 /// Runs deterministic Nova bridge assertions against a manifest.
 ///
 /// # Errors
@@ -343,6 +399,7 @@ pub async fn run_eval_command(args: &EvalRunArgs) -> DispatchResult {
     let started = Instant::now();
     let suite = load_suite(&args.suite)?;
     validate_fail_under(args.fail_under)?;
+    validate_telemetry_retention(args.telemetry_retention)?;
     if suite.cases.is_empty() {
         return Err(
             DbtNovaError::InvalidParams("eval suite contains no bridge cases".to_string()).into(),
@@ -374,12 +431,19 @@ pub async fn run_eval_command(args: &EvalRunArgs) -> DispatchResult {
         cases,
     );
     write_report_artifacts(&output_dir, &report, &args.suite)?;
-    finish_report(
-        "eval run",
-        &report,
-        args.json,
-        started.elapsed().as_millis(),
-    )
+    let elapsed = started.elapsed();
+    let elapsed_ms = elapsed.as_millis();
+    if args.telemetry {
+        write_eval_telemetry(
+            &report,
+            &args.suite,
+            Some(&load_result.search.manifest_hash),
+            elapsed_ms_to_u64(elapsed),
+            args.telemetry_retention,
+            None,
+        )?;
+    }
+    finish_report("eval run", &report, args.json, elapsed_ms)
 }
 
 /// Runs agent-provider evals and scores the tool-use trace.
@@ -390,6 +454,7 @@ pub async fn run_agent_eval_command(args: &EvalAgentRunArgs) -> DispatchResult {
     let started = Instant::now();
     let suite = load_suite(&args.suite)?;
     validate_fail_under(args.fail_under)?;
+    validate_telemetry_retention(args.telemetry_retention)?;
     if suite.agent_cases.is_empty() {
         return Err(
             DbtNovaError::InvalidParams("eval suite contains no agent_cases".to_string()).into(),
@@ -412,12 +477,22 @@ pub async fn run_agent_eval_command(args: &EvalAgentRunArgs) -> DispatchResult {
         cases,
     );
     write_report_artifacts(&output_dir, &report, &args.suite)?;
-    finish_report(
-        "eval agent run",
-        &report,
-        args.json,
-        started.elapsed().as_millis(),
-    )
+    let elapsed = started.elapsed();
+    let elapsed_ms = elapsed.as_millis();
+    if args.telemetry {
+        write_eval_telemetry(
+            &report,
+            &args.suite,
+            None,
+            elapsed_ms_to_u64(elapsed),
+            args.telemetry_retention,
+            Some(AgentTelemetryContext {
+                provider: &args.provider,
+                provider_command_preset: agent_provider_command_preset(args),
+            }),
+        )?;
+    }
+    finish_report("eval agent run", &report, args.json, elapsed_ms)
 }
 
 async fn evaluate_bridge_case(
@@ -759,6 +834,7 @@ async fn run_agent_case(
         &trace.rows,
         &final_answer_text,
     ));
+    let telemetry = eval_case_telemetry_from_trace(&trace.rows);
     EvalCaseReport::new(
         case.id.clone(),
         Some(case.task.clone()),
@@ -769,6 +845,7 @@ async fn run_agent_case(
             tool_trace: trace_path.display().to_string(),
         }),
     )
+    .with_telemetry(telemetry)
 }
 
 fn score_agent_expectations(
@@ -1852,6 +1929,326 @@ fn write_report_artifacts(
     Ok(())
 }
 
+fn write_eval_telemetry(
+    report: &EvalReport,
+    suite_path: &str,
+    manifest_hash: Option<&str>,
+    duration_ms: u64,
+    retention: Option<usize>,
+    agent: Option<AgentTelemetryContext<'_>>,
+) -> DispatchResult {
+    let telemetry_path = telemetry_path_for_suite(&report.suite_name);
+    if let Some(parent) = telemetry_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| server_error(error.to_string()))?;
+    }
+    let timestamp_ms = timestamp_millis();
+    let timestamp = format_utc_timestamp_millis(timestamp_ms);
+    let git_sha = current_git_sha();
+    let manifest_hash = manifest_hash
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&telemetry_path)
+        .map_err(|error| server_error(error.to_string()))?;
+    for case in &report.cases {
+        for assertion in &case.assertions {
+            let mut row = serde_json::Map::new();
+            row.insert("timestamp".to_string(), json!(&timestamp));
+            row.insert("timestamp_ms".to_string(), json!(timestamp_ms));
+            row.insert("suite_name".to_string(), json!(&report.suite_name));
+            row.insert("suite_path".to_string(), json!(suite_path));
+            row.insert("mode".to_string(), json!(report.mode));
+            row.insert("case_id".to_string(), json!(&case.id));
+            row.insert("assertion_name".to_string(), json!(&assertion.name));
+            row.insert(
+                "assertion_type".to_string(),
+                json!(assertion_type(&assertion.name)),
+            );
+            row.insert("status".to_string(), json!(assertion.status));
+            row.insert(
+                "grade_mode".to_string(),
+                json!(telemetry_grade_mode(report.mode)),
+            );
+            row.insert("duration_ms".to_string(), json!(duration_ms));
+            row.insert("output_dir".to_string(), json!(&report.output_dir));
+            if let Some(manifest_hash) = manifest_hash.as_ref() {
+                row.insert("manifest_hash".to_string(), json!(manifest_hash));
+            }
+            if let Some(git_sha) = git_sha.as_ref() {
+                row.insert("git_sha".to_string(), json!(git_sha));
+            }
+            if let Some(agent) = agent {
+                row.insert("provider".to_string(), json!(agent.provider));
+                row.insert(
+                    "provider_command_preset".to_string(),
+                    json!(agent.provider_command_preset),
+                );
+                if let Some(telemetry) = case.telemetry.as_ref() {
+                    row.insert(
+                        "tool_call_count".to_string(),
+                        json!(telemetry.tool_call_count),
+                    );
+                    row.insert(
+                        "distinct_tool_count".to_string(),
+                        json!(telemetry.distinct_tool_count),
+                    );
+                    if let Some(value) = telemetry.total_response_bytes {
+                        row.insert("total_response_bytes".to_string(), json!(value));
+                    }
+                    if let Some(value) = telemetry.input_tokens {
+                        row.insert("input_tokens".to_string(), json!(value));
+                    }
+                    if let Some(value) = telemetry.output_tokens {
+                        row.insert("output_tokens".to_string(), json!(value));
+                    }
+                    if let Some(value) = telemetry.total_tokens {
+                        row.insert("total_tokens".to_string(), json!(value));
+                    }
+                }
+            }
+            let line = serde_json::to_string(&JsonValue::Object(row))
+                .map_err(|error| server_error(error.to_string()))?;
+            file.write_all(line.as_bytes())
+                .map_err(|error| server_error(error.to_string()))?;
+            file.write_all(b"\n")
+                .map_err(|error| server_error(error.to_string()))?;
+        }
+    }
+    drop(file);
+
+    if let Some(max_rows) = retention {
+        apply_telemetry_retention(&telemetry_path, max_rows)?;
+    }
+    Ok(())
+}
+
+fn apply_telemetry_retention(path: &Path, max_rows: usize) -> DispatchResult {
+    let raw = fs::read_to_string(path).map_err(|error| server_error(error.to_string()))?;
+    let rows: Vec<&str> = raw.lines().filter(|line| !line.trim().is_empty()).collect();
+    if rows.len() <= max_rows {
+        return Ok(());
+    }
+    let keep_from = rows.len().saturating_sub(max_rows);
+    let mut out = rows[keep_from..].join("\n");
+    out.push('\n');
+    fs::write(path, out).map_err(|error| server_error(error.to_string()))?;
+    Ok(())
+}
+
+fn telemetry_path_for_suite(suite_name: &str) -> PathBuf {
+    PathBuf::from(DEFAULT_TELEMETRY_DIR).join(format!(
+        "{}-{:016x}.jsonl",
+        safe_path_segment(suite_name),
+        stable_telemetry_hash(suite_name)
+    ))
+}
+
+fn stable_telemetry_hash(value: &str) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in value.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0001_0000_01b3);
+    }
+    hash
+}
+
+fn telemetry_row_matches_since(row: &JsonValue, since_boundary: &str) -> bool {
+    row.get("timestamp")
+        .and_then(JsonValue::as_str)
+        .is_some_and(|timestamp| timestamp >= since_boundary)
+}
+
+fn validate_since_date(value: &str) -> crate::error::Result<String> {
+    let valid_shape = value.len() == 10
+        && value.as_bytes()[4] == b'-'
+        && value.as_bytes()[7] == b'-'
+        && value
+            .chars()
+            .enumerate()
+            .all(|(index, ch)| matches!(index, 4 | 7) || ch.is_ascii_digit());
+    if !valid_shape {
+        return Err(DbtNovaError::InvalidParams(
+            "--since must use YYYY-MM-DD".to_string(),
+        ));
+    }
+    let year = value[0..4]
+        .parse::<i32>()
+        .map_err(|_| DbtNovaError::InvalidParams("--since must use YYYY-MM-DD".to_string()))?;
+    let month = value[5..7]
+        .parse::<u32>()
+        .map_err(|_| DbtNovaError::InvalidParams("--since must use YYYY-MM-DD".to_string()))?;
+    let day = value[8..10]
+        .parse::<u32>()
+        .map_err(|_| DbtNovaError::InvalidParams("--since must use YYYY-MM-DD".to_string()))?;
+    if !(1..=12).contains(&month) || day == 0 || day > days_in_month(year, month) {
+        return Err(DbtNovaError::InvalidParams(
+            "--since must use a valid YYYY-MM-DD date".to_string(),
+        ));
+    }
+    Ok(format!("{value}T00:00:00.000Z"))
+}
+
+fn validate_telemetry_retention(value: Option<usize>) -> crate::error::Result<()> {
+    if value == Some(0) {
+        return Err(DbtNovaError::InvalidParams(
+            "--telemetry-retention must be greater than zero".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn telemetry_grade_mode(mode: &str) -> &'static str {
+    match mode {
+        "agent" => "provider_trace",
+        _ => "deterministic",
+    }
+}
+
+fn assertion_type(name: &str) -> &str {
+    name.split_once(':').map_or(name, |(prefix, _)| prefix)
+}
+
+fn agent_provider_command_preset(args: &EvalAgentRunArgs) -> &str {
+    if args.provider_command.is_some() || args.provider_args_json.is_some() {
+        "custom"
+    } else {
+        args.provider.as_str()
+    }
+}
+
+fn eval_case_telemetry_from_trace(trace: &[JsonValue]) -> EvalCaseTelemetry {
+    let mut distinct_tools = BTreeSet::new();
+    let mut response_bytes_seen = false;
+    let mut total_response_bytes = 0_u64;
+    for row in trace {
+        if let Some(tool) = row.get("tool").and_then(JsonValue::as_str) {
+            distinct_tools.insert(tool.to_string());
+        }
+        if let Some(bytes) = row.get("response_bytes").and_then(JsonValue::as_u64) {
+            response_bytes_seen = true;
+            total_response_bytes = total_response_bytes.saturating_add(bytes);
+        }
+    }
+    EvalCaseTelemetry {
+        tool_call_count: trace.len(),
+        distinct_tool_count: distinct_tools.len(),
+        total_response_bytes: response_bytes_seen.then_some(total_response_bytes),
+        input_tokens: sum_first_available_u64(
+            trace,
+            &[
+                &["input_tokens"],
+                &["usage", "input_tokens"],
+                &["usage", "prompt_tokens"],
+            ],
+        ),
+        output_tokens: sum_first_available_u64(
+            trace,
+            &[
+                &["output_tokens"],
+                &["usage", "output_tokens"],
+                &["usage", "completion_tokens"],
+            ],
+        ),
+        total_tokens: sum_first_available_u64(
+            trace,
+            &[&["total_tokens"], &["usage", "total_tokens"]],
+        ),
+    }
+}
+
+fn sum_first_available_u64(trace: &[JsonValue], paths: &[&[&str]]) -> Option<u64> {
+    let mut seen = false;
+    let mut total = 0_u64;
+    for row in trace {
+        for path in paths {
+            if let Some(value) = json_path_u64(row, path) {
+                seen = true;
+                total = total.saturating_add(value);
+                break;
+            }
+        }
+    }
+    seen.then_some(total)
+}
+
+fn json_path_u64(value: &JsonValue, path: &[&str]) -> Option<u64> {
+    let mut cursor = value;
+    for part in path {
+        cursor = cursor.get(*part)?;
+    }
+    cursor.as_u64()
+}
+
+fn current_git_sha() -> Option<String> {
+    let output = StdCommand::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!sha.is_empty()).then_some(sha)
+}
+
+fn timestamp_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| {
+            u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+        })
+}
+
+fn format_utc_timestamp_millis(timestamp_ms: u64) -> String {
+    let secs = timestamp_ms / 1000;
+    let millis = timestamp_ms % 1000;
+    let days = i64::try_from(secs / 86_400).unwrap_or(i64::MAX);
+    let seconds_of_day = secs % 86_400;
+    let (year, month, day) = civil_from_days(days);
+    let hour = seconds_of_day / 3_600;
+    let minute = (seconds_of_day % 3_600) / 60;
+    let second = seconds_of_day % 60;
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z")
+}
+
+fn civil_from_days(days_since_epoch: i64) -> (i32, u32, u32) {
+    let z = days_since_epoch.saturating_add(719_468);
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let mut year = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = mp + if mp < 10 { 3 } else { -9 };
+    if month <= 2 {
+        year += 1;
+    }
+    (
+        i32::try_from(year).unwrap_or(i32::MAX),
+        u32::try_from(month).unwrap_or(12),
+        u32::try_from(day).unwrap_or(31),
+    )
+}
+
+fn days_in_month(year: i32, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+fn is_leap_year(year: i32) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
 fn render_tsv(report: &EvalReport) -> String {
     let mut out = String::from("case_id\tassertion\tstatus\tmessage\n");
     for case in &report.cases {
@@ -1968,7 +2365,13 @@ impl EvalCaseReport {
             error_count,
             assertions,
             artifacts,
+            telemetry: None,
         }
+    }
+
+    fn with_telemetry(mut self, telemetry: EvalCaseTelemetry) -> Self {
+        self.telemetry = Some(telemetry);
+        self
     }
 }
 

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -7,10 +7,12 @@ use tempfile::{NamedTempFile, TempDir};
 use super::{
     AgentCalledWith, AgentEntityRank, AgentExpected, AgentOrder, AssertionResult, EvalCaseReport,
     EvalDefaults, EvalRunArgs, EvalSuite, EvalValidateArgs, FinalAnswerExpected,
-    contains_rank_assertion, context_contains_assertion, context_field_equals_assertion,
+    apply_telemetry_retention, contains_rank_assertion, context_contains_assertion,
+    context_field_equals_assertion, eval_case_telemetry_from_trace, format_utc_timestamp_millis,
     json_has_field_path, read_tool_trace, recipe_rank_assertion, run_eval_command,
     run_validate_command, safe_path_segment, score_agent_expectations, selected_agent_cases,
-    selected_bridge_cases, tool_response_budget_assertion, tool_success_assertion, validate_suite,
+    selected_bridge_cases, telemetry_path_for_suite, telemetry_row_matches_since,
+    tool_response_budget_assertion, tool_success_assertion, validate_since_date, validate_suite,
 };
 
 #[test]
@@ -283,6 +285,110 @@ fn read_tool_trace_reports_parse_errors() {
     assert!(!trace.missing);
     assert_eq!(trace.rows[0]["tool_call_index"], json!(0));
     assert_eq!(trace.rows[1]["tool_call_index"], json!(1));
+}
+
+#[test]
+fn telemetry_stats_summarize_trace_without_params() {
+    let trace = vec![
+        json!({
+            "tool": "search",
+            "response_bytes": 40,
+            "params_summary": {"query": "revenue"},
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5}
+        }),
+        json!({
+            "tool": "get_context",
+            "response_bytes": 60,
+            "usage": {"input_tokens": 4, "output_tokens": 3, "total_tokens": 7}
+        }),
+    ];
+
+    let telemetry = eval_case_telemetry_from_trace(&trace);
+
+    assert_eq!(telemetry.tool_call_count, 2);
+    assert_eq!(telemetry.distinct_tool_count, 2);
+    assert_eq!(telemetry.total_response_bytes, Some(100));
+    assert_eq!(telemetry.input_tokens, Some(14));
+    assert_eq!(telemetry.output_tokens, Some(8));
+    assert_eq!(telemetry.total_tokens, Some(7));
+}
+
+#[test]
+fn telemetry_history_since_filters_iso_timestamps() {
+    let since = validate_since_date("2026-06-01").expect("valid date");
+    assert!(telemetry_row_matches_since(
+        &json!({"timestamp": "2026-06-01T00:00:00.000Z"}),
+        &since
+    ));
+    assert!(telemetry_row_matches_since(
+        &json!({"timestamp": "2026-06-02T12:00:00.000Z"}),
+        &since
+    ));
+    assert!(!telemetry_row_matches_since(
+        &json!({"timestamp": "2026-05-31T23:59:59.999Z"}),
+        &since
+    ));
+    assert!(validate_since_date("2026-02-29").is_err());
+}
+
+#[test]
+fn telemetry_retention_keeps_newest_valid_jsonl_rows() {
+    let file = NamedTempFile::new().expect("temp file");
+    std::fs::write(
+        file.path(),
+        "{\"case_id\":\"one\"}\n{\"case_id\":\"two\"}\n{\"case_id\":\"three\"}\n",
+    )
+    .expect("write telemetry");
+
+    let result = apply_telemetry_retention(file.path(), 2);
+    assert!(
+        result.is_ok(),
+        "retention failed: {}",
+        result
+            .err()
+            .map_or_else(String::new, |error| error.error.to_string())
+    );
+
+    let raw = std::fs::read_to_string(file.path()).expect("read telemetry");
+    let lines: Vec<&str> = raw.lines().collect();
+    assert_eq!(lines.len(), 2);
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(lines[0]).unwrap()["case_id"],
+        "two"
+    );
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(lines[1]).unwrap()["case_id"],
+        "three"
+    );
+}
+
+#[test]
+fn telemetry_timestamp_format_is_utc_rfc3339_millis() {
+    assert_eq!(
+        format_utc_timestamp_millis(1_767_225_600_123),
+        "2026-01-01T00:00:00.123Z"
+    );
+}
+
+#[test]
+fn telemetry_paths_include_hash_to_avoid_sanitized_name_collisions() {
+    let spaced = telemetry_path_for_suite("sales smoke");
+    let slashed = telemetry_path_for_suite("sales/smoke");
+    let dashed = telemetry_path_for_suite("sales-smoke");
+
+    assert_ne!(spaced, slashed);
+    assert_ne!(spaced, dashed);
+    assert_ne!(slashed, dashed);
+    let file_name = dashed
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("telemetry file name");
+    assert!(file_name.starts_with("sales-smoke-"));
+    assert!(
+        dashed
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("jsonl"))
+    );
 }
 
 #[test]

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -7,13 +7,13 @@ use tempfile::{NamedTempFile, TempDir};
 use super::{
     AgentCalledWith, AgentEntityRank, AgentExpected, AgentOrder, AssertionResult, EvalCaseReport,
     EvalDefaults, EvalRunArgs, EvalSuite, EvalValidateArgs, FinalAnswerExpected,
-    apply_telemetry_retention, contains_rank_assertion, context_contains_assertion,
-    context_field_equals_assertion, eval_case_telemetry_from_trace, format_utc_timestamp_millis,
-    json_has_field_path, read_tool_trace, recipe_rank_assertion, run_eval_command,
-    run_validate_command, safe_path_segment, score_agent_expectations, selected_agent_cases,
-    selected_bridge_cases, telemetry_path_for_suite, telemetry_row_matches_since,
-    tool_response_budget_assertion, tool_success_assertion, validate_since_date, validate_suite,
-    validate_telemetry_suite_name,
+    apply_telemetry_retention, build_eval_gate_report, contains_rank_assertion,
+    context_contains_assertion, context_field_equals_assertion, eval_case_telemetry_from_trace,
+    format_utc_timestamp_millis, json_has_field_path, read_tool_trace, recipe_rank_assertion,
+    run_eval_command, run_validate_command, safe_path_segment, score_agent_expectations,
+    selected_agent_cases, selected_bridge_cases, suite_file_hash, telemetry_path_for_suite,
+    telemetry_row_matches_since, tool_response_budget_assertion, tool_success_assertion,
+    validate_since_date, validate_suite, validate_telemetry_suite_name,
 };
 
 #[test]
@@ -397,6 +397,7 @@ fn telemetry_requires_named_suite() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        gate: None,
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
         agent_cases: Vec::new(),
@@ -409,10 +410,368 @@ fn telemetry_requires_named_suite() {
 }
 
 #[test]
+fn eval_gate_allows_latest_run_above_threshold() {
+    let suite = gate_suite_file(Some(0.5));
+    let suite_path = suite.path().display().to_string();
+    let rows = vec![
+        telemetry_row(
+            "gated",
+            &suite_path,
+            "old",
+            1,
+            "case_old",
+            "assertion",
+            "fail",
+        ),
+        telemetry_row_with_assertion_count(
+            "gated",
+            &suite_path,
+            "new",
+            2,
+            "case_a",
+            "assertion_a",
+            "pass",
+            2,
+        ),
+        telemetry_row_with_assertion_count(
+            "gated",
+            &suite_path,
+            "new",
+            2,
+            "case_b",
+            "assertion_b",
+            "pass",
+            2,
+        ),
+    ];
+
+    let report = build_eval_gate_report("gated", &rows).expect("gate report");
+
+    assert!(report.allowed);
+    assert!(!report.blocked);
+    assert!(report.gate_configured);
+    assert_eq!(report.threshold, Some(0.5));
+    assert_eq!(report.total_evals, 2);
+    assert_eq!(report.failed_evals, 0);
+    assert!((report.pass_rate - 1.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn eval_gate_blocks_latest_run_below_threshold_with_failed_ids() {
+    let suite = gate_suite_file(Some(1.0));
+    let suite_path = suite.path().display().to_string();
+    let rows = vec![
+        telemetry_row(
+            "gated",
+            &suite_path,
+            "old",
+            1,
+            "case_old",
+            "assertion",
+            "pass",
+        ),
+        telemetry_row_with_assertion_count(
+            "gated",
+            &suite_path,
+            "new",
+            2,
+            "case_a",
+            "assertion_a",
+            "pass",
+            2,
+        ),
+        telemetry_row_with_assertion_count(
+            "gated",
+            &suite_path,
+            "new",
+            2,
+            "case_b",
+            "assertion_b",
+            "fail",
+            2,
+        ),
+    ];
+
+    let report = build_eval_gate_report("gated", &rows).expect("gate report");
+
+    assert!(!report.allowed);
+    assert!(report.blocked);
+    assert!((report.pass_rate - 0.5).abs() < f64::EPSILON);
+    assert_eq!(report.failed_evals, 1);
+    assert_eq!(report.failed_eval_ids, vec!["case_b::assertion_b"]);
+    assert_eq!(report.failed_case_ids, vec!["case_b"]);
+}
+
+#[test]
+fn eval_gate_uses_run_id_not_reused_output_dir() {
+    let suite = gate_suite_file(Some(1.0));
+    let suite_path = suite.path().display().to_string();
+    let rows = vec![
+        telemetry_row_with_run_id(
+            "gated",
+            &suite_path,
+            "stable-output",
+            1,
+            "case_old",
+            "assertion_old",
+            "pass",
+            "run-old",
+        ),
+        telemetry_row_with_run_id(
+            "gated",
+            &suite_path,
+            "stable-output",
+            2,
+            "case_new",
+            "assertion_new",
+            "fail",
+            "run-new",
+        ),
+    ];
+
+    let report = build_eval_gate_report("gated", &rows).expect("gate report");
+
+    assert!(!report.allowed);
+    assert_eq!(report.total_evals, 1);
+    assert_eq!(report.failed_eval_ids, vec!["case_new::assertion_new"]);
+}
+
+#[test]
+fn eval_gate_blocks_partial_latest_run_after_retention() {
+    let suite = gate_suite_file(Some(1.0));
+    let suite_path = suite.path().display().to_string();
+    let rows = vec![
+        telemetry_row(
+            "gated",
+            &suite_path,
+            "old",
+            1,
+            "case_old",
+            "assertion_old",
+            "fail",
+        ),
+        telemetry_row_with_assertion_count(
+            "gated",
+            &suite_path,
+            "new",
+            2,
+            "case_new",
+            "assertion_new",
+            "pass",
+            2,
+        ),
+    ];
+
+    let report = build_eval_gate_report("gated", &rows).expect("gate report");
+
+    assert!(!report.allowed);
+    assert!(report.blocked);
+    assert_eq!(report.total_evals, 1);
+    assert!(report.message.contains("found 1 of 2"));
+}
+
+#[test]
+fn eval_gate_blocks_filtered_latest_run_even_when_selected_case_passed() {
+    let suite = gate_suite_file(Some(1.0));
+    let suite_path = suite.path().display().to_string();
+    let rows = vec![telemetry_row_with_case_counts(
+        "gated",
+        &suite_path,
+        "latest",
+        1,
+        "case_a",
+        "assertion_a",
+        "pass",
+        1,
+        1,
+        2,
+    )];
+
+    let report = build_eval_gate_report("gated", &rows).expect("gate report");
+
+    assert!(!report.allowed);
+    assert!(report.blocked);
+    assert_eq!(report.total_evals, 1);
+    assert!((report.pass_rate - 1.0).abs() < f64::EPSILON);
+    assert!(report.message.contains("covers 1 of 2 suite cases"));
+}
+
+#[test]
+fn eval_gate_blocks_latest_run_from_changed_suite_file() {
+    let suite = gate_suite_file(Some(1.0));
+    let suite_path = suite.path().display().to_string();
+    let rows = vec![telemetry_row(
+        "gated",
+        &suite_path,
+        "latest",
+        1,
+        "case_a",
+        "assertion_a",
+        "pass",
+    )];
+    std::fs::write(
+        suite.path(),
+        "version: 1\nname: gated\ngate:\n  threshold: 1.0\ncases: []\nagent_cases: []\n# changed\n",
+    )
+    .expect("change suite");
+
+    let report = build_eval_gate_report("gated", &rows).expect("gate report");
+
+    assert!(!report.allowed);
+    assert!(report.blocked);
+    assert!(report.message.contains("different suite file version"));
+}
+
+#[test]
+fn eval_gate_blocks_legacy_telemetry_without_suite_hash() {
+    let suite = gate_suite_file(Some(1.0));
+    let suite_path = suite.path().display().to_string();
+    let mut row = telemetry_row(
+        "gated",
+        &suite_path,
+        "latest",
+        1,
+        "case_a",
+        "assertion_a",
+        "pass",
+    );
+    row.as_object_mut()
+        .expect("telemetry object")
+        .remove("suite_hash");
+    let rows = vec![row];
+
+    let report = build_eval_gate_report("gated", &rows).expect("gate report");
+
+    assert!(!report.allowed);
+    assert!(report.blocked);
+    assert!(report.message.contains("suite_hash"));
+}
+
+#[test]
+fn eval_gate_blocks_legacy_telemetry_without_run_assertion_count() {
+    let suite = gate_suite_file(Some(1.0));
+    let suite_path = suite.path().display().to_string();
+    let mut row = telemetry_row(
+        "gated",
+        &suite_path,
+        "latest",
+        1,
+        "case_a",
+        "assertion_a",
+        "pass",
+    );
+    row.as_object_mut()
+        .expect("telemetry object")
+        .remove("run_assertion_count");
+    let rows = vec![row];
+
+    let report = build_eval_gate_report("gated", &rows).expect("gate report");
+
+    assert!(!report.allowed);
+    assert!(report.blocked);
+    assert!(report.message.contains("run_assertion_count"));
+}
+
+#[test]
+fn eval_gate_missing_config_allows_with_explicit_signal() {
+    let suite = gate_suite_file(None);
+    let suite_path = suite.path().display().to_string();
+    let rows = vec![telemetry_row(
+        "ungated",
+        &suite_path,
+        "latest",
+        1,
+        "case_a",
+        "assertion_a",
+        "fail",
+    )];
+
+    let report = build_eval_gate_report("ungated", &rows).expect("gate report");
+
+    assert!(report.allowed);
+    assert!(!report.blocked);
+    assert!(!report.gate_configured);
+    assert_eq!(report.threshold, None);
+    assert!(report.message.contains("allowed by default"));
+}
+
+#[test]
+fn eval_gate_missing_config_allows_legacy_telemetry_without_run_assertion_count() {
+    let suite = gate_suite_file(None);
+    let suite_path = suite.path().display().to_string();
+    let mut row = telemetry_row(
+        "ungated",
+        &suite_path,
+        "latest",
+        1,
+        "case_a",
+        "assertion_a",
+        "pass",
+    );
+    row.as_object_mut()
+        .expect("telemetry object")
+        .remove("run_assertion_count");
+    let rows = vec![row];
+
+    let report = build_eval_gate_report("ungated", &rows).expect("gate report");
+
+    assert!(report.allowed);
+    assert!(!report.blocked);
+    assert!(!report.gate_configured);
+    assert!(report.message.contains("allowed by default"));
+}
+
+#[test]
+fn eval_gate_missing_suite_config_blocks_with_actionable_message() {
+    let rows = vec![telemetry_row(
+        "gated",
+        "target/does-not-exist/gated.yml",
+        "latest",
+        1,
+        "case_a",
+        "assertion_a",
+        "pass",
+    )];
+
+    let report = build_eval_gate_report("gated", &rows).expect("gate report");
+
+    assert!(!report.allowed);
+    assert!(report.blocked);
+    assert!(!report.gate_configured);
+    assert!(report.message.contains("could not be read"));
+}
+
+#[test]
+fn eval_gate_missing_telemetry_returns_actionable_message() {
+    let report = build_eval_gate_report("missing", &[]).expect("gate report");
+
+    assert!(!report.allowed);
+    assert!(report.blocked);
+    assert!(!report.gate_configured);
+    assert_eq!(report.total_evals, 0);
+    assert!(report.message.contains("--telemetry"));
+}
+
+#[test]
+fn validate_suite_rejects_invalid_gate_threshold() {
+    let suite = EvalSuite {
+        version: 1,
+        name: None,
+        gate: Some(super::EvalGateConfig { threshold: 1.1 }),
+        defaults: EvalDefaults::default(),
+        cases: Vec::new(),
+        agent_cases: Vec::new(),
+    };
+    let error = validate_suite(&suite).expect_err("invalid gate threshold should fail");
+    assert!(error.to_string().contains("gate.threshold"));
+}
+
+#[test]
 fn validate_suite_rejects_duplicate_agent_case_ids() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        gate: None,
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
         agent_cases: vec![
@@ -437,6 +796,7 @@ fn validate_suite_rejects_duplicate_artifact_segments() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        gate: None,
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
         agent_cases: vec![
@@ -461,6 +821,7 @@ fn validate_suite_rejects_case_insensitive_artifact_segment_collisions() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        gate: None,
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
         agent_cases: vec![
@@ -485,6 +846,7 @@ fn validate_suite_rejects_vacuous_search_columns_rank_assertion() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        gate: None,
         defaults: EvalDefaults::default(),
         cases: vec![super::EvalCase {
             id: "columns".to_string(),
@@ -508,6 +870,7 @@ fn validate_suite_rejects_unmatchable_called_with_param_values() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        gate: None,
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
         agent_cases: vec![super::AgentCase {
@@ -651,4 +1014,182 @@ fn fixture_manifest_path(name: &str) -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures")
         .join(name)
+}
+
+fn gate_suite_file(threshold: Option<f64>) -> NamedTempFile {
+    let suite = NamedTempFile::new().expect("suite file");
+    let gate = threshold.map_or_else(String::new, |threshold| {
+        format!("gate:\n  threshold: {threshold}\n")
+    });
+    std::fs::write(
+        suite.path(),
+        format!("version: 1\nname: gated\n{gate}cases: []\nagent_cases: []\n"),
+    )
+    .expect("write suite");
+    suite
+}
+
+fn telemetry_row(
+    suite_name: &str,
+    suite_path: &str,
+    output_dir: &str,
+    timestamp_ms: u64,
+    case_id: &str,
+    assertion_name: &str,
+    status: &str,
+) -> serde_json::Value {
+    let run_id = format!("run-{timestamp_ms}");
+    telemetry_row_with_run_id_and_count(
+        suite_name,
+        suite_path,
+        output_dir,
+        timestamp_ms,
+        case_id,
+        assertion_name,
+        status,
+        &run_id,
+        1,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn telemetry_row_with_run_id(
+    suite_name: &str,
+    suite_path: &str,
+    output_dir: &str,
+    timestamp_ms: u64,
+    case_id: &str,
+    assertion_name: &str,
+    status: &str,
+    run_id: &str,
+) -> serde_json::Value {
+    telemetry_row_with_run_id_and_count(
+        suite_name,
+        suite_path,
+        output_dir,
+        timestamp_ms,
+        case_id,
+        assertion_name,
+        status,
+        run_id,
+        1,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn telemetry_row_with_assertion_count(
+    suite_name: &str,
+    suite_path: &str,
+    output_dir: &str,
+    timestamp_ms: u64,
+    case_id: &str,
+    assertion_name: &str,
+    status: &str,
+    run_assertion_count: u64,
+) -> serde_json::Value {
+    let run_id = format!("run-{timestamp_ms}");
+    telemetry_row_with_run_id_and_count(
+        suite_name,
+        suite_path,
+        output_dir,
+        timestamp_ms,
+        case_id,
+        assertion_name,
+        status,
+        &run_id,
+        run_assertion_count,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn telemetry_row_with_run_id_and_count(
+    suite_name: &str,
+    suite_path: &str,
+    output_dir: &str,
+    timestamp_ms: u64,
+    case_id: &str,
+    assertion_name: &str,
+    status: &str,
+    run_id: &str,
+    run_assertion_count: u64,
+) -> serde_json::Value {
+    telemetry_row_with_run_id_and_counts(
+        suite_name,
+        suite_path,
+        output_dir,
+        timestamp_ms,
+        case_id,
+        assertion_name,
+        status,
+        run_id,
+        run_assertion_count,
+        1,
+        1,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn telemetry_row_with_case_counts(
+    suite_name: &str,
+    suite_path: &str,
+    output_dir: &str,
+    timestamp_ms: u64,
+    case_id: &str,
+    assertion_name: &str,
+    status: &str,
+    run_assertion_count: u64,
+    run_case_count: u64,
+    suite_case_count: u64,
+) -> serde_json::Value {
+    let run_id = format!("run-{timestamp_ms}");
+    telemetry_row_with_run_id_and_counts(
+        suite_name,
+        suite_path,
+        output_dir,
+        timestamp_ms,
+        case_id,
+        assertion_name,
+        status,
+        &run_id,
+        run_assertion_count,
+        run_case_count,
+        suite_case_count,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn telemetry_row_with_run_id_and_counts(
+    suite_name: &str,
+    suite_path: &str,
+    output_dir: &str,
+    timestamp_ms: u64,
+    case_id: &str,
+    assertion_name: &str,
+    status: &str,
+    run_id: &str,
+    run_assertion_count: u64,
+    run_case_count: u64,
+    suite_case_count: u64,
+) -> serde_json::Value {
+    let mut row = json!({
+        "timestamp": format_utc_timestamp_millis(timestamp_ms),
+        "timestamp_ms": timestamp_ms,
+        "run_id": run_id,
+        "run_case_count": run_case_count,
+        "suite_case_count": suite_case_count,
+        "run_assertion_count": run_assertion_count,
+        "suite_name": suite_name,
+        "suite_path": suite_path,
+        "mode": "bridge",
+        "case_id": case_id,
+        "assertion_name": assertion_name,
+        "status": status,
+        "output_dir": output_dir
+    });
+    if let Ok(hash) = suite_file_hash(suite_path)
+        && let Some(object) = row.as_object_mut()
+    {
+        object.insert("suite_hash".to_string(), json!(hash));
+    }
+    row
 }

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -13,6 +13,7 @@ use super::{
     run_validate_command, safe_path_segment, score_agent_expectations, selected_agent_cases,
     selected_bridge_cases, telemetry_path_for_suite, telemetry_row_matches_since,
     tool_response_budget_assertion, tool_success_assertion, validate_since_date, validate_suite,
+    validate_telemetry_suite_name,
 };
 
 #[test]
@@ -389,6 +390,22 @@ fn telemetry_paths_include_hash_to_avoid_sanitized_name_collisions() {
             .extension()
             .is_some_and(|ext| ext.eq_ignore_ascii_case("jsonl"))
     );
+}
+
+#[test]
+fn telemetry_requires_named_suite() {
+    let suite = EvalSuite {
+        version: 1,
+        name: None,
+        defaults: EvalDefaults::default(),
+        cases: Vec::new(),
+        agent_cases: Vec::new(),
+    };
+
+    assert!(validate_telemetry_suite_name(&suite, false).is_ok());
+    let error = validate_telemetry_suite_name(&suite, true)
+        .expect_err("telemetry should require suite name");
+    assert!(error.to_string().contains("non-empty name"));
 }
 
 #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -89,6 +89,7 @@ pub async fn dispatch(command: args::Command) -> DispatchResult {
                     eval_cmd::run_agent_eval_command(&run_args).await
                 }
             },
+            args::EvalCommand::Gate(gate_args) => eval_cmd::run_gate_command(&gate_args),
             args::EvalCommand::History(history_args) => {
                 eval_cmd::run_history_command(&history_args)
             }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -89,6 +89,9 @@ pub async fn dispatch(command: args::Command) -> DispatchResult {
                     eval_cmd::run_agent_eval_command(&run_args).await
                 }
             },
+            args::EvalCommand::History(history_args) => {
+                eval_cmd::run_history_command(&history_args)
+            }
             args::EvalCommand::Validate(validate_args) => {
                 eval_cmd::run_validate_command(&validate_args)
             }


### PR DESCRIPTION
## Summary

- Add `dbt-nova eval gate <NAME> [--json]` for advisory readiness checks from eval telemetry.
- Add `gate.threshold` suite config and validate thresholds in `eval validate`.
- Harden configured gates so they only allow the latest telemetry when it matches the current suite file hash, covers the full suite, and includes every assertion row for the run.
- Extend eval telemetry with `suite_hash`, `run_case_count`, `suite_case_count`, and `run_assertion_count`.
- Document readiness gate behavior and update packaged analyst/eval-author guidance.

## Validation

- `cargo test --locked eval_cmd`
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `uv run mkdocs build --strict`
- `git diff --check`
- `cargo run --locked -- eval run --suite evals/agent-tokenomics-bridge.yml --manifest-path tests/fixtures/tokenomics_manifest.json --output-dir target/joe-12-gate-filtered-start-hash --case-id conversion_rate_indicator_rank --telemetry --json`
- `cargo run --locked -- eval gate agent-tokenomics-bridge --json` verified filtered telemetry blocks with `covers 1 of 5 suite cases`
- `cargo run --locked -- eval run --suite evals/agent-tokenomics-bridge.yml --manifest-path tests/fixtures/tokenomics_manifest.json --output-dir target/joe-12-gate-full-start-hash --telemetry --json`
- `cargo run --locked -- eval gate agent-tokenomics-bridge --json` verified full-suite telemetry allows at threshold `1.0`
- Raw JSONL check verified 5 rows, one `suite_hash`, one `run_id`, `run_assertion_count=5`, `run_case_count=5`, and `suite_case_count=5`
- `python3 /Users/joe/.codex/skills/autoreview/scripts/autoreview --mode local` clean: no accepted/actionable findings

Linear: JOE-12