### PR TITLE
Add eval readiness gates

### DIFF
--- a/.github/skills/analyst/SKILL.md
+++ b/.github/skills/analyst/SKILL.md
@@ -70,6 +70,7 @@ Rules:
 - Do not assume friendly labels map directly to raw warehouse values without validation.
 - Keep validation probes close to the target slice. Do not scan a year-plus range just to confirm one filter member.
 - Do not front-load every trust tool by default. Escalate only when the answer is high-stakes or the entity choice is ambiguous.
+- For high-stakes, launch-readiness, or recurring production workflows, check the relevant eval suite gate with `dbt-nova eval gate <suite_name> --json` when CLI access and suite ownership are known. Treat blocked gates as advisory warnings to surface before final analysis, not as permission to hide the answer.
 
 ## Analysis discipline
 

--- a/.github/skills/eval-author/SKILL.md
+++ b/.github/skills/eval-author/SKILL.md
@@ -51,7 +51,9 @@ Eval execution is CLI-only. MCP is for discovering ground truth and debugging ex
 6. Validate the suite shape with `dbt-nova eval validate`.
 7. Run one case with `--case-id` before running the full suite.
 8. Set a gate that matches the suite purpose.
-9. Read `results.json` for machines, `report.md` for humans, and tool traces for agent behavior.
+9. Run the full suite with `--telemetry` before checking readiness gates.
+10. Check readiness with `dbt-nova eval gate <suite_name> --json` for high-stakes, launch-readiness, or recurring production suites.
+11. Read `results.json` for machines, `report.md` for humans, and tool traces for agent behavior.
 
 ## Design rules
 
@@ -63,6 +65,7 @@ Eval execution is CLI-only. MCP is for discovering ground truth and debugging ex
 - Avoid brittle prose checks. Use `final_answer.must_contain` only for short, durable business terms.
 - Freeze relative dates in agent tasks. Do not leave "last week", "this month", or "last 52 weeks" unresolved unless the eval is explicitly testing date interpretation.
 - Keep smoke suites small and strict. Keep broader regression suites larger with realistic `--fail-under` thresholds.
+- Put advisory launch-readiness thresholds in suite YAML as `gate: { threshold: <0.0-1.0> }`, then verify the latest full-suite telemetry with `dbt-nova eval gate <suite_name> --json`. Filtered `--case-id` runs are for iteration and do not satisfy configured gates.
 - Never include secrets, credentials, raw SQL parameter maps, or private manifests in public eval artifacts.
 
 ## Output standard

--- a/.github/skills/eval-author/references/workflow.md
+++ b/.github/skills/eval-author/references/workflow.md
@@ -45,21 +45,24 @@ generic week boundary.
 2. Run `dbt-nova eval validate --suite <suite>`.
 3. Run one bridge case with `dbt-nova eval run --suite <suite> --case-id <id>`.
 4. Fix expected ids, ranks, or metadata gaps.
-5. Run the full bridge suite.
+5. Run the full bridge suite with `--telemetry` when the suite will be readiness-gated.
 6. Add agent cases for workflows where tool-use behavior matters.
-7. Run one agent case with the target provider.
+7. Run one agent case with the target provider for iteration; run the full agent suite with `--telemetry` before checking a readiness gate.
 8. Inspect `tool-calls/<case>.jsonl`, `stdout.log`, and `report.md`.
 9. Set the CI gate only after the suite has at least one clean local run.
+10. For high-stakes, launch-readiness, or recurring production suites, check `dbt-nova eval gate <suite_name> --json` after full-suite telemetry-producing runs.
 
 ## Gate Selection
 
 Use strict gates for smoke suites:
 - `--fail-under 1.0`
+- `gate.threshold: 1.0`
 - small number of high-signal cases
 - should run after every manifest build
 
 Use realistic gates for broad regression suites:
 - `--fail-under 0.90` to `0.98`
+- `gate.threshold: 0.90` to `0.98`
 - larger coverage across domains
 - should run on a schedule or before metadata releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--telemetry`, keep newest rows with `--telemetry-retention`, and print
   filtered run history with `dbt-nova eval history --suite <NAME> --since
   <YYYY-MM-DD>`.
+- Eval suites can now declare advisory readiness gates with `gate.threshold`;
+  `dbt-nova eval gate <NAME> --json` reads the latest full-suite telemetry and
+  reports allowed/blocked status, pass rate, and failed case/assertion ids,
+  blocking stale suite-file telemetry before allowing configured gates.
 - Fixed release OCI publishing to build images from native Linux release binaries
   instead of compiling Rust inside the ARM64 Docker/QEMU path.
 - Fixed the Monthly workflow by refreshing advisory/dependency-watchlist review

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -304,12 +304,13 @@ dbt-nova eval agent run \
   --telemetry
 ```
 
-Rows include the suite name/path, mode, case id, assertion name/type, status,
-run duration, output directory, git SHA when available, and manifest hash for
-bridge runs. Agent rows also include provider metadata and sanitized trace
-counters such as tool-call count, distinct tool count, response bytes, and token
-counts when a provider trace exposes them. Telemetry does not store raw SQL
-parameter maps, provider stdout/stderr, or credentials.
+Rows include a run id, run/suite case counts, run assertion count, suite
+name/path/hash, mode, case id, assertion name/type, status, run duration, output
+directory, git SHA when available, and manifest hash for bridge runs. Agent rows
+also include provider metadata and sanitized trace counters such as tool-call
+count, distinct tool count, response bytes, and token counts when a provider
+trace exposes them. Telemetry does not store raw SQL parameter maps, provider
+stdout/stderr, or credentials.
 
 Use `eval history` for a thin date filter over the JSONL file:
 
@@ -319,6 +320,40 @@ dbt-nova eval history --suite agent-tokenomics-bridge --since 2026-06-01
 
 Use `--telemetry-retention <ROWS>` with `eval run` or `eval agent run` to keep
 only the newest rows for that suite after appending the current run.
+
+## Readiness Gates
+
+Suites can declare an advisory readiness threshold:
+
+```yaml
+version: 1
+name: analyst-smoke
+gate:
+  threshold: 0.9
+```
+
+After running the full suite with `--telemetry`, check the latest run:
+
+```bash
+dbt-nova eval gate analyst-smoke --json
+```
+
+The gate scans the suite telemetry JSONL, selects the latest run, computes its
+pass rate, and reports `allowed`, `blocked`, `gate_configured`, `pass_rate`,
+`total_evals`, `failed_evals`, `failed_eval_ids`, `failed_case_ids`, and the
+telemetry timestamp. Configured gates require the latest telemetry to match the
+current suite file hash, cover the full suite, and include every assertion row
+for that run, so stale suite files, filtered `--case-id` runs, and row-trimmed
+telemetry are blocked with rerun guidance. If the suite has no
+`gate.threshold`, the command returns `allowed=true` with
+`gate_configured=false`. If telemetry is missing, the command returns an
+actionable message to run the suite with `--telemetry` first. If the latest
+telemetry points at a suite file that cannot be read, the gate is blocked
+because the threshold cannot be verified.
+
+Gate results are advisory in this release. Use them to warn before
+launch-readiness checks or high-stakes analysis; they do not hard-block MCP
+tooling or hosted server startup.
 
 ## Tool Trace
 

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -4,7 +4,7 @@ Use `dbt-nova` in two modes:
 
 - No subcommand: start MCP server (backward compatible behavior)
 - Subcommand: run one-shot CLI commands and exit
