### PR TITLE
Harden CI semantic model caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       RUSTFLAGS: "-C debuginfo=0"
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
@@ -31,7 +31,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Format
         run: cargo fmt --check
@@ -49,7 +49,7 @@ jobs:
       RUSTFLAGS: "-C debuginfo=0"
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Free runner disk space
         run: |
@@ -63,7 +63,7 @@ jobs:
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Test
         run: cargo test --locked --all-features
@@ -77,7 +77,7 @@ jobs:
       RUSTFLAGS: "-C debuginfo=0"
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
@@ -85,7 +85,7 @@ jobs:
           toolchain: 1.93.0
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Check MSRV (all features)
         run: cargo check --locked --all-features
@@ -99,13 +99,13 @@ jobs:
       RUSTFLAGS: "-C debuginfo=0"
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Search Eval Smoke
         run: |
@@ -123,13 +123,13 @@ jobs:
       RUSTFLAGS: "-C debuginfo=0"
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Validate Tokenomics Bridge Eval
         run: cargo run --locked --no-default-features -- eval validate --suite evals/agent-tokenomics-bridge.yml
@@ -153,13 +153,13 @@ jobs:
       RUSTFLAGS: "-C debuginfo=0"
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Check (no default features)
         run: cargo check --locked --no-default-features --all-targets
@@ -169,13 +169,13 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Verify generated config reference
         run: scripts/check_config_reference.sh
@@ -190,7 +190,7 @@ jobs:
       RUSTFLAGS: "-C debuginfo=0"
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
@@ -198,7 +198,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@288875dd3d64326724fa6d9593062d9f8ba0b131
@@ -219,10 +219,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.11"
 
@@ -239,7 +239,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Build container image
         run: docker build -t dbt-nova:ci .
@@ -252,7 +252,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
@@ -447,7 +447,7 @@ jobs:
           sudo apt-get install -y jq
 
       - name: Download dry-run publish summary artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ needs.reusable-assets-remote-publish-dryrun.outputs.artifact_name_publish_summary }}
           path: dryrun-publish-summary
@@ -508,13 +508,13 @@ jobs:
       STORAGE_INSTANCE_ID: ci-readonly-smoke
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Build dbt-nova CLI binary
         run: cargo build --locked --bin dbt-nova
@@ -544,7 +544,7 @@ jobs:
           test "${PUBLISHED_MODELS_URIS}" = '{}'
 
       - name: Download publish summary artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ needs.reusable-assets-producer.outputs.artifact_name_publish_summary }}
           path: consumer-artifacts/publish-summary
@@ -566,13 +566,13 @@ jobs:
           jq -e '.published_models_uris == {}' "${summary_path}" >/dev/null
 
       - name: Download storage artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ needs.reusable-assets-producer.outputs.artifact_name_storage }}
           path: consumer-artifacts/storage
 
       - name: Download metadata artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ needs.reusable-assets-producer.outputs.artifact_name_metadata }}
           path: consumer-artifacts/metadata
@@ -712,13 +712,13 @@ jobs:
       STORAGE_INSTANCE_ID: ci-readonly-smoke
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Build dbt-nova CLI binary
         run: cargo build --locked --bin dbt-nova
@@ -734,13 +734,13 @@ jobs:
           sudo apt-get install -y jq
 
       - name: Download storage artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ needs.reusable-assets-producer.outputs.artifact_name_storage }}
           path: remote-consumer-artifacts/storage
 
       - name: Download metadata artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ needs.reusable-assets-producer.outputs.artifact_name_metadata }}
           path: remote-consumer-artifacts/metadata
@@ -839,13 +839,13 @@ jobs:
       STORAGE_INSTANCE_ID: ci-semantic-smoke
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Build dbt-nova CLI binary
         run: cargo build --locked --bin dbt-nova
@@ -861,19 +861,19 @@ jobs:
           sudo apt-get install -y jq
 
       - name: Download storage artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ needs.reusable-assets-semantic-producer.outputs.artifact_name_storage }}
           path: semantic-consumer-artifacts/storage
 
       - name: Download metadata artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ needs.reusable-assets-semantic-producer.outputs.artifact_name_metadata }}
           path: semantic-consumer-artifacts/metadata
 
       - name: Download models artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ needs.reusable-assets-semantic-producer.outputs.artifact_name_models }}
           path: semantic-consumer-artifacts/models