-- CLI surface: `17` CLI-only leaf commands, plus `tool call` access to all `33` MCP tools
+- CLI surface: `18` CLI-only leaf commands, plus `tool call` access to all `33` MCP tools
 
 ## Command Tree
 
@@ -26,6 +26,7 @@ dbt-nova
 ├── eval validate --suite <PATH> [--json]
 ├── eval run --suite <PATH> [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--telemetry] [--telemetry-retention] [--case-id <ID>...] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
 ├── eval agent run --suite <PATH> [--provider] [--provider-command] [--provider-args-json] [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--telemetry] [--telemetry-retention] [--case-id <ID>...] [--timeout-secs] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
+├── eval gate <NAME> [--json]
 ├── eval history --suite <NAME> --since <YYYY-MM-DD>
 └── health check [--manifest-path|--manifest-uri] [--json]
 ```

--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -54,6 +54,13 @@ rows when comparing whether metadata or prompt changes improved a suite over
 time. Add `--telemetry-retention <ROWS>` to keep only the newest rows for that
 suite after each run.
 
+When a suite declares `gate.threshold`, run the full suite with `--telemetry`
+and then run `dbt-nova eval gate <NAME> --json`. Configured gates reject latest
+telemetry from stale suite files, filtered `--case-id` runs, or row-retention
+truncation, because those runs do not prove current full-suite readiness. Gates
+are advisory in v1: use blocked results to warn before high-stakes analysis or
+launch-readiness claims, then inspect the reported failed case/assertion ids.
+
 ## Test Storage Cleanup
 
 Tests use temporary storage under `target/dbt-nova-tests` and clean up automatically.

--- a/evals/agent-tokenomics-bridge.yml
+++ b/evals/agent-tokenomics-bridge.yml
@@ -1,5 +1,7 @@
 version: 1
 name: agent-tokenomics-bridge
+gate:
+  threshold: 1.0
 defaults:
   persona: analyst
   top_k: 5

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -345,6 +345,8 @@ pub enum EvalCommand {
     Run(EvalRunArgs),
     /// Run provider-backed agent evals and score observed Nova tool use.
     Agent(EvalAgentArgs),
+    /// Report readiness from the latest eval telemetry for a suite.
+    Gate(EvalGateArgs),
     /// Print filtered JSONL eval telemetry history.
     History(EvalHistoryArgs),
     /// Validate an eval suite without loading a manifest or running a provider.
@@ -559,6 +561,14 @@ pub struct EvalHistoryArgs {
 }
 
 #[derive(Debug, Clone, Args, Default)]
+pub struct EvalGateArgs {
+    #[arg(value_name = "NAME", help = "Eval suite name to check")]
+    pub suite: String,
+    #[arg(long, default_value_t = false, help = "Emit a JSON CLI envelope")]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Args, Default)]
 pub struct EvalValidateArgs {
     #[arg(long, value_name = "PATH", help = "YAML or JSON eval suite path")]
     pub suite: String,
@@ -734,6 +744,21 @@ mod tests {
                     assert_eq!(args.since, "2026-06-01");
                 }
                 _ => panic!("expected eval history"),
+            },
+            _ => panic!("expected eval command"),
+        }
+    }
+
+    #[test]
+    fn eval_gate_parses_suite_and_json() {
+        let cli = Cli::parse_from(["dbt-nova", "eval", "gate", "starter", "--json"]);
+        match cli.command.expect("command") {
+            Command::Eval(eval) => match eval.command {
+                EvalCommand::Gate(args) => {
+                    assert_eq!(args.suite, "starter");
+                    assert!(args.json);
+                }
+                _ => panic!("expected eval gate"),
             },
             _ => panic!("expected eval command"),
         }

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
 
 use crate::cli::args::{
-    EvalAgentRunArgs, EvalHistoryArgs, EvalInitArgs, EvalRunArgs, EvalValidateArgs,
+    EvalAgentRunArgs, EvalGateArgs, EvalHistoryArgs, EvalInitArgs, EvalRunArgs, EvalValidateArgs,
     ManifestLoadArgs,
 };
 use crate::cli::manifest::{build_manifest_load_config, execute_manifest_load};
@@ -34,11 +34,18 @@ struct EvalSuite {
     #[serde(default)]
     name: Option<String>,
     #[serde(default)]
+    gate: Option<EvalGateConfig>,
+    #[serde(default)]
     defaults: EvalDefaults,
     #[serde(default)]
     cases: Vec<EvalCase>,
     #[serde(default)]
     agent_cases: Vec<AgentCase>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+struct EvalGateConfig {
+    threshold: f64,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -287,6 +294,48 @@ struct AgentTelemetryContext<'a> {
     provider_command_preset: &'a str,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct EvalTelemetryRunContext<'a> {
+    suite_path: &'a str,
+    suite_hash: &'a str,
+    suite_case_count: usize,
+    manifest_hash: Option<&'a str>,
+    duration_ms: u64,
+    retention: Option<usize>,
+    agent: Option<AgentTelemetryContext<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct EvalGateReport {
+    suite_name: String,
+    allowed: bool,
+    blocked: bool,
+    gate_configured: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    threshold: Option<f64>,
+    pass_rate: f64,
+    total_evals: usize,
+    failed_evals: usize,
+    failed_eval_ids: Vec<String>,
+    failed_case_ids: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    telemetry_timestamp: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    suite_path: Option<String>,
+    message: String,
+}
+
+enum GateConfigStatus {
+    Configured {
+        gate: EvalGateConfig,
+        suite_hash: String,
+    },
+    Unconfigured,
+    Unavailable(String),
+}
+
 /// Writes a starter eval suite.
 ///
 /// # Errors
@@ -364,31 +413,33 @@ pub fn run_validate_command(args: &EvalValidateArgs) -> DispatchResult {
     Ok(())
 }
 
+/// Reports readiness from the latest eval telemetry for a suite.
+///
+/// # Errors
+/// Returns an error when existing telemetry or suite configuration cannot be parsed.
+pub fn run_gate_command(args: &EvalGateArgs) -> DispatchResult {
+    let started = Instant::now();
+    let rows = read_telemetry_rows_for_suite(&args.suite)?;
+    let report = build_eval_gate_report(&args.suite, &rows)?;
+    if args.json {
+        let envelope = CliEnvelope::success("eval gate", &report, started.elapsed().as_millis());
+        let out = serde_json::to_string_pretty(&envelope)
+            .map_err(|error| server_error(error.to_string()))?;
+        println!("{out}");
+    } else {
+        print_gate_report(&report);
+    }
+    Ok(())
+}
+
 /// Prints filtered JSONL eval telemetry history.
 ///
 /// # Errors
 /// Returns an error when `--since` is invalid or existing telemetry cannot be read.
 pub fn run_history_command(args: &EvalHistoryArgs) -> DispatchResult {
     let since_boundary = validate_since_date(&args.since)?;
-    let path = telemetry_path_for_suite(&args.suite);
-    if !path.exists() {
-        return Ok(());
-    }
-    let file = fs::File::open(&path).map_err(|error| server_error(error.to_string()))?;
-    let reader = BufReader::new(file);
-    for (index, line) in reader.lines().enumerate() {
-        let line = line.map_err(|error| server_error(error.to_string()))?;
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let row = serde_json::from_str::<JsonValue>(trimmed).map_err(|error| {
-            DbtNovaError::InvalidParams(format!(
-                "failed to parse telemetry line {} in '{}': {error}",
-                index + 1,
-                path.display()
-            ))
-        })?;
+    let rows = read_telemetry_rows_for_suite(&args.suite)?;
+    for row in rows {
         if telemetry_row_matches_since(&row, &since_boundary) {
             let out =
                 serde_json::to_string(&row).map_err(|error| server_error(error.to_string()))?;
@@ -404,7 +455,7 @@ pub fn run_history_command(args: &EvalHistoryArgs) -> DispatchResult {
 /// Returns an error when the suite is invalid, manifest loading fails, assertions error, or the score gate fails.
 pub async fn run_eval_command(args: &EvalRunArgs) -> DispatchResult {
     let started = Instant::now();
-    let suite = load_suite(&args.suite)?;
+    let (suite, suite_hash) = load_suite_with_hash(&args.suite)?;
     validate_fail_under(args.fail_under)?;
     validate_telemetry_retention(args.telemetry_retention)?;
     validate_telemetry_suite_name(&suite, args.telemetry)?;
@@ -444,11 +495,15 @@ pub async fn run_eval_command(args: &EvalRunArgs) -> DispatchResult {
     if args.telemetry {
         write_eval_telemetry(
             &report,
-            &args.suite,
-            Some(&load_result.search.manifest_hash),
-            elapsed_ms_to_u64(elapsed),
-            args.telemetry_retention,
-            None,
+            EvalTelemetryRunContext {
+                suite_path: &args.suite,
+                suite_hash: &suite_hash,
+                suite_case_count: suite.cases.len(),
+                manifest_hash: Some(&load_result.search.manifest_hash),
+                duration_ms: elapsed_ms_to_u64(elapsed),
+                retention: args.telemetry_retention,
+                agent: None,
+            },
         )?;
     }
     finish_report("eval run", &report, args.json, elapsed_ms)
@@ -460,7 +515,7 @@ pub async fn run_eval_command(args: &EvalRunArgs) -> DispatchResult {
 /// Returns an error when the suite is invalid, a provider command cannot be run, or the score gate fails.
 pub async fn run_agent_eval_command(args: &EvalAgentRunArgs) -> DispatchResult {
     let started = Instant::now();
-    let suite = load_suite(&args.suite)?;
+    let (suite, suite_hash) = load_suite_with_hash(&args.suite)?;
     validate_fail_under(args.fail_under)?;
     validate_telemetry_retention(args.telemetry_retention)?;
     validate_telemetry_suite_name(&suite, args.telemetry)?;
@@ -491,14 +546,18 @@ pub async fn run_agent_eval_command(args: &EvalAgentRunArgs) -> DispatchResult {
     if args.telemetry {
         write_eval_telemetry(
             &report,
-            &args.suite,
-            None,
-            elapsed_ms_to_u64(elapsed),
-            args.telemetry_retention,
-            Some(AgentTelemetryContext {
-                provider: &args.provider,
-                provider_command_preset: agent_provider_command_preset(args),
-            }),
+            EvalTelemetryRunContext {
+                suite_path: &args.suite,
+                suite_hash: &suite_hash,
+                suite_case_count: suite.agent_cases.len(),
+                manifest_hash: None,
+                duration_ms: elapsed_ms_to_u64(elapsed),
+                retention: args.telemetry_retention,
+                agent: Some(AgentTelemetryContext {
+                    provider: &args.provider,
+                    provider_command_preset: agent_provider_command_preset(args),
+                }),
+            },
         )?;
     }
     finish_report("eval agent run", &report, args.json, elapsed_ms)
@@ -1979,13 +2038,340 @@ fn write_report_artifacts(
     Ok(())
 }
 
+fn read_telemetry_rows_for_suite(suite_name: &str) -> crate::error::Result<Vec<JsonValue>> {
+    let path = telemetry_path_for_suite(suite_name);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let file = fs::File::open(&path).map_err(|error| server_error(error.to_string()))?;
+    let reader = BufReader::new(file);
+    let mut rows = Vec::new();
+    for (index, line) in reader.lines().enumerate() {
+        let line = line.map_err(|error| server_error(error.to_string()))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let row = serde_json::from_str::<JsonValue>(trimmed).map_err(|error| {
+            DbtNovaError::InvalidParams(format!(
+                "failed to parse telemetry line {} in '{}': {error}",
+                index + 1,
+                path.display()
+            ))
+        })?;
+        if row
+            .get("suite_name")
+            .and_then(JsonValue::as_str)
+            .is_some_and(|value| value == suite_name)
+        {
+            rows.push(row);
+        }
+    }
+    Ok(rows)
+}
+
+fn build_eval_gate_report(
+    suite_name: &str,
+    rows: &[JsonValue],
+) -> crate::error::Result<EvalGateReport> {
+    let latest_rows = latest_telemetry_rows(rows);
+    if latest_rows.is_empty() {
+        return Ok(EvalGateReport {
+            suite_name: suite_name.to_string(),
+            allowed: false,
+            blocked: true,
+            gate_configured: false,
+            threshold: None,
+            pass_rate: 0.0,
+            total_evals: 0,
+            failed_evals: 0,
+            failed_eval_ids: Vec::new(),
+            failed_case_ids: Vec::new(),
+            telemetry_timestamp: None,
+            output_dir: None,
+            suite_path: None,
+            message: format!(
+                "no eval telemetry found for suite '{suite_name}'; run the suite with --telemetry first"
+            ),
+        });
+    }
+
+    let total_evals = latest_rows.len();
+    let pass_count = latest_rows
+        .iter()
+        .filter(|row| row.get("status").and_then(JsonValue::as_str) == Some("pass"))
+        .count();
+    let failed_rows: Vec<&JsonValue> = latest_rows
+        .iter()
+        .copied()
+        .filter(|row| row.get("status").and_then(JsonValue::as_str) != Some("pass"))
+        .collect();
+    let failed_eval_ids: Vec<String> = failed_rows
+        .iter()
+        .map(|row| telemetry_eval_id(row))
+        .collect();
+    let failed_case_ids: Vec<String> = failed_rows
+        .iter()
+        .filter_map(|row| row.get("case_id").and_then(JsonValue::as_str))
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let pass_rate = ratio(pass_count, total_evals);
+    let first = latest_rows[0];
+    let suite_path = first
+        .get("suite_path")
+        .and_then(JsonValue::as_str)
+        .map(str::to_string);
+    let gate = gate_config_status_from_suite_path(suite_path.as_deref())?;
+    let telemetry_timestamp = first
+        .get("timestamp")
+        .and_then(JsonValue::as_str)
+        .map(str::to_string);
+    let output_dir = first
+        .get("output_dir")
+        .and_then(JsonValue::as_str)
+        .map(str::to_string);
+
+    let (gate_configured, threshold, current_suite_hash, unavailable_message) = match gate {
+        GateConfigStatus::Configured { gate, suite_hash } => {
+            (true, Some(gate.threshold), Some(suite_hash), None)
+        }
+        GateConfigStatus::Unconfigured => (false, None, None, None),
+        GateConfigStatus::Unavailable(message) => (false, None, None, Some(message)),
+    };
+    let incomplete_message = threshold
+        .is_some()
+        .then(|| {
+            latest_run_incomplete_message(
+                &latest_rows,
+                current_suite_hash.as_deref().unwrap_or_default(),
+            )
+        })
+        .flatten();
+    if let Some(message) = unavailable_message.or(incomplete_message) {
+        return Ok(EvalGateReport {
+            suite_name: suite_name.to_string(),
+            allowed: false,
+            blocked: true,
+            gate_configured,
+            threshold,
+            pass_rate,
+            total_evals,
+            failed_evals: failed_eval_ids.len(),
+            failed_eval_ids,
+            failed_case_ids,
+            telemetry_timestamp,
+            output_dir,
+            suite_path,
+            message,
+        });
+    }
+
+    let (allowed, message) = if let Some(threshold) = threshold {
+        let allowed = pass_rate >= threshold;
+        let message = if allowed {
+            format!("latest eval telemetry passed gate threshold {threshold:.3}")
+        } else {
+            format!(
+                "latest eval telemetry below gate threshold {threshold:.3}; inspect failed_eval_ids before relying on this suite"
+            )
+        };
+        (allowed, message)
+    } else {
+        (
+            true,
+            "no gate threshold configured; advisory gate allowed by default".to_string(),
+        )
+    };
+
+    Ok(EvalGateReport {
+        suite_name: suite_name.to_string(),
+        allowed,
+        blocked: !allowed,
+        gate_configured,
+        threshold,
+        pass_rate,
+        total_evals,
+        failed_evals: failed_eval_ids.len(),
+        failed_eval_ids,
+        failed_case_ids,
+        telemetry_timestamp,
+        output_dir,
+        suite_path,
+        message,
+    })
+}
+
+fn latest_telemetry_rows(rows: &[JsonValue]) -> Vec<&JsonValue> {
+    let Some(latest) = rows.iter().max_by_key(|row| {
+        row.get("timestamp_ms")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0)
+    }) else {
+        return Vec::new();
+    };
+    if let Some(run_id) = latest
+        .get("run_id")
+        .and_then(JsonValue::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        return rows
+            .iter()
+            .filter(|row| row.get("run_id").and_then(JsonValue::as_str) == Some(run_id))
+            .collect();
+    }
+    let latest_timestamp = latest
+        .get("timestamp_ms")
+        .and_then(JsonValue::as_u64)
+        .unwrap_or(0);
+    if let Some(output_dir) = latest
+        .get("output_dir")
+        .and_then(JsonValue::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        rows.iter()
+            .filter(|row| {
+                row.get("timestamp_ms").and_then(JsonValue::as_u64) == Some(latest_timestamp)
+                    && row.get("output_dir").and_then(JsonValue::as_str) == Some(output_dir)
+            })
+            .collect()
+    } else {
+        rows.iter()
+            .filter(|row| {
+                row.get("timestamp_ms").and_then(JsonValue::as_u64) == Some(latest_timestamp)
+            })
+            .collect()
+    }
+}
+
+fn latest_run_incomplete_message(rows: &[&JsonValue], current_suite_hash: &str) -> Option<String> {
+    let Some(recorded_suite_hash) = rows
+        .first()
+        .and_then(|row| row.get("suite_hash"))
+        .and_then(JsonValue::as_str)
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return Some(
+            "latest eval telemetry does not include suite_hash; rerun the full suite with --telemetry before checking the gate"
+                .to_string(),
+        );
+    };
+    if recorded_suite_hash != current_suite_hash {
+        return Some(
+            "latest eval telemetry was produced from a different suite file version; rerun the full suite with --telemetry before checking the gate"
+                .to_string(),
+        );
+    }
+    let Some(run_case_count) = rows
+        .first()
+        .and_then(|row| row.get("run_case_count"))
+        .and_then(JsonValue::as_u64)
+    else {
+        return Some(
+            "latest eval telemetry does not include run_case_count; rerun the full suite with --telemetry before checking the gate"
+                .to_string(),
+        );
+    };
+    let Some(suite_case_count) = rows
+        .first()
+        .and_then(|row| row.get("suite_case_count"))
+        .and_then(JsonValue::as_u64)
+    else {
+        return Some(
+            "latest eval telemetry does not include suite_case_count; rerun the full suite with --telemetry before checking the gate"
+                .to_string(),
+        );
+    };
+    if run_case_count != suite_case_count {
+        return Some(format!(
+            "latest eval telemetry covers {run_case_count} of {suite_case_count} suite cases; rerun the full suite with --telemetry before checking the gate"
+        ));
+    }
+    let Some(expected) = rows
+        .first()
+        .and_then(|row| row.get("run_assertion_count"))
+        .and_then(JsonValue::as_u64)
+    else {
+        return Some(
+            "latest eval telemetry does not include run_assertion_count; rerun the suite with --telemetry before checking the gate"
+                .to_string(),
+        );
+    };
+    let observed = u64::try_from(rows.len()).unwrap_or(u64::MAX);
+    if expected == observed {
+        return None;
+    }
+    Some(format!(
+        "latest eval telemetry is incomplete: found {observed} of {expected} assertion rows; rerun the suite with --telemetry or increase --telemetry-retention"
+    ))
+}
+
+fn gate_config_status_from_suite_path(
+    path: Option<&str>,
+) -> crate::error::Result<GateConfigStatus> {
+    let Some(path) = path.filter(|value| !value.trim().is_empty()) else {
+        return Ok(GateConfigStatus::Unavailable(
+            "latest telemetry did not include suite_path; rerun the suite with --telemetry"
+                .to_string(),
+        ));
+    };
+    if !Path::new(path).exists() {
+        return Ok(GateConfigStatus::Unavailable(format!(
+            "suite config '{path}' could not be read; rerun the suite with --telemetry from the current checkout"
+        )));
+    }
+    let (suite, suite_hash) = load_suite_with_hash(path)?;
+    Ok(match suite.gate {
+        Some(gate) => GateConfigStatus::Configured { gate, suite_hash },
+        None => GateConfigStatus::Unconfigured,
+    })
+}
+
+#[cfg(test)]
+fn suite_file_hash(path: &str) -> crate::error::Result<String> {
+    let raw = fs::read(path).map_err(|error| {
+        DbtNovaError::InvalidParams(format!(
+            "failed to read eval suite '{path}' for hash: {error}"
+        ))
+    })?;
+    Ok(blake3::hash(&raw).to_hex().to_string())
+}
+
+fn telemetry_eval_id(row: &JsonValue) -> String {
+    let case_id = row
+        .get("case_id")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("unknown_case");
+    let assertion_name = row
+        .get("assertion_name")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("unknown_assertion");
+    format!("{case_id}::{assertion_name}")
+}
+
+fn print_gate_report(report: &EvalGateReport) {
+    let status = if report.allowed { "allowed" } else { "blocked" };
+    println!("Nova eval gate {}: {status}", report.suite_name);
+    println!("  gate_configured: {}", report.gate_configured);
+    if let Some(threshold) = report.threshold {
+        println!("  threshold: {threshold:.3}");
+    }
+    println!("  pass_rate: {:.3}", report.pass_rate);
+    println!("  total_evals: {}", report.total_evals);
+    println!("  failed_evals: {}", report.failed_evals);
+    if let Some(timestamp) = report.telemetry_timestamp.as_ref() {
+        println!("  telemetry_timestamp: {timestamp}");
+    }
+    println!("  message: {}", report.message);
+    if !report.failed_eval_ids.is_empty() {
+        println!("  failed_eval_ids: {}", report.failed_eval_ids.join(", "));
+    }
+}
+
 fn write_eval_telemetry(
     report: &EvalReport,
-    suite_path: &str,
-    manifest_hash: Option<&str>,
-    duration_ms: u64,
-    retention: Option<usize>,
-    agent: Option<AgentTelemetryContext<'_>>,
+    context: EvalTelemetryRunContext<'_>,
 ) -> DispatchResult {
     let telemetry_path = telemetry_path_for_suite(&report.suite_name);
     if let Some(parent) = telemetry_path.parent() {
@@ -1993,8 +2379,14 @@ fn write_eval_telemetry(
     }
     let timestamp_ms = timestamp_millis();
     let timestamp = format_utc_timestamp_millis(timestamp_ms);
+    let run_id = format!(
+        "{}-{}-{timestamp_ms}",
+        report.mode,
+        safe_path_segment(&report.suite_name)
+    );
     let git_sha = current_git_sha();
-    let manifest_hash = manifest_hash
+    let manifest_hash = context
+        .manifest_hash
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string);
@@ -2009,8 +2401,19 @@ fn write_eval_telemetry(
             let mut row = serde_json::Map::new();
             row.insert("timestamp".to_string(), json!(&timestamp));
             row.insert("timestamp_ms".to_string(), json!(timestamp_ms));
+            row.insert("run_id".to_string(), json!(&run_id));
+            row.insert("run_case_count".to_string(), json!(report.cases.len()));
+            row.insert(
+                "suite_case_count".to_string(),
+                json!(context.suite_case_count),
+            );
+            row.insert(
+                "run_assertion_count".to_string(),
+                json!(report.assertion_count),
+            );
             row.insert("suite_name".to_string(), json!(&report.suite_name));
-            row.insert("suite_path".to_string(), json!(suite_path));
+            row.insert("suite_path".to_string(), json!(context.suite_path));
+            row.insert("suite_hash".to_string(), json!(context.suite_hash));
             row.insert("mode".to_string(), json!(report.mode));
             row.insert("case_id".to_string(), json!(&case.id));
             row.insert("assertion_name".to_string(), json!(&assertion.name));
@@ -2023,7 +2426,7 @@ fn write_eval_telemetry(
                 "grade_mode".to_string(),
                 json!(telemetry_grade_mode(report.mode)),
             );
-            row.insert("duration_ms".to_string(), json!(duration_ms));
+            row.insert("duration_ms".to_string(), json!(context.duration_ms));
             row.insert("output_dir".to_string(), json!(&report.output_dir));
             if let Some(manifest_hash) = manifest_hash.as_ref() {
                 row.insert("manifest_hash".to_string(), json!(manifest_hash));
@@ -2031,7 +2434,7 @@ fn write_eval_telemetry(
             if let Some(git_sha) = git_sha.as_ref() {
                 row.insert("git_sha".to_string(), json!(git_sha));
             }
-            if let Some(agent) = agent {
+            if let Some(agent) = context.agent {
                 row.insert("provider".to_string(), json!(agent.provider));
                 row.insert(
                     "provider_command_preset".to_string(),
@@ -2070,7 +2473,7 @@ fn write_eval_telemetry(
     }
     drop(file);
 
-    if let Some(max_rows) = retention {
+    if let Some(max_rows) = context.retention {
         apply_telemetry_retention(&telemetry_path, max_rows)?;
     }
     Ok(())
@@ -2487,29 +2890,46 @@ impl AgentExpected {
 }
 
 fn load_suite(path: &str) -> crate::error::Result<EvalSuite> {
-    let raw = fs::read_to_string(path).map_err(|error| {
+    load_suite_with_hash(path).map(|(suite, _hash)| suite)
+}
+
+fn load_suite_with_hash(path: &str) -> crate::error::Result<(EvalSuite, String)> {
+    let raw = fs::read(path).map_err(|error| {
         DbtNovaError::InvalidParams(format!("failed to read eval suite '{path}': {error}"))
+    })?;
+    let suite_hash = blake3::hash(&raw).to_hex().to_string();
+    let raw = std::str::from_utf8(&raw).map_err(|error| {
+        DbtNovaError::InvalidParams(format!(
+            "failed to read eval suite '{path}' as UTF-8: {error}"
+        ))
     })?;
     let suite: EvalSuite = if Path::new(path)
         .extension()
         .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
     {
-        serde_json::from_str(&raw).map_err(|error| {
+        serde_json::from_str(raw).map_err(|error| {
             DbtNovaError::InvalidParams(format!("failed to parse eval suite JSON: {error}"))
         })?
     } else {
-        serde_yaml::from_str(&raw).map_err(|error| {
+        serde_yaml::from_str(raw).map_err(|error| {
             DbtNovaError::InvalidParams(format!("failed to parse eval suite YAML: {error}"))
         })?
     };
     validate_suite(&suite)?;
-    Ok(suite)
+    Ok((suite, suite_hash))
 }
 
 fn validate_suite(suite: &EvalSuite) -> crate::error::Result<()> {
     if suite.version == 0 {
         return Err(DbtNovaError::InvalidParams(
             "eval suite version must be greater than zero".to_string(),
+        ));
+    }
+    if let Some(gate) = suite.gate
+        && !(0.0..=1.0).contains(&gate.threshold)
+    {
+        return Err(DbtNovaError::InvalidParams(
+            "eval suite gate.threshold must be between 0.0 and 1.0".to_string(),
         ));
     }
     validate_case_ids(suite.cases.iter().map(|case| case.id.as_str()), "cases")?;

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -7,13 +7,14 @@ use tempfile::{NamedTempFile, TempDir};
 use super::{
     AgentCalledWith, AgentEntityRank, AgentExpected, AgentOrder, AssertionResult, EvalCaseReport,
     EvalDefaults, EvalRunArgs, EvalSuite, EvalValidateArgs, FinalAnswerExpected,
-    apply_telemetry_retention, contains_rank_assertion, context_contains_assertion,
-    context_field_equals_assertion, eval_case_telemetry_from_trace, format_utc_timestamp_millis,
-    json_has_field_path, metadata_score_max_assertion, metadata_score_min_assertion,
-    read_tool_trace, recipe_rank_assertion, run_eval_command, run_validate_command,
-    safe_path_segment, score_agent_expectations, selected_agent_cases, selected_bridge_cases,
-    telemetry_path_for_suite, telemetry_row_matches_since, tool_response_budget_assertion,
-    tool_success_assertion, validate_since_date, validate_suite, validate_telemetry_suite_name,
+    apply_telemetry_retention, build_eval_gate_report, contains_rank_assertion,
+    context_contains_assertion, context_field_equals_assertion, eval_case_telemetry_from_trace,
+    format_utc_timestamp_millis, json_has_field_path, metadata_score_max_assertion,
+    metadata_score_min_assertion, read_tool_trace, recipe_rank_assertion, run_eval_command,
+    run_validate_command, safe_path_segment, score_agent_expectations, selected_agent_cases,
+    selected_bridge_cases, suite_file_hash, telemetry_path_for_suite, telemetry_row_matches_since,
+    tool_response_budget_assertion, tool_success_assertion, validate_since_date, validate_suite,
+    validate_telemetry_suite_name,
 };
 
 #[test]
@@ -411,6 +412,7 @@ fn telemetry_requires_named_suite() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        gate: None,
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
         agent_cases: Vec::new(),
@@ -423,10 +425,368 @@ fn telemetry_requires_named_suite() {
 }
 
 #[test]
+fn eval_gate_allows_latest_run_above_threshold() {
+    let suite = gate_suite_file(Some(0.5));
+    let suite_path = suite.path().display().to_string();
+    let rows = vec![
+        telemetry_row(
+            "gated",
+            &suite_path,
+            "old",
+            1,
+            "case_old",
+            "assertion",
+            "fail",
+        ),
+        telemetry_row_with_assertion_count(
+            "gated",
+            &suite_path,
+            "new",
+            2,
+            "case_a",
+            "assertion_a",
+            "pass",
+            2,
+        ),
+        telemetry_row_with_assertion_count(
+            "gated",
+            &suite_path,
+            "new",
+            2,
+            "case_b",
+            "assertion_b",
+            "pass",
+            2,
+        ),
+    ];
+
+    let report = build_eval_gate_report("gated", &rows).expect("gate report");
+
+    assert!(report.allowed);
+    assert!(!report.blocked);
+    assert!(report.gate_configured);
+    assert_eq!(report.threshold, Some(0.5));
+    assert_eq!(report.total_evals, 2);
+    assert_eq!(report.failed_evals, 0);
+    assert!((report.pass_rate - 1.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn eval_gate_blocks_latest_run_below_threshold_with_failed_ids() {
+    let suite = gate_suite_file(Some(1.0));
+    let suite_path = suite.path().display().to_string();
+    let rows = vec![
+        telemetry_row(
+            "gated",
+            &suite_path,
+            "old",
+            1,
+            "case_old",
+            "assertion",
+            "pass",
+        ),
+        telemetry_row_with_assertion_count(
+            "gated",
+            &suite_path,
+            "new",
+            2,
+            "case_a",
+            "assertion_a",
+            "pass",
+            2,
+        ),
+        telemetry_row_with_assertion_count(
+            "gated",
+            &suite_path,
+            "new",
+            2,
+            "case_b",
+            "assertion_b",
+            "fail",
+            2,
+        ),
+    ];
+
+    let report = build_eval_gate_report("gated", &rows).expect("gate report");
+
+    assert!(!report.allowed);
+    assert!(report.blocked);
+    assert!((report.pass_rate - 0.5).abs() < f64::EPSILON);
+    assert_eq!(report.failed_evals, 1);
+    assert_eq!(report.failed_eval_ids, vec!["case_b::assertion_b"]);
+    assert_eq!(report.failed_case_ids, vec!["case_b"]);
+}
+
+#[test]
+fn eval_gate_uses_run_id_not_reused_output_dir() {
+    let suite = gate_suite_file(Some(1.0));
+    let suite_path = suite.path().display().to_string();
+    let rows = vec![
+        telemetry_row_with_run_id(
+            "gated",
+            &suite_path,
+            "stable-output",
+            1,
+            "case_old",
+            "assertion_old",
+            "pass",
+            "run-old",
+        ),
+        telemetry_row_with_run_id(
+            "gated",
+            &suite_path,
+            "stable-output",
+            2,
+            "case_new",
+            "assertion_new",
+            "fail",
+            "run-new",
+        ),
+    ];
+
+    let report = build_eval_gate_report("gated", &rows).expect("gate report");
+
+    assert!(!report.allowed);
+    assert_eq!(report.total_evals, 1);
+    assert_eq!(report.failed_eval_ids, vec!["case_new::assertion_new"]);
+}
+
+#[test]
+fn eval_gate_blocks_partial_latest_run_after_retention() {
+    let suite = gate_suite_file(Some(1.0));
+    let suite_path = suite.path().display().to_string();
+    let rows = vec![
+        telemetry_row(
+            "gated",
+            &suite_path,
+            "old",
+            1,
+            "case_old",
+            "assertion_old",
+            "fail",
+        ),
+        telemetry_row_with_assertion_count(
+            "gated",
+            &suite_path,
+            "new",
+            2,
+            "case_new",
+            "assertion_new",
+            "pass",
+            2,
+        ),
+    ];
+
+    let report = build_eval_gate_report("gated", &rows).expect("gate report");
+
+    assert!(!report.allowed);
+    assert!(report.blocked);
+    assert_eq!(report.total_evals, 1);
+    assert!(report.message.contains("found 1 of 2"));
+}
+
+#[test]
+fn eval_gate_blocks_filtered_latest_run_even_when_selected_case_passed() {
+    let suite = gate_suite_file(Some(1.0));
+    let suite_path = suite.path().display().to_string();
+    let rows = vec![telemetry_row_with_case_counts(
+        "gated",
+        &suite_path,
+        "latest",
+        1,
+        "case_a",
+        "assertion_a",
+        "pass",
+        1,
+        1,
+        2,
+    )];
+
+    let report = build_eval_gate_report("gated", &rows).expect("gate report");
+
+    assert!(!report.allowed);
+    assert!(report.blocked);
+    assert_eq!(report.total_evals, 1);
+    assert!((report.pass_rate - 1.0).abs() < f64::EPSILON);
+    assert!(report.message.contains("covers 1 of 2 suite cases"));
+}
+
+#[test]
+fn eval_gate_blocks_latest_run_from_changed_suite_file() {
+    let suite = gate_suite_file(Some(1.0));
+    let suite_path = suite.path().display().to_string();
+    let rows = vec![telemetry_row(
+        "gated",
+        &suite_path,
+        "latest",
+        1,
+        "case_a",
+        "assertion_a",
+        "pass",
+    )];
+    std::fs::write(
+        suite.path(),
+        "version: 1\nname: gated\ngate:\n  threshold: 1.0\ncases: []\nagent_cases: []\n# changed\n",
+    )
+    .expect("change suite");
+
+    let report = build_eval_gate_report("gated", &rows).expect("gate report");
+
+    assert!(!report.allowed);
+    assert!(report.blocked);
+    assert!(report.message.contains("different suite file version"));
+}
+
+#[test]
+fn eval_gate_blocks_legacy_telemetry_without_suite_hash() {
+    let suite = gate_suite_file(Some(1.0));
+    let suite_path = suite.path().display().to_string();
+    let mut row = telemetry_row(
+        "gated",
+        &suite_path,
+        "latest",
+        1,
+        "case_a",
+        "assertion_a",
+        "pass",
+    );
+    row.as_object_mut()
+        .expect("telemetry object")
+        .remove("suite_hash");
+    let rows = vec![row];
+
+    let report = build_eval_gate_report("gated", &rows).expect("gate report");
+
+    assert!(!report.allowed);
+    assert!(report.blocked);
+    assert!(report.message.contains("suite_hash"));
+}
+
+#[test]
+fn eval_gate_blocks_legacy_telemetry_without_run_assertion_count() {
+    let suite = gate_suite_file(Some(1.0));
+    let suite_path = suite.path().display().to_string();
+    let mut row = telemetry_row(
+        "gated",
+        &suite_path,
+        "latest",
+        1,
+        "case_a",
+        "assertion_a",
+        "pass",
+    );
+    row.as_object_mut()
+        .expect("telemetry object")
+        .remove("run_assertion_count");
+    let rows = vec![row];
+
+    let report = build_eval_gate_report("gated", &rows).expect("gate report");
+
+    assert!(!report.allowed);
+    assert!(report.blocked);
+    assert!(report.message.contains("run_assertion_count"));
+}
+
+#[test]
+fn eval_gate_missing_config_allows_with_explicit_signal() {
+    let suite = gate_suite_file(None);
+    let suite_path = suite.path().display().to_string();
+    let rows = vec![telemetry_row(
+        "ungated",
+        &suite_path,
+        "latest",
+        1,
+        "case_a",
+        "assertion_a",
+        "fail",
+    )];
+
+    let report = build_eval_gate_report("ungated", &rows).expect("gate report");
+
+    assert!(report.allowed);
+    assert!(!report.blocked);
+    assert!(!report.gate_configured);
+    assert_eq!(report.threshold, None);
+    assert!(report.message.contains("allowed by default"));
+}
+
+#[test]
+fn eval_gate_missing_config_allows_legacy_telemetry_without_run_assertion_count() {
+    let suite = gate_suite_file(None);
+    let suite_path = suite.path().display().to_string();
+    let mut row = telemetry_row(
+        "ungated",
+        &suite_path,
+        "latest",
+        1,
+        "case_a",
+        "assertion_a",
+        "pass",
+    );
+    row.as_object_mut()
+        .expect("telemetry object")
+        .remove("run_assertion_count");
+    let rows = vec![row];
+
+    let report = build_eval_gate_report("ungated", &rows).expect("gate report");
+
+    assert!(report.allowed);
+    assert!(!report.blocked);
+    assert!(!report.gate_configured);
+    assert!(report.message.contains("allowed by default"));
+}
+
+#[test]
+fn eval_gate_missing_suite_config_blocks_with_actionable_message() {
+    let rows = vec![telemetry_row(
+        "gated",
+        "target/does-not-exist/gated.yml",
+        "latest",
+        1,
+        "case_a",
+        "assertion_a",
+        "pass",
+    )];
+
+    let report = build_eval_gate_report("gated", &rows).expect("gate report");
+
+    assert!(!report.allowed);
+    assert!(report.blocked);
+    assert!(!report.gate_configured);
+    assert!(report.message.contains("could not be read"));
+}
+
+#[test]
+fn eval_gate_missing_telemetry_returns_actionable_message() {
+    let report = build_eval_gate_report("missing", &[]).expect("gate report");
+
+    assert!(!report.allowed);
+    assert!(report.blocked);
+    assert!(!report.gate_configured);
+    assert_eq!(report.total_evals, 0);
+    assert!(report.message.contains("--telemetry"));
+}
+
+#[test]
+fn validate_suite_rejects_invalid_gate_threshold() {
+    let suite = EvalSuite {
+        version: 1,
+        name: None,
+        gate: Some(super::EvalGateConfig { threshold: 1.1 }),
+        defaults: EvalDefaults::default(),
+        cases: Vec::new(),
+        agent_cases: Vec::new(),
+    };
+    let error = validate_suite(&suite).expect_err("invalid gate threshold should fail");
+    assert!(error.to_string().contains("gate.threshold"));
+}
+
+#[test]
 fn validate_suite_rejects_duplicate_agent_case_ids() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        gate: None,
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
         agent_cases: vec![
@@ -451,6 +811,7 @@ fn validate_suite_rejects_duplicate_artifact_segments() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        gate: None,
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
         agent_cases: vec![
@@ -475,6 +836,7 @@ fn validate_suite_rejects_case_insensitive_artifact_segment_collisions() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        gate: None,
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
         agent_cases: vec![
@@ -499,6 +861,7 @@ fn validate_suite_rejects_vacuous_search_columns_rank_assertion() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        gate: None,
         defaults: EvalDefaults::default(),
         cases: vec![super::EvalCase {
             id: "columns".to_string(),
@@ -522,6 +885,7 @@ fn validate_suite_rejects_unmatchable_called_with_param_values() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        gate: None,
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
         agent_cases: vec![super::AgentCase {
@@ -665,4 +1029,182 @@ fn fixture_manifest_path(name: &str) -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures")
         .join(name)
+}
+
+fn gate_suite_file(threshold: Option<f64>) -> NamedTempFile {
+    let suite = NamedTempFile::new().expect("suite file");
+    let gate = threshold.map_or_else(String::new, |threshold| {
+        format!("gate:\n  threshold: {threshold}\n")
+    });
+    std::fs::write(
+        suite.path(),
+        format!("version: 1\nname: gated\n{gate}cases: []\nagent_cases: []\n"),
+    )
+    .expect("write suite");
+    suite
+}
+
+fn telemetry_row(
+    suite_name: &str,
+    suite_path: &str,
+    output_dir: &str,
+    timestamp_ms: u64,
+    case_id: &str,
+    assertion_name: &str,
+    status: &str,
+) -> serde_json::Value {
+    let run_id = format!("run-{timestamp_ms}");
+    telemetry_row_with_run_id_and_count(
+        suite_name,
+        suite_path,
+        output_dir,
+        timestamp_ms,
+        case_id,
+        assertion_name,
+        status,
+        &run_id,
+        1,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn telemetry_row_with_run_id(
+    suite_name: &str,
+    suite_path: &str,
+    output_dir: &str,
+    timestamp_ms: u64,
+    case_id: &str,
+    assertion_name: &str,
+    status: &str,
+    run_id: &str,
+) -> serde_json::Value {
+    telemetry_row_with_run_id_and_count(
+        suite_name,
+        suite_path,
+        output_dir,
+        timestamp_ms,
+        case_id,
+        assertion_name,
+        status,
+        run_id,
+        1,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn telemetry_row_with_assertion_count(
+    suite_name: &str,
+    suite_path: &str,
+    output_dir: &str,
+    timestamp_ms: u64,
+    case_id: &str,
+    assertion_name: &str,
+    status: &str,
+    run_assertion_count: u64,
+) -> serde_json::Value {
+    let run_id = format!("run-{timestamp_ms}");
+    telemetry_row_with_run_id_and_count(
+        suite_name,
+        suite_path,
+        output_dir,
+        timestamp_ms,
+        case_id,
+        assertion_name,
+        status,
+        &run_id,
+        run_assertion_count,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn telemetry_row_with_run_id_and_count(
+    suite_name: &str,
+    suite_path: &str,
+    output_dir: &str,
+    timestamp_ms: u64,
+    case_id: &str,
+    assertion_name: &str,
+    status: &str,
+    run_id: &str,
+    run_assertion_count: u64,
+) -> serde_json::Value {
+    telemetry_row_with_run_id_and_counts(
+        suite_name,
+        suite_path,
+        output_dir,
+        timestamp_ms,
+        case_id,
+        assertion_name,
+        status,
+        run_id,
+        run_assertion_count,
+        1,
+        1,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn telemetry_row_with_case_counts(
+    suite_name: &str,
+    suite_path: &str,
+    output_dir: &str,
+    timestamp_ms: u64,
+    case_id: &str,
+    assertion_name: &str,
+    status: &str,
+    run_assertion_count: u64,
+    run_case_count: u64,
+    suite_case_count: u64,
+) -> serde_json::Value {
+    let run_id = format!("run-{timestamp_ms}");
+    telemetry_row_with_run_id_and_counts(
+        suite_name,
+        suite_path,
+        output_dir,
+        timestamp_ms,
+        case_id,
+        assertion_name,
+        status,
+        &run_id,
+        run_assertion_count,
+        run_case_count,
+        suite_case_count,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn telemetry_row_with_run_id_and_counts(
+    suite_name: &str,
+    suite_path: &str,
+    output_dir: &str,
+    timestamp_ms: u64,
+    case_id: &str,
+    assertion_name: &str,
+    status: &str,
+    run_id: &str,
+    run_assertion_count: u64,
+    run_case_count: u64,
+    suite_case_count: u64,
+) -> serde_json::Value {
+    let mut row = json!({
+        "timestamp": format_utc_timestamp_millis(timestamp_ms),
+        "timestamp_ms": timestamp_ms,
+        "run_id": run_id,
+        "run_case_count": run_case_count,
+        "suite_case_count": suite_case_count,
+        "run_assertion_count": run_assertion_count,
+        "suite_name": suite_name,
+        "suite_path": suite_path,
+        "mode": "bridge",
+        "case_id": case_id,
+        "assertion_name": assertion_name,
+        "status": status,
+        "output_dir": output_dir
+    });
+    if let Ok(hash) = suite_file_hash(suite_path)
+        && let Some(object) = row.as_object_mut()
+    {
+        object.insert("suite_hash".to_string(), json!(hash));
+    }
+    row
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -89,6 +89,7 @@ pub async fn dispatch(command: args::Command) -> DispatchResult {
                     eval_cmd::run_agent_eval_command(&run_args).await
                 }
             },
+            args::EvalCommand::Gate(gate_args) => eval_cmd::run_gate_command(&gate_args),
             args::EvalCommand::History(history_args) => {
                 eval_cmd::run_history_command(&history_args)
             }


### PR DESCRIPTION
## Summary
- Add eval readiness gates over JSONL telemetry so suites can block promotion when the latest run is below threshold.
- Add eval gate SUITE with JSON output and actionable messages for missing telemetry/configuration.
- Harden gate behavior around suite hash mismatches, retained telemetry, reused output dirs, filtered case runs, and legacy telemetry rows.
- Update eval docs, CLI docs, testing docs, and packaged eval-author/analyst skill guidance.

## Validation
- cargo fmt --check
- cargo test --locked eval_gate
- cargo test --locked telemetry
- cargo run --locked -- eval run --suite evals/agent-tokenomics-bridge.yml --manifest-path tests/fixtures/tokenomics_manifest.json --telemetry --telemetry-retention 20 --fail-under 1.0
- cargo run --locked -- eval gate agent-tokenomics-bridge --json (allowed: true, pass_rate: 1.0, total_evals: 5)
- uv run mkdocs build --strict

Replaces #202, which GitHub closed when its stacked base branch was merged/deleted and would not allow reopening.

Closes JOE-12