@@ -1002,13 +1002,13 @@ jobs:
       STORAGE_INSTANCE_ID: ci-readonly-smoke
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Build dbt-nova CLI binary
         run: cargo build --locked --bin dbt-nova
@@ -1024,13 +1024,13 @@ jobs:
           sudo apt-get install -y jq
 
       - name: Download storage artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ needs.reusable-assets-producer.outputs.artifact_name_storage }}
           path: negative-artifacts/storage
 
       - name: Download metadata artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ needs.reusable-assets-producer.outputs.artifact_name_metadata }}
           path: negative-artifacts/metadata

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,15 +20,15 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: '3.12'
 
       - name: Cache pip dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-mkdocs-material-${{ hashFiles('docs/requirements.txt') }}
@@ -45,7 +45,7 @@ jobs:
         run: mkdocs build --strict
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: site
 
@@ -60,4 +60,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -18,13 +18,13 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Install Rust Nightly
         uses: dtolnay/rust-toolchain@0f1b44df7e9cbb178d781a242338dfa5e243ad7f
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
           shared-key: monthly-fuzz-nightly
           cache-all-crates: true
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7

--- a/.github/workflows/nova-build-assets.yml
+++ b/.github/workflows/nova-build-assets.yml
@@ -891,7 +891,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ${{ env.DBT_NOVA_EMBEDDINGS_CACHE_DIR }}
-          key: ${{ runner.os }}-${{ runner.arch }}-dbt-nova-models-${{ needs.prepare.outputs.installer_ref }}-${{ hashFiles('Cargo.lock', 'src/config/search.rs', 'src/manifest/embeddings/mod.rs', 'src/manifest/prebuilt_assets_resolver.rs', 'scripts/warm_models.sh') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-dbt-nova-models-${{ needs.prepare.outputs.installer_ref }}-${{ hashFiles('Cargo.lock', 'src/config/search.rs', 'src/manifest/embeddings/mod.rs', 'src/manifest/prebuilt_assets_resolver.rs', 'scripts/warm_models.sh', '.nova-installer-source/Cargo.lock', '.nova-installer-source/src/config/search.rs', '.nova-installer-source/src/manifest/embeddings/mod.rs', '.nova-installer-source/src/manifest/prebuilt_assets_resolver.rs', '.nova-installer-source/scripts/warm_models.sh') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-dbt-nova-models-
 

--- a/.github/workflows/nova-build-assets.yml
+++ b/.github/workflows/nova-build-assets.yml
@@ -657,37 +657,39 @@ jobs:
             artifact_name_models="${artifact_name_prefix}-models-${run_suffix}"
           fi
 
-          echo "artifact_name_storage=${artifact_name_storage}" >> "$GITHUB_OUTPUT"
-          echo "artifact_name_models=${artifact_name_models}" >> "$GITHUB_OUTPUT"
-          echo "storage_dir=${storage_dir}" >> "$GITHUB_OUTPUT"
-          echo "models_dir=${models_dir}" >> "$GITHUB_OUTPUT"
-          echo "manifest_path=${manifest_path}" >> "$GITHUB_OUTPUT"
-          echo "manifest_uri=${manifest_uri}" >> "$GITHUB_OUTPUT"
-          echo "storage_instance_id=${storage_instance_id}" >> "$GITHUB_OUTPUT"
-          echo "installer_repository=${installer_repository}" >> "$GITHUB_OUTPUT"
-          echo "installer_ref=${installer_ref}" >> "$GITHUB_OUTPUT"
-          echo "installer_install_mode=${installer_install_mode}" >> "$GITHUB_OUTPUT"
-          echo "publish_targets=${publish_targets_normalized}" >> "$GITHUB_OUTPUT"
-          echo "publish_s3_prefix=${publish_s3_prefix}" >> "$GITHUB_OUTPUT"
-          echo "publish_gcs_prefix=${publish_gcs_prefix}" >> "$GITHUB_OUTPUT"
-          echo "gcp_workload_identity_provider=${gcp_workload_identity_provider}" >> "$GITHUB_OUTPUT"
-          echo "gcp_service_account=${gcp_service_account}" >> "$GITHUB_OUTPUT"
-          echo "gcp_project_id=${gcp_project_id}" >> "$GITHUB_OUTPUT"
-          echo "publish_dbfs_prefix=${publish_dbfs_prefix}" >> "$GITHUB_OUTPUT"
-          echo "publish_dry_run=${publish_dry_run}" >> "$GITHUB_OUTPUT"
-          echo "models_distribution_mode=${models_distribution_mode}" >> "$GITHUB_OUTPUT"
-          echo "publish_models_archive=${publish_models_archive}" >> "$GITHUB_OUTPUT"
-          echo "include_models_in_bootstrap=${include_models_in_bootstrap}" >> "$GITHUB_OUTPUT"
-          echo "search_warm_strategy=${search_warm_strategy}" >> "$GITHUB_OUTPUT"
-          echo "search_onnx_threads=${search_onnx_threads}" >> "$GITHUB_OUTPUT"
-          echo "search_embedding_batch_size=${search_embedding_batch_size}" >> "$GITHUB_OUTPUT"
-          echo "search_sparse_embedding_batch_size=${search_sparse_embedding_batch_size}" >> "$GITHUB_OUTPUT"
-          echo "build_timeout_minutes=${build_timeout_minutes}" >> "$GITHUB_OUTPUT"
-          echo "dbt_env_json=${dbt_env_json}" >> "$GITHUB_OUTPUT"
-          echo "dbt_secret_env_map_json=${dbt_secret_env_map_json}" >> "$GITHUB_OUTPUT"
-          echo "dbt_invocation_mode=${dbt_invocation_mode}" >> "$GITHUB_OUTPUT"
-          echo "dbt_command_args_json=${dbt_command_args_json}" >> "$GITHUB_OUTPUT"
-          echo "dbt_executable=${dbt_executable}" >> "$GITHUB_OUTPUT"
+          {
+            echo "artifact_name_storage=${artifact_name_storage}"
+            echo "artifact_name_models=${artifact_name_models}"
+            echo "storage_dir=${storage_dir}"
+            echo "models_dir=${models_dir}"
+            echo "manifest_path=${manifest_path}"
+            echo "manifest_uri=${manifest_uri}"
+            echo "storage_instance_id=${storage_instance_id}"
+            echo "installer_repository=${installer_repository}"
+            echo "installer_ref=${installer_ref}"
+            echo "installer_install_mode=${installer_install_mode}"
+            echo "publish_targets=${publish_targets_normalized}"
+            echo "publish_s3_prefix=${publish_s3_prefix}"
+            echo "publish_gcs_prefix=${publish_gcs_prefix}"
+            echo "gcp_workload_identity_provider=${gcp_workload_identity_provider}"
+            echo "gcp_service_account=${gcp_service_account}"
+            echo "gcp_project_id=${gcp_project_id}"
+            echo "publish_dbfs_prefix=${publish_dbfs_prefix}"
+            echo "publish_dry_run=${publish_dry_run}"
+            echo "models_distribution_mode=${models_distribution_mode}"
+            echo "publish_models_archive=${publish_models_archive}"
+            echo "include_models_in_bootstrap=${include_models_in_bootstrap}"
+            echo "search_warm_strategy=${search_warm_strategy}"
+            echo "search_onnx_threads=${search_onnx_threads}"
+            echo "search_embedding_batch_size=${search_embedding_batch_size}"
+            echo "search_sparse_embedding_batch_size=${search_sparse_embedding_batch_size}"
+            echo "build_timeout_minutes=${build_timeout_minutes}"
+            echo "dbt_env_json=${dbt_env_json}"
+            echo "dbt_secret_env_map_json=${dbt_secret_env_map_json}"
+            echo "dbt_invocation_mode=${dbt_invocation_mode}"
+            echo "dbt_command_args_json=${dbt_command_args_json}"
+            echo "dbt_executable=${dbt_executable}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Summarize contract
         shell: bash
@@ -764,7 +766,7 @@ jobs:
       DBT_NOVA_SEARCH_SPARSE_EMBEDDING_BATCH_SIZE: ${{ needs.prepare.outputs.search_sparse_embedding_batch_size }}
     steps:
       - name: Checkout caller repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Install jq
         shell: bash
@@ -845,7 +847,7 @@ jobs:
 
       - name: Checkout installer source
         if: ${{ needs.prepare.outputs.installer_install_mode == 'source' || (needs.prepare.outputs.installer_install_mode == 'auto' && steps.install_release.outputs.installed != 'true') }}
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           repository: ${{ needs.prepare.outputs.installer_repository }}
           ref: ${{ needs.prepare.outputs.installer_ref }}
@@ -870,7 +872,7 @@ jobs:
 
       - name: Rust cache (installer source)
         if: ${{ needs.prepare.outputs.installer_install_mode == 'source' || (needs.prepare.outputs.installer_install_mode == 'auto' && steps.install_release.outputs.installed != 'true') }}
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
           workspaces: ".nova-installer-source -> target"
 
@@ -883,6 +885,38 @@ jobs:
           mkdir -p "$HOME/.local/bin"
           install -m 755 .nova-installer-source/target/release/dbt-nova "$HOME/.local/bin/dbt-nova"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Cache semantic model snapshots
+        if: ${{ needs.prepare.outputs.publish_models_archive == 'true' }}
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: ${{ env.DBT_NOVA_EMBEDDINGS_CACHE_DIR }}
+          key: ${{ runner.os }}-${{ runner.arch }}-dbt-nova-models-${{ needs.prepare.outputs.installer_ref }}-${{ hashFiles('Cargo.lock', 'src/config/search.rs', 'src/manifest/embeddings/mod.rs', 'src/manifest/prebuilt_assets_resolver.rs', 'scripts/warm_models.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-dbt-nova-models-
+
+      - name: Seed semantic model snapshots
+        if: ${{ needs.prepare.outputs.publish_models_archive == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          warm_script=""
+          if [[ -f ".nova-installer-source/scripts/warm_models.sh" ]]; then
+            warm_script=".nova-installer-source/scripts/warm_models.sh"
+          elif [[ -f "scripts/warm_models.sh" ]]; then
+            warm_script="scripts/warm_models.sh"
+          fi
+
+          if [[ -z "${warm_script}" ]]; then
+            echo "No warm_models.sh script available; manifest warm will seed models if needed."
+            exit 0
+          fi
+
+          if ! DBT_NOVA_WARMUP_FALLBACK_FROM_RELEASE=0 \
+            DBT_NOVA_WARMUP_REQUIRED_MODELS=3 \
+            bash "${warm_script}" partial; then
+            echo "::warning::semantic model pre-seed failed; manifest warm will retry direct initialization"
+          fi
 
       - name: Optionally generate manifest via dbt
         if: ${{ inputs.dbt_generate_manifest }}
@@ -1004,6 +1038,34 @@ jobs:
           set -euo pipefail
           mkdir -p out
 
+          run_json_with_retry() {
+            local label="$1"
+            local output_path="$2"
+            shift 2
+            local attempt=1
+            local max_attempts=4
+            local delay_secs=15
+            local exit_code
+
+            while true; do
+              set +e
+              "$@" | tee "${output_path}"
+              exit_code="${PIPESTATUS[0]}"
+              set -e
+              if [[ "${exit_code}" -eq 0 ]]; then
+                return 0
+              fi
+              if [[ "${attempt}" -ge "${max_attempts}" ]]; then
+                echo "${label} failed after ${attempt} attempt(s)." >&2
+                return "${exit_code}"
+              fi
+              echo "::warning::${label} failed on attempt ${attempt}/${max_attempts}; retrying in ${delay_secs}s"
+              sleep "${delay_secs}"
+              attempt=$((attempt + 1))
+              delay_secs=$((delay_secs * 2))
+            done
+          }
+
           manifest_path="${INPUT_MANIFEST_PATH}"
           manifest_uri="${INPUT_MANIFEST_URI}"
           if [[ -z "${manifest_path}" && -z "${manifest_uri}" ]]; then
@@ -1022,15 +1084,18 @@ jobs:
 
           if [[ "${INPUT_PUBLISH_MODELS_ARCHIVE}" == "true" ]]; then
             if [[ "${INPUT_SEARCH_WARM_STRATEGY}" == "staged" ]]; then
-              dbt-nova manifest warm "${manifest_args[@]}" --storage-instance-id "${DBT_NOVA_STORAGE_INSTANCE_ID}" --vector --json | tee out/manifest-warm-vector.json
+              run_json_with_retry "manifest warm vector" out/manifest-warm-vector.json \
+                dbt-nova manifest warm "${manifest_args[@]}" --storage-instance-id "${DBT_NOVA_STORAGE_INSTANCE_ID}" --vector --json
               jq -e '.status == "success"' out/manifest-warm-vector.json >/dev/null
               jq -e '.data.persisted.vector == true and .data.ready.vector == true' out/manifest-warm-vector.json >/dev/null
 
-              dbt-nova manifest warm "${manifest_args[@]}" --storage-instance-id "${DBT_NOVA_STORAGE_INSTANCE_ID}" --sparse --json | tee out/manifest-warm-sparse.json
+              run_json_with_retry "manifest warm sparse" out/manifest-warm-sparse.json \
+                dbt-nova manifest warm "${manifest_args[@]}" --storage-instance-id "${DBT_NOVA_STORAGE_INSTANCE_ID}" --sparse --json
               jq -e '.status == "success"' out/manifest-warm-sparse.json >/dev/null
               jq -e '.data.persisted.sparse == true and .data.ready.sparse == true' out/manifest-warm-sparse.json >/dev/null
 
-              dbt-nova manifest warm "${manifest_args[@]}" --storage-instance-id "${DBT_NOVA_STORAGE_INSTANCE_ID}" --reranker --json | tee out/manifest-warm-reranker.json
+              run_json_with_retry "manifest warm reranker" out/manifest-warm-reranker.json \
+                dbt-nova manifest warm "${manifest_args[@]}" --storage-instance-id "${DBT_NOVA_STORAGE_INSTANCE_ID}" --reranker --json
               jq -e '.status == "success"' out/manifest-warm-reranker.json >/dev/null
               jq -e '.data.ready.reranker == true' out/manifest-warm-reranker.json >/dev/null
 
@@ -1054,7 +1119,8 @@ jobs:
                   }
                 }' > out/manifest-warm.json
             else
-              dbt-nova manifest warm "${manifest_args[@]}" --storage-instance-id "${DBT_NOVA_STORAGE_INSTANCE_ID}" --vector --sparse --reranker --json | tee out/manifest-warm.json
+              run_json_with_retry "manifest warm full" out/manifest-warm.json \
+                dbt-nova manifest warm "${manifest_args[@]}" --storage-instance-id "${DBT_NOVA_STORAGE_INSTANCE_ID}" --vector --sparse --reranker --json
               jq -e '.status == "success"' out/manifest-warm.json >/dev/null
               jq -e '.data.persisted.vector == true and .data.persisted.sparse == true and .data.ready.vector == true and .data.ready.sparse == true and .data.ready.reranker == true' out/manifest-warm.json >/dev/null
             fi
@@ -1171,17 +1237,19 @@ jobs:
             (.artifact_name_models | type == "string")
           ' "${metadata_path}" >/dev/null
 
-          echo "manifest_hash=${manifest_hash}" >> "$GITHUB_OUTPUT"
-          echo "manifest_version=${manifest_version}" >> "$GITHUB_OUTPUT"
-          echo "entity_count=${entity_count}" >> "$GITHUB_OUTPUT"
-          echo "artifact_name_storage=${artifact_name_storage}" >> "$GITHUB_OUTPUT"
-          echo "artifact_name_models=${artifact_name_models}" >> "$GITHUB_OUTPUT"
-          echo "artifact_name_metadata=${artifact_name_metadata}" >> "$GITHUB_OUTPUT"
-          echo "artifact_name_manifest=${artifact_name_manifest}" >> "$GITHUB_OUTPUT"
-          echo "artifact_name_bootstrap=${artifact_name_bootstrap}" >> "$GITHUB_OUTPUT"
-          echo "artifact_name_publish_summary=${artifact_name_publish_summary}" >> "$GITHUB_OUTPUT"
-          echo "metadata_path=${metadata_path}" >> "$GITHUB_OUTPUT"
-          echo "manifest_export_path=${manifest_export_path}" >> "$GITHUB_OUTPUT"
+          {
+            echo "manifest_hash=${manifest_hash}"
+            echo "manifest_version=${manifest_version}"
+            echo "entity_count=${entity_count}"
+            echo "artifact_name_storage=${artifact_name_storage}"
+            echo "artifact_name_models=${artifact_name_models}"
+            echo "artifact_name_metadata=${artifact_name_metadata}"
+            echo "artifact_name_manifest=${artifact_name_manifest}"
+            echo "artifact_name_bootstrap=${artifact_name_bootstrap}"
+            echo "artifact_name_publish_summary=${artifact_name_publish_summary}"
+            echo "metadata_path=${metadata_path}"
+            echo "manifest_export_path=${manifest_export_path}"
+          } >> "$GITHUB_OUTPUT"
 
           {
             echo "### Build Metadata Contract"
@@ -1202,7 +1270,7 @@ jobs:
           tar -C "$(dirname "${DBT_NOVA_STORAGE_DIR}")" -czf "${storage_archive}" "$(basename "${DBT_NOVA_STORAGE_DIR}")"
 
       - name: Upload storage artifact
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ steps.collect.outputs.artifact_name_storage }}
           path: ${{ steps.collect.outputs.artifact_name_storage }}.tar.gz
@@ -1210,7 +1278,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload build metadata artifact
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ steps.collect.outputs.artifact_name_metadata }}
           path: ${{ steps.collect.outputs.metadata_path }}
@@ -1218,7 +1286,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload manifest artifact
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ steps.collect.outputs.artifact_name_manifest }}
           path: ${{ steps.collect.outputs.manifest_export_path }}
@@ -1264,7 +1332,7 @@ jobs:
 
       - name: Upload models artifact
         if: ${{ needs.prepare.outputs.publish_models_archive == 'true' }}
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ steps.collect.outputs.artifact_name_models }}
           path: ${{ steps.collect.outputs.artifact_name_models }}.tar.gz
@@ -1274,7 +1342,7 @@ jobs:
       - name: Authenticate to Google Cloud for GCS publish
         id: gcp_auth
         if: ${{ contains(needs.prepare.outputs.publish_targets, 'gcs') && needs.prepare.outputs.gcp_workload_identity_provider != '' && needs.prepare.outputs.gcp_service_account != '' }}
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
         with:
           workload_identity_provider: ${{ needs.prepare.outputs.gcp_workload_identity_provider }}
           service_account: ${{ needs.prepare.outputs.gcp_service_account }}
@@ -1285,7 +1353,7 @@ jobs:
 
       - name: Set up gcloud for GCS publish
         if: ${{ contains(needs.prepare.outputs.publish_targets, 'gcs') && needs.prepare.outputs.gcp_workload_identity_provider != '' && needs.prepare.outputs.gcp_service_account != '' }}
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
         with:
           project_id: ${{ needs.prepare.outputs.gcp_project_id }}
 
@@ -2121,7 +2189,7 @@ jobs:
 
       - name: Upload bootstrap contract artifact
         if: ${{ steps.publish.outputs.published_targets != '' }}
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ steps.collect.outputs.artifact_name_bootstrap }}
           path: out/bootstrap/*.json
@@ -2129,7 +2197,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload publish summary artifact
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ steps.collect.outputs.artifact_name_publish_summary }}
           path: ${{ steps.publish.outputs.publish_summary_path }}

--- a/.github/workflows/nova-metadata-audit.yml
+++ b/.github/workflows/nova-metadata-audit.yml
@@ -528,7 +528,7 @@ jobs:
       DBT_NOVA_COLUMN_LINEAGE_PRECOMPUTE: "false"
     steps:
       - name: Checkout caller repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           fetch-depth: 0
 
@@ -594,7 +594,7 @@ jobs:
 
       - name: Checkout installer source
         if: ${{ needs.prepare.outputs.installer_install_mode == 'source' || (needs.prepare.outputs.installer_install_mode == 'auto' && steps.install_release.outputs.installed != 'true') }}
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           repository: ${{ needs.prepare.outputs.installer_repository }}
           ref: ${{ needs.prepare.outputs.installer_ref }}
@@ -607,7 +607,7 @@ jobs:
 
       - name: Rust cache (installer source)
         if: ${{ needs.prepare.outputs.installer_install_mode == 'source' || (needs.prepare.outputs.installer_install_mode == 'auto' && steps.install_release.outputs.installed != 'true') }}
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
           workspaces: ".nova-installer-source -> target"
 
@@ -845,7 +845,7 @@ jobs:
 
       - name: Upload JSON report artifact
         if: ${{ always() && hashFiles('out/metadata-audit-report.json') != '' }}
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ needs.prepare.outputs.artifact_name_report_json }}
           path: out/metadata-audit-report.json
@@ -853,7 +853,7 @@ jobs:
 
       - name: Upload Markdown report artifact
         if: ${{ always() && hashFiles('out/metadata-audit-report.md') != '' }}
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ needs.prepare.outputs.artifact_name_report_md }}
           path: out/metadata-audit-report.md
@@ -861,7 +861,7 @@ jobs:
 
       - name: Upload CLI output artifact
         if: ${{ always() && hashFiles('out/metadata-audit-cli.json') != '' }}
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ needs.prepare.outputs.artifact_name_report_json }}-cli
           path: out/metadata-audit-cli.json

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -28,7 +28,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TAG_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           fetch-depth: 0
 
@@ -127,7 +127,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           ref: ${{ needs.validate.outputs.release_tag }}
 
@@ -206,7 +206,7 @@ jobs:
             dbt-nova-${{ matrix.asset }}.sbom.spdx.json
 
       - name: Publish release assets
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
           tag_name: ${{ needs.validate.outputs.release_tag }}
           body_path: RELEASE_NOTES.md
@@ -234,7 +234,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           fetch-depth: 0
 
@@ -248,10 +248,12 @@ jobs:
           image="ghcr.io/${GITHUB_REPOSITORY,,}"
           git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
           commit_sha="$(git rev-list -n1 "${RELEASE_TAG}")"
-          echo "image=${image}" >> "$GITHUB_OUTPUT"
-          echo "commit_sha=${commit_sha}" >> "$GITHUB_OUTPUT"
-          echo "amd64_tag=${image}:sha-${commit_sha}-amd64" >> "$GITHUB_OUTPUT"
-          echo "arm64_tag=${image}:sha-${commit_sha}-arm64" >> "$GITHUB_OUTPUT"
+          {
+            echo "image=${image}"
+            echo "commit_sha=${commit_sha}"
+            echo "amd64_tag=${image}:sha-${commit_sha}-amd64"
+            echo "arm64_tag=${image}:sha-${commit_sha}-arm64"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
@@ -391,7 +393,7 @@ jobs:
           timeout: 10m
 
       - name: Publish OCI scan report
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
           tag_name: ${{ needs.validate.outputs.release_tag }}
           overwrite_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Hardened CI workflows by caching reusable semantic model snapshots during
+  model artifact builds and upgrading maintained GitHub Actions to Node
+  24-compatible pinned releases.
 - Added Snowflake SQL provider support (`DBT_NOVA_SQL_PROVIDER=snowflake`) via
   the Snowflake SQL API, including key-pair JWT, OAuth, and programmatic access
   token auth, named parameter binding, partitioned result fetching, cancellation


### PR DESCRIPTION
## Summary

- Add a reusable-workflow semantic model cache for runs that publish model artifacts.
- Key the cache by runner, resolved dbt-nova installer ref, and semantic/cache source files from both the caller checkout and checked-out installer source, with broad restore keys so PRs can reuse default-branch warmed snapshots.
- Add a cold-cache hardening path: best-effort semantic model pre-seeding via `scripts/warm_models.sh` when installer source is available, plus exponential retry around each `dbt-nova manifest warm` stage.
- Upgrade maintained workflow actions to Node 24-compatible pinned SHAs and pin existing Google workflow actions that were still floating on version tags.
- Keep semantic consumer smoke tests isolated: they still materialize models into a fresh temp `DBT_NOVA_EMBEDDINGS_CACHE_DIR` from the produced models artifact.

## Root Cause

Recent post-merge CI needed manual reruns because the semantic asset producer repeatedly fetched Hugging Face model files live and hit HTTP 429 throttling. The first PR run reproduced that exact failure on a cold cache. Caching helps after one successful warm, but the workflow also needs a resilient cold-cache path.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/docs.yml .github/workflows/monthly.yml .github/workflows/nova-build-assets.yml .github/workflows/nova-metadata-audit.yml .github/workflows/release.yml .github/workflows/release-prepare.yml .github/workflows/release-tag.yml`
- `git diff --check`
- `rg -n "node20|node16|node12|uses: .+@v[0-9]" .github/workflows || true`
- Fresh PR CI on `a23ae79`: all 34 checks passed, including `reusable-assets-semantic-producer` and `reusable-assets-semantic-remote-consumer-smoke`.

Refs JOE-139.
