### PR TITLE
Add agent-ready metadata diagnostics and summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Agent-readiness reports now include advisory `suggested_meta_patches` for
   reviewable `meta.nova` remediation and draft `golden_question_seeds` for
   turning readiness gaps into eval backlog candidates.
+- Metadata scoring now returns a shared `metadata_score_contract.v1` scoring
+  contract plus machine-readable diagnostics for description tiers, array-count
+  tier progress, invalid Nova grain shapes, and primary-key integrity test gaps.
+- Metadata score, metadata audit, agent-readiness, and modelling consistency
+  outputs now include compact agent triage summaries with score/grade buckets,
+  weak spots, repeated recommendation fields, bounded examples, and drill-down
+  hints for fetching detailed rows intentionally.
 - Added the `get_agent_readiness` MCP tool and CLI `tool call` bridge support
   for the same `agent_readiness.v1` report without CLI report-file writes.
 - Added the `get_metadata_audit` MCP tool and CLI `tool call` bridge support

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -344,6 +344,11 @@ Common:
 {"name":"modelling_consistency_report","arguments":{"resource_types":["model"],"limit":20}}
 ```
 
+Responses include a compact `summary` with section counts, top duplicate
+indicator groups, top canonical conflicts, overlap evidence category counts,
+bounded overlap examples, multi-grain entity highlights, and drill-down hints.
+The existing detail arrays remain paged by `limit` and `offset`.
+
 ### `get_entity`
 Fetch a single entity by `unique_id` or name.
 
@@ -660,8 +665,14 @@ Optional:
 - `limit` (project scope)
 - `offset` (project scope pagination)
 
-Project scope responses include `quality_summary.test_coverage`, aggregated
-across the returned entities and use deterministic ordering for pagination.
+Responses include `scoring_contract` metadata describing grade bands,
+description tiers, array-count tiers, canonical grain shape, and primary-key
+integrity evidence rules. Entity and column scope responses include
+`diagnostics` rows for partial or missing credit. Project scope responses include
+`quality_summary.test_coverage`, aggregated across the returned entities, plus
+`summary` scope/paging metadata, buckets, weak spots, repeated recommendation
+fields, and drill-down hints. Project rows use deterministic ordering for
+pagination.
 
 ```json
 {"name":"get_metadata_score","arguments":{"id_or_name":"model.jaffle_shop.orders","persona":"analyst","scope":"entity"}}
@@ -690,6 +701,9 @@ Optional:
 
 Required threshold failures are returned in `data.gate_status` and
 `data.summary`; they do not become MCP transport errors.
+`data.summary` also includes score/grade buckets, worst entities by persona,
+category weak spots, repeated recommendation fields with estimated impact, and
+drill-down hints.
 
 ```json
 {"name":"get_metadata_audit","arguments":{"selection_mode":"changed","changed_files_json":"[\"models/marts/orders.sql\"]"}}
@@ -711,7 +725,9 @@ The tool returns the same `agent_readiness.v1` report contract as
 CLI exit semantics. Reports include advisory `suggested_meta_patches` for
 reviewable dbt metadata remediation and draft `golden_question_seeds` for eval
 authoring. Suggested patches never edit files, and generated seeds should be
-reviewed before becoming CI gates.
+reviewed before becoming CI gates. Reports also include the shared metadata
+`scoring_contract` and compact `summary` triage fields for score buckets, weak
+spots, repeated fields, and drill-down hints.
 
 Large reports use the standard MCP response-budget behavior; check
 `_nova_result_meta.truncated` when response budgeting is enabled.

--- a/docs/features/agent-readiness.md
+++ b/docs/features/agent-readiness.md
@@ -92,10 +92,16 @@ JSON reports use `schema_version: "agent_readiness.v1"` and include:
 - sanitized manifest source, hash, version, entity counts, and search readiness
 - personas, selected resource types, thresholds, storage mode, and metadata-only
   mode
+- `scoring_contract` with the metadata score grade bands, description tiers,
+  array tiers, canonical grain shape, and primary-key integrity evidence rules
 - overall readiness score, grade, readiness band, and gate status
 - per-persona project metadata scores and threshold status
+- compact triage fields in `summary`: score/grade buckets, worst entities by
+  persona, category weak spots, repeated recommendation fields, estimated point
+  impact, and drill-down hints
 - blocking findings and improvement findings
-- lowest-scoring or signal-poor entity findings with top recommendations
+- lowest-scoring or signal-poor entity findings with top recommendations and
+  metadata score diagnostics
 - ambiguous Nova indicator definitions that need stronger execution metadata
 - advisory `suggested_meta_patches` for missing or weak `meta`, `meta.nova`,
   and column metadata fields
@@ -129,6 +135,12 @@ Suggestions stay conservative. For example, missing ownership produces a
 placeholder owner suggestion rather than a fabricated person, and ambiguous
 metrics ask for expression/canonical clarification rather than inventing ground
 truth.
+
+Suggestions consume metadata score diagnostics where available. For example, a
+string-valued `meta.nova.grain` produces an `invalid_grain_shape` diagnostic and
+a whole-object `meta.nova.grain` suggestion using the canonical
+`primary_key`/`time_field`/`dimensions` shape, rather than suggesting unsafe
+nested edits under a non-object value.
 
 ## Golden-Question Seeds
 

--- a/docs/features/metadata-audit.md
+++ b/docs/features/metadata-audit.md
@@ -87,17 +87,22 @@ Rules:
 JSON reports include:
 
 - manifest hash/version
+- `scoring_contract` with grade bands, description tiers, array tiers, canonical
+  grain shape, and primary-key integrity evidence rules
 - selected entities
 - per-persona scores
 - per-category breakdowns
 - recommendations
-- gate summary
+- gate summary plus agent triage fields under `summary`: score/grade buckets,
+  worst entities by persona, category weak spots, repeated recommendation
+  fields, estimated point impact, and drill-down hints
 
 Markdown reports include:
 
 - overall gate status
 - scored target count
 - pass/fail counts
+- compact triage summary for weak spots and repeated fields
 - compact per-entity table
 - top findings for failing entities
 

--- a/docs/features/metadata-scoring.md
+++ b/docs/features/metadata-scoring.md
@@ -50,12 +50,14 @@ Notes:
     "persona": "analyst",
     "overall_score": 72,
     "grade": "C",
+    "scoring_contract": { "schema_version": "metadata_score_contract.v1" },
     "categories": {
       "documentation": { "score": 85, "weight": 0.20, "weighted": 17.0 },
       "semantic": { "score": 65, "weight": 0.45, "weighted": 29.25 },
       "governance": { "score": 40, "weight": 0.15, "weighted": 6.0 },
       "quality": { "score": 98, "weight": 0.20, "weighted": 19.6 }
     },
+    "diagnostics": [ /* machine-readable scoring evidence */ ],
     "breakdown": { /* per-check detail */ },
     "recommendations": [ /* suggestions */ ]
   }
@@ -66,6 +68,37 @@ For `scope=project`, the tool returns an overall score and a list of scored
 entities, honoring `limit` and marking responses as `truncated` when needed.
 It also returns `quality_summary.test_coverage`, aggregated across the
 returned entities (or all entities when not truncated).
+
+All scopes include `scoring_contract.schema_version:
+"metadata_score_contract.v1"` so agents can explain scores without reading
+source code. The contract includes grade bands, description tiers, array-count
+tiers, canonical grain shape, and the primary-key integrity evidence rule.
+
+Entity and column responses include `diagnostics` when Nova can explain partial
+or missing credit. Diagnostics are deterministic JSON rows with `code`,
+`category`, `field`, observed values, expected thresholds, and a short message.
+Common diagnostic codes:
+
+- `description_tier_progress`: shows observed character count, the 50-character
+  good-enough threshold, and the 100-character full-credit threshold
+- `array_tier_progress`: shows current count, next useful count, full-credit
+  count, score, and max points for tiered arrays
+- `invalid_grain_shape`: identifies `meta.nova.grain`, `meta.nova.metric.grain`,
+  or `meta.nova.metrics[].grain` values that are strings, empty objects, or
+  otherwise not canonical grain objects
+- `primary_key_integrity_missing_tests`: names the primary key column and the
+  missing `unique` or `not_null` dbt manifest test evidence; Nova does not infer
+  uniqueness from compiled SQL or warehouse introspection
+
+Project scope responses include `summary` for agent triage:
+
+- `scope`, `entities`, `entities_total`, `truncated`, and `page` so agents know
+  whether the summary covers all matching entities or only the returned page
+- `score_buckets` and `grade_buckets`
+- `worst_entities`
+- `category_weak_spots`
+- `top_recommendation_fields` with estimated point impact where available
+- `drill_down_hints` with exact `get_metadata_score` calls for detailed follow-up
 
 ## Scoring Model
 
@@ -181,6 +214,7 @@ The overall column score is still weighted by persona category weights.
 - sorts selected `resource_types` and entity IDs deterministically
 - scores entities using `limit` + `offset` paging
 - returns an overall average and per‑entity results
+- returns compact summary buckets and drill-down hints for agent triage
 - sets `truncated: true` if `offset + count < total_available`
 
 ## Examples

--- a/src/cli/agent_readiness_cmd.rs
+++ b/src/cli/agent_readiness_cmd.rs
@@ -17,7 +17,7 @@ use crate::manifest::entity::{
 use crate::manifest::search::ManifestSearch;
 use crate::params::{GetAgentReadinessParams, GetMetadataScoreParams};
 use crate::responses::SuccessResponse;
-use crate::tools::metadata_score::grade_from_score;
+use crate::tools::metadata_score::{grade_from_score, metadata_score_scoring_contract};
 use crate::utils::{SearchPersona, sanitize_uri};
 
 use super::{DispatchError, DispatchResult};
@@ -46,6 +46,7 @@ struct AgentReadinessReport {
     generated_at_ms: u128,
     manifest: ReadinessManifestSummary,
     config: ReadinessConfigSummary,
+    scoring_contract: JsonValue,
     overall_score: u8,
     grade: String,
     readiness_band: &'static str,
@@ -100,6 +101,12 @@ struct ReadinessSummary {
     ambiguous_indicator_count: usize,
     suggested_meta_patch_count: usize,
     golden_question_seed_count: usize,
+    score_buckets: JsonValue,
+    grade_buckets: JsonValue,
+    worst_entities_by_persona: JsonValue,
+    category_weak_spots: JsonValue,
+    top_recommendation_fields: JsonValue,
+    drill_down_hints: JsonValue,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -111,6 +118,7 @@ struct PersonaReadinessScore {
     scored_count: usize,
     total_available: usize,
     quality_summary: JsonValue,
+    metadata_summary: JsonValue,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -132,6 +140,7 @@ struct EntityReadinessFinding {
     grade: String,
     persona_scores: BTreeMap<String, u8>,
     signals: EntityReadinessSignals,
+    diagnostics: JsonValue,
     recommendations: Vec<ReadinessRecommendation>,
 }
 
@@ -158,6 +167,11 @@ struct ReadinessRecommendation {
     impact: Option<u8>,
     field: Option<String>,
     message: String,
+}
+
+struct EntityScoreEvidence {
+    diagnostics: JsonValue,
+    recommendations: Vec<ReadinessRecommendation>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -566,12 +580,14 @@ async fn build_agent_readiness_report(
         suggested_meta_patches.len(),
         golden_question_seeds.len(),
     );
+    let triage_summary = build_readiness_triage_summary(&persona_scores);
 
     Ok(AgentReadinessReport {
         schema_version: "agent_readiness.v1",
         generated_at_ms: current_timestamp_ms(),
         manifest: build_manifest_summary(search),
         config: build_config_summary(search, inputs, &resource_types),
+        scoring_contract: metadata_score_scoring_contract(),
         overall_score,
         grade: grade.to_string(),
         readiness_band,
@@ -585,6 +601,12 @@ async fn build_agent_readiness_report(
             ambiguous_indicator_count,
             suggested_meta_patch_count: suggested_meta_patches.len(),
             golden_question_seed_count: golden_question_seeds.len(),
+            score_buckets: triage_summary.score_buckets,
+            grade_buckets: triage_summary.grade_buckets,
+            worst_entities_by_persona: triage_summary.worst_entities_by_persona,
+            category_weak_spots: triage_summary.category_weak_spots,
+            top_recommendation_fields: triage_summary.top_recommendation_fields,
+            drill_down_hints: triage_summary.drill_down_hints,
         },
         persona_scores,
         blocking_findings,
@@ -704,7 +726,7 @@ async fn score_project_personas(
             persona: Some(persona.clone()),
             scope: Some("project".to_string()),
             include_breakdown: false,
-            include_recommendations: false,
+            include_recommendations: true,
             resource_types: resource_types.to_vec(),
             limit: Some(target_count),
             offset: Some(0),
@@ -742,11 +764,186 @@ async fn score_project_personas(
                     .get("quality_summary")
                     .cloned()
                     .unwrap_or(JsonValue::Null),
+                metadata_summary: data.get("summary").cloned().unwrap_or(JsonValue::Null),
             },
         );
     }
 
     Ok((persona_scores, entity_scores))
+}
+
+struct ReadinessTriageSummary {
+    score_buckets: JsonValue,
+    grade_buckets: JsonValue,
+    worst_entities_by_persona: JsonValue,
+    category_weak_spots: JsonValue,
+    top_recommendation_fields: JsonValue,
+    drill_down_hints: JsonValue,
+}
+
+#[derive(Default)]
+struct ReadinessRecommendationAggregate {
+    categories: BTreeSet<String>,
+    count: usize,
+    total_impact: u64,
+}
+
+fn build_readiness_triage_summary(
+    persona_scores: &BTreeMap<String, PersonaReadinessScore>,
+) -> ReadinessTriageSummary {
+    let mut score_buckets = BTreeMap::new();
+    let mut grade_buckets = BTreeMap::new();
+    let mut worst_entities = Vec::new();
+    let mut category_weak_spots = Vec::new();
+    let mut drill_down_hints = Vec::new();
+    let mut recommendation_fields = BTreeMap::<String, ReadinessRecommendationAggregate>::new();
+
+    for (persona, score) in persona_scores {
+        if let Some(summary) = score.metadata_summary.as_object() {
+            score_buckets.insert(
+                persona.clone(),
+                summary
+                    .get("score_buckets")
+                    .cloned()
+                    .unwrap_or_else(|| json!({})),
+            );
+            grade_buckets.insert(
+                persona.clone(),
+                summary
+                    .get("grade_buckets")
+                    .cloned()
+                    .unwrap_or_else(|| json!({})),
+            );
+            append_persona_summary_rows(
+                persona,
+                summary.get("worst_entities").and_then(JsonValue::as_array),
+                &mut worst_entities,
+            );
+            append_persona_summary_rows(
+                persona,
+                summary
+                    .get("category_weak_spots")
+                    .and_then(JsonValue::as_array),
+                &mut category_weak_spots,
+            );
+            append_persona_summary_rows(
+                persona,
+                summary
+                    .get("drill_down_hints")
+                    .and_then(JsonValue::as_array),
+                &mut drill_down_hints,
+            );
+            ingest_readiness_recommendation_summary(
+                &mut recommendation_fields,
+                summary
+                    .get("top_recommendation_fields")
+                    .and_then(JsonValue::as_array),
+            );
+        }
+    }
+
+    category_weak_spots.sort_by(|left, right| {
+        json_f64(right, "estimated_weighted_point_gap")
+            .partial_cmp(&json_f64(left, "estimated_weighted_point_gap"))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    category_weak_spots.truncate(12);
+
+    let mut top_recommendation_fields = recommendation_fields
+        .into_iter()
+        .map(|(field, aggregate)| {
+            let categories = aggregate.categories.into_iter().collect::<Vec<_>>();
+            json!({
+                "field": field,
+                "categories": categories,
+                "count": aggregate.count,
+                "estimated_point_impact": aggregate.total_impact
+            })
+        })
+        .collect::<Vec<_>>();
+    top_recommendation_fields.sort_by(|left, right| {
+        right
+            .get("count")
+            .and_then(JsonValue::as_u64)
+            .cmp(&left.get("count").and_then(JsonValue::as_u64))
+            .then_with(|| {
+                right
+                    .get("estimated_point_impact")
+                    .and_then(JsonValue::as_u64)
+                    .cmp(
+                        &left
+                            .get("estimated_point_impact")
+                            .and_then(JsonValue::as_u64),
+                    )
+            })
+            .then_with(|| {
+                left.get("field")
+                    .and_then(JsonValue::as_str)
+                    .cmp(&right.get("field").and_then(JsonValue::as_str))
+            })
+    });
+    top_recommendation_fields.truncate(10);
+    drill_down_hints.truncate(10);
+
+    ReadinessTriageSummary {
+        score_buckets: serde_json::to_value(score_buckets).unwrap_or(JsonValue::Null),
+        grade_buckets: serde_json::to_value(grade_buckets).unwrap_or(JsonValue::Null),
+        worst_entities_by_persona: JsonValue::Array(worst_entities),
+        category_weak_spots: JsonValue::Array(category_weak_spots),
+        top_recommendation_fields: JsonValue::Array(top_recommendation_fields),
+        drill_down_hints: JsonValue::Array(drill_down_hints),
+    }
+}
+
+fn append_persona_summary_rows(
+    persona: &str,
+    rows: Option<&Vec<JsonValue>>,
+    out: &mut Vec<JsonValue>,
+) {
+    let Some(rows) = rows else {
+        return;
+    };
+    for row in rows.iter().take(5) {
+        let mut row = row.clone();
+        if let Some(obj) = row.as_object_mut() {
+            obj.entry("persona".to_string())
+                .or_insert_with(|| JsonValue::String(persona.to_string()));
+        }
+        out.push(row);
+    }
+}
+
+fn ingest_readiness_recommendation_summary(
+    aggregate: &mut BTreeMap<String, ReadinessRecommendationAggregate>,
+    rows: Option<&Vec<JsonValue>>,
+) {
+    let Some(rows) = rows else {
+        return;
+    };
+    for row in rows {
+        let field = row
+            .get("field")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("metadata")
+            .to_string();
+        let entry = aggregate.entry(field).or_default();
+        entry.count += row
+            .get("count")
+            .and_then(JsonValue::as_u64)
+            .and_then(|value| usize::try_from(value).ok())
+            .unwrap_or(0);
+        entry.total_impact += row
+            .get("estimated_point_impact")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0);
+        if let Some(category) = row.get("category").and_then(JsonValue::as_str) {
+            entry.categories.insert(category.to_string());
+        }
+    }
+}
+
+fn json_f64(value: &JsonValue, field: &str) -> f64 {
+    value.get(field).and_then(JsonValue::as_f64).unwrap_or(0.0)
 }
 
 fn ingest_project_entity_scores(
@@ -818,7 +1015,7 @@ async fn build_entity_findings(
         let score = entity_scores.get(&unique_id).ok_or_else(|| {
             DbtNovaError::ServerError(format!("missing entity score accumulator for {unique_id}"))
         })?;
-        let recommendations = entity_recommendations(search, &unique_id, score).await?;
+        let score_evidence = entity_score_evidence(search, &unique_id, score).await?;
         let grade = grade_from_score(average);
         let message = if average < 70 {
             format!("{unique_id} scored {average} ({grade}) across readiness personas")
@@ -846,18 +1043,19 @@ async fn build_entity_findings(
             grade: grade.to_string(),
             persona_scores: score.persona_scores.clone(),
             signals,
-            recommendations,
+            diagnostics: score_evidence.diagnostics,
+            recommendations: score_evidence.recommendations,
         });
     }
 
     Ok((entity_findings, improvements))
 }
 
-async fn entity_recommendations(
+async fn entity_score_evidence(
     search: &ManifestSearch,
     unique_id: &str,
     score: &EntityScoreAccumulator,
-) -> Result<Vec<ReadinessRecommendation>> {
+) -> Result<EntityScoreEvidence> {
     let persona = score
         .persona_scores
         .iter()
@@ -876,14 +1074,23 @@ async fn entity_recommendations(
     let data = result.get("data").ok_or_else(|| {
         DbtNovaError::ServerError("metadata score response missing data".to_string())
     })?;
-    let Some(recommendations) = data.get("recommendations").and_then(JsonValue::as_array) else {
-        return Ok(Vec::new());
-    };
-    Ok(recommendations
-        .iter()
-        .take(MAX_ENTITY_RECOMMENDATIONS)
-        .map(readiness_recommendation_from_json)
-        .collect())
+    let recommendations = data
+        .get("recommendations")
+        .and_then(JsonValue::as_array)
+        .map_or_else(Vec::new, |recommendations| {
+            recommendations
+                .iter()
+                .take(MAX_ENTITY_RECOMMENDATIONS)
+                .map(readiness_recommendation_from_json)
+                .collect()
+        });
+    Ok(EntityScoreEvidence {
+        diagnostics: data
+            .get("diagnostics")
+            .cloned()
+            .unwrap_or_else(|| JsonValue::Array(Vec::new())),
+        recommendations,
+    })
 }
 
 fn entity_signals(
@@ -1258,6 +1465,11 @@ fn append_grain_meta_patches(
     patches: &mut Vec<SuggestedMetaPatch>,
     seen: &mut BTreeSet<String>,
 ) {
+    if has_invalid_grain_diagnostic(&finding.diagnostics, "meta.nova.grain") {
+        append_invalid_grain_shape_patch(entity, entity_json, patches, seen);
+        return;
+    }
+
     let primary_keys = nova
         .and_then(|nova| nova.get("grain"))
         .and_then(|grain| grain.get("primary_key"))
@@ -1332,6 +1544,49 @@ fn append_grain_meta_patches(
             ),
         );
     }
+}
+
+fn append_invalid_grain_shape_patch(
+    entity: &ArchivedEntity,
+    entity_json: &JsonValue,
+    patches: &mut Vec<SuggestedMetaPatch>,
+    seen: &mut BTreeSet<String>,
+) {
+    let primary_key = infer_primary_key_column(entity_json).map_or_else(
+        || json!(["__PRIMARY_KEY_COLUMN__"]),
+        |column| json!([column]),
+    );
+    let time_field = infer_time_column(entity_json)
+        .map_or_else(|| json!("__TIME_FIELD__"), |column| json!(column));
+    push_meta_patch(
+        patches,
+        seen,
+        entity_patch(
+            entity,
+            MetaPatchTarget::Entity,
+            MetaPatchContent {
+                field_path: "meta.nova.grain",
+                suggested_value: json!({
+                    "primary_key": primary_key,
+                    "time_field": time_field,
+                    "dimensions": ["__DIMENSION_COLUMN__"]
+                }),
+                placeholder: true,
+                rationale: "Replace the invalid grain value with the canonical Nova object shape before adding nested grain fields.",
+                confidence: 0.74,
+                evidence: json!({"diagnostic": "invalid_grain_shape"}),
+            },
+        ),
+    );
+}
+
+fn has_invalid_grain_diagnostic(diagnostics: &JsonValue, field: &str) -> bool {
+    diagnostics.as_array().is_some_and(|items| {
+        items.iter().any(|item| {
+            item.get("code").and_then(JsonValue::as_str) == Some("invalid_grain_shape")
+                && item.get("field").and_then(JsonValue::as_str) == Some(field)
+        })
+    })
 }
 
 fn append_governance_meta_patches(
@@ -2616,6 +2871,8 @@ fn render_markdown_report(report: &AgentReadinessReport) -> String {
     let mut out = String::new();
     out.push_str("# Nova Agent Readiness\n\n");
     append_markdown_summary(&mut out, report);
+    append_scoring_contract_summary(&mut out, report);
+    append_readiness_triage_summary(&mut out, report);
     append_persona_score_table(&mut out, report);
     append_findings_table(&mut out, "Blockers", &report.blocking_findings);
     append_findings_table(&mut out, "Improvements", &report.improvement_findings);
@@ -2626,6 +2883,72 @@ fn render_markdown_report(report: &AgentReadinessReport) -> String {
     append_golden_question_seeds_table(&mut out, &report.golden_question_seeds);
     append_next_actions(&mut out, &report.next_actions);
     out
+}
+
+fn append_scoring_contract_summary(out: &mut String, report: &AgentReadinessReport) {
+    if report.gate_status == "pass" {
+        return;
+    }
+    out.push_str("## Scoring Contract\n\n");
+    out.push_str("- grade_bands: `A >= 90`, `B >= 80`, `C >= 70`, `D >= 60`, `F < 60`\n");
+    out.push_str("- description_tiers: `50-99 chars = 80%`, `100+ chars = full credit`\n");
+    out.push_str("- array_tiers: `1 item = 40%`, `2 items = 70%`, `3+ items = full credit`\n\n");
+}
+
+fn append_readiness_triage_summary(out: &mut String, report: &AgentReadinessReport) {
+    let weak_spots = report
+        .summary
+        .category_weak_spots
+        .as_array()
+        .map_or(&[][..], Vec::as_slice);
+    let repeated_fields = report
+        .summary
+        .top_recommendation_fields
+        .as_array()
+        .map_or(&[][..], Vec::as_slice);
+    if weak_spots.is_empty() && repeated_fields.is_empty() {
+        return;
+    }
+
+    out.push_str("## Triage Summary\n\n");
+    for weak_spot in weak_spots.iter().take(5) {
+        let persona = weak_spot
+            .get("persona")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("project");
+        let category = weak_spot
+            .get("category")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("metadata");
+        let average_score = weak_spot
+            .get("average_score")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0);
+        let gap = weak_spot
+            .get("estimated_point_gap")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0);
+        let _ = writeln!(
+            out,
+            "- `{persona}` `{category}` average score `{average_score}`, estimated point gap `{gap}`"
+        );
+    }
+    for field in repeated_fields.iter().take(5) {
+        let field_name = field
+            .get("field")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("metadata");
+        let count = field.get("count").and_then(JsonValue::as_u64).unwrap_or(0);
+        let impact = field
+            .get("estimated_point_impact")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0);
+        let _ = writeln!(
+            out,
+            "- repeated field `{field_name}` appears `{count}` time(s), estimated point impact `{impact}`"
+        );
+    }
+    out.push('\n');
 }
 
 fn append_markdown_summary(out: &mut String, report: &AgentReadinessReport) {
@@ -3233,6 +3556,7 @@ mod tests {
             generated_at_ms: 1,
             manifest: markdown_fixture_manifest(),
             config: markdown_fixture_config(),
+            scoring_contract: json!({}),
             overall_score: 60,
             grade: "D".to_string(),
             readiness_band: "blocked",
@@ -3246,6 +3570,12 @@ mod tests {
                 ambiguous_indicator_count: 0,
                 suggested_meta_patch_count: 1,
                 golden_question_seed_count: 1,
+                score_buckets: json!({}),
+                grade_buckets: json!({}),
+                worst_entities_by_persona: json!([]),
+                category_weak_spots: json!([]),
+                top_recommendation_fields: json!([]),
+                drill_down_hints: json!([]),
             },
             persona_scores: markdown_fixture_persona_scores(),
             blocking_findings: vec![ReadinessFinding {
@@ -3307,6 +3637,7 @@ mod tests {
                 scored_count: 1,
                 total_available: 1,
                 quality_summary: json!({}),
+                metadata_summary: json!({}),
             },
         )])
     }
@@ -3406,6 +3737,35 @@ mod tests {
         let markdown = render_markdown_report(&report);
         assert!(markdown.contains("## Suggested Meta Patches"));
         assert!(markdown.contains("meta.nova.governance.sensitivity"));
+    }
+
+    #[tokio::test]
+    async fn readiness_uses_score_diagnostics_for_invalid_grain_patch() {
+        let report = readiness_report_for_fixture(
+            "metadata_diagnostics.json",
+            "agent-readiness-invalid-grain-diagnostics",
+        )
+        .await;
+
+        let bad_grain = report
+            .entity_findings
+            .iter()
+            .find(|finding| finding.unique_id == "model.pkg.bad_grain_orders")
+            .expect("bad grain finding");
+        assert!(bad_grain.diagnostics.as_array().is_some_and(|diagnostics| {
+            diagnostics.iter().any(|diagnostic| {
+                diagnostic["code"] == json!("invalid_grain_shape")
+                    && diagnostic["field"] == json!("meta.nova.grain")
+            })
+        }));
+        assert!(report.suggested_meta_patches.iter().any(|patch| {
+            patch.unique_id == "model.pkg.bad_grain_orders"
+                && patch.field_path == "meta.nova.grain"
+                && patch.evidence["diagnostic"] == json!("invalid_grain_shape")
+        }));
+        assert!(report.scoring_contract["grade_bands"].is_array());
+        assert!(report.summary.worst_entities_by_persona.is_array());
+        assert!(report.summary.top_recommendation_fields.is_array());
     }
 
     #[tokio::test]

--- a/src/cli/audit_cmd.rs
+++ b/src/cli/audit_cmd.rs
@@ -17,6 +17,7 @@ use crate::params::{
     GetMetadataAuditParams, GetMetadataScoreParams, MetadataAuditSelectionModeParam,
 };
 use crate::responses::SuccessResponse;
+use crate::tools::metadata_score::metadata_score_scoring_contract;
 use crate::utils::SearchPersona;
 
 use super::{DispatchError, DispatchResult};
@@ -37,6 +38,7 @@ struct MetadataAuditReport {
     manifest_hash: String,
     manifest_version: String,
     manifest_source: String,
+    scoring_contract: JsonValue,
     resource_types: Vec<String>,
     personas: Vec<String>,
     changed_files: Vec<String>,
@@ -56,6 +58,12 @@ struct AuditSummary {
     pass_count: usize,
     no_target: bool,
     no_target_reason: Option<String>,
+    score_buckets: JsonValue,
+    grade_buckets: JsonValue,
+    worst_entities_by_persona: JsonValue,
+    category_weak_spots: JsonValue,
+    top_recommendation_fields: JsonValue,
+    drill_down_hints: JsonValue,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -409,12 +417,14 @@ async fn build_metadata_audit_report(
         (0, advisory) if advisory > 0 => "advisory",
         _ => "pass",
     };
+    let triage_summary = build_audit_triage_summary(&entities, &inputs.personas);
 
     Ok(MetadataAuditReport {
         selection_mode: selection_mode_label(inputs.selection_mode).to_string(),
         manifest_hash: search.manifest_hash.clone(),
         manifest_version: search.manifest_version.clone(),
         manifest_source: search.manifest_source_uri.clone(),
+        scoring_contract: metadata_score_scoring_contract(),
         resource_types: inputs.resource_types.clone(),
         personas: inputs.personas.clone(),
         changed_files: inputs.changed_files.clone(),
@@ -428,10 +438,293 @@ async fn build_metadata_audit_report(
             pass_count,
             no_target: selected_entity_ids.is_empty(),
             no_target_reason,
+            score_buckets: triage_summary.score_buckets,
+            grade_buckets: triage_summary.grade_buckets,
+            worst_entities_by_persona: triage_summary.worst_entities_by_persona,
+            category_weak_spots: triage_summary.category_weak_spots,
+            top_recommendation_fields: triage_summary.top_recommendation_fields,
+            drill_down_hints: triage_summary.drill_down_hints,
         },
         project_summary,
         entities,
     })
+}
+
+struct AuditTriageSummary {
+    score_buckets: JsonValue,
+    grade_buckets: JsonValue,
+    worst_entities_by_persona: JsonValue,
+    category_weak_spots: JsonValue,
+    top_recommendation_fields: JsonValue,
+    drill_down_hints: JsonValue,
+}
+
+#[derive(Clone)]
+struct AuditWorstEntity {
+    persona: String,
+    unique_id: String,
+    resource_type: Option<String>,
+    overall_score: u8,
+    grade: String,
+    gate_status: &'static str,
+}
+
+#[derive(Default)]
+struct AuditCategoryAggregate {
+    total_score: u64,
+    count: u64,
+    point_gap: u64,
+    weighted_point_gap: f64,
+}
+
+#[derive(Default)]
+struct AuditRecommendationAggregate {
+    category: Option<String>,
+    count: usize,
+    total_impact: u64,
+}
+
+fn build_audit_triage_summary(
+    entities: &[EntityAuditReport],
+    personas: &[String],
+) -> AuditTriageSummary {
+    let mut score_buckets = BTreeMap::<String, BTreeMap<String, usize>>::new();
+    let mut grade_buckets = BTreeMap::<String, BTreeMap<String, usize>>::new();
+    let mut worst_by_persona = Vec::<AuditWorstEntity>::new();
+    let mut categories = BTreeMap::<(String, String), AuditCategoryAggregate>::new();
+    let mut recommendations = BTreeMap::<String, AuditRecommendationAggregate>::new();
+
+    for entity in entities {
+        for persona in personas {
+            let Some(score) = entity.personas.get(persona) else {
+                continue;
+            };
+            *score_buckets
+                .entry(persona.clone())
+                .or_default()
+                .entry(audit_score_bucket(score.overall_score).to_string())
+                .or_default() += 1;
+            *grade_buckets
+                .entry(persona.clone())
+                .or_default()
+                .entry(score.grade.clone())
+                .or_default() += 1;
+            worst_by_persona.push(AuditWorstEntity {
+                persona: persona.clone(),
+                unique_id: entity.unique_id.clone(),
+                resource_type: entity.resource_type.clone(),
+                overall_score: score.overall_score,
+                grade: score.grade.clone(),
+                gate_status: score.gate_status,
+            });
+            ingest_audit_categories(&mut categories, persona, &score.categories);
+            ingest_audit_recommendations(&mut recommendations, &score.recommendations);
+        }
+    }
+
+    let worst_entities = audit_worst_entities(worst_by_persona);
+    let category_weak_spots = audit_category_weak_spots(categories);
+    let top_recommendation_fields = audit_recommendation_fields(recommendations);
+    let drill_down_hints = audit_drill_down_hints(&worst_entities);
+
+    AuditTriageSummary {
+        score_buckets: serde_json::to_value(score_buckets).unwrap_or(JsonValue::Null),
+        grade_buckets: serde_json::to_value(grade_buckets).unwrap_or(JsonValue::Null),
+        worst_entities_by_persona: JsonValue::Array(worst_entities),
+        category_weak_spots: JsonValue::Array(category_weak_spots),
+        top_recommendation_fields: JsonValue::Array(top_recommendation_fields),
+        drill_down_hints: JsonValue::Array(drill_down_hints),
+    }
+}
+
+fn audit_worst_entities(mut candidates: Vec<AuditWorstEntity>) -> Vec<JsonValue> {
+    candidates.sort_by(|left, right| {
+        left.persona
+            .cmp(&right.persona)
+            .then_with(|| left.overall_score.cmp(&right.overall_score))
+            .then_with(|| left.unique_id.cmp(&right.unique_id))
+    });
+
+    let mut worst_entities = Vec::new();
+    let mut worst_counts = BTreeMap::<String, usize>::new();
+    for entity in &candidates {
+        let count = worst_counts.entry(entity.persona.clone()).or_default();
+        if *count >= 5 {
+            continue;
+        }
+        *count += 1;
+        worst_entities.push(serde_json::json!({
+            "persona": entity.persona,
+            "unique_id": entity.unique_id,
+            "resource_type": entity.resource_type,
+            "overall_score": entity.overall_score,
+            "grade": entity.grade,
+            "gate_status": entity.gate_status
+        }));
+    }
+    worst_entities
+}
+
+fn audit_category_weak_spots(
+    categories: BTreeMap<(String, String), AuditCategoryAggregate>,
+) -> Vec<JsonValue> {
+    let mut weak_spots = categories
+        .into_iter()
+        .filter(|(_, aggregate)| aggregate.count > 0)
+        .map(|((persona, category), aggregate)| {
+            serde_json::json!({
+                "persona": persona,
+                "category": category,
+                "average_score": average_u64(aggregate.total_score, aggregate.count),
+                "entity_count": aggregate.count,
+                "estimated_point_gap": aggregate.point_gap,
+                "estimated_weighted_point_gap": aggregate.weighted_point_gap
+            })
+        })
+        .collect::<Vec<_>>();
+    weak_spots.sort_by(|left, right| {
+        json_f64(right, "estimated_weighted_point_gap")
+            .partial_cmp(&json_f64(left, "estimated_weighted_point_gap"))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    weak_spots.truncate(12);
+    weak_spots
+}
+
+fn audit_recommendation_fields(
+    recommendations: BTreeMap<String, AuditRecommendationAggregate>,
+) -> Vec<JsonValue> {
+    let mut fields = recommendations
+        .into_iter()
+        .map(|(field, aggregate)| {
+            serde_json::json!({
+                "field": field,
+                "category": aggregate.category,
+                "count": aggregate.count,
+                "estimated_point_impact": aggregate.total_impact
+            })
+        })
+        .collect::<Vec<_>>();
+    fields.sort_by(|left, right| {
+        right
+            .get("count")
+            .and_then(JsonValue::as_u64)
+            .cmp(&left.get("count").and_then(JsonValue::as_u64))
+            .then_with(|| {
+                right
+                    .get("estimated_point_impact")
+                    .and_then(JsonValue::as_u64)
+                    .cmp(
+                        &left
+                            .get("estimated_point_impact")
+                            .and_then(JsonValue::as_u64),
+                    )
+            })
+            .then_with(|| {
+                left.get("field")
+                    .and_then(JsonValue::as_str)
+                    .cmp(&right.get("field").and_then(JsonValue::as_str))
+            })
+    });
+    fields.truncate(10);
+    fields
+}
+
+fn audit_drill_down_hints(worst_entities: &[JsonValue]) -> Vec<JsonValue> {
+    worst_entities
+        .iter()
+        .take(5)
+        .filter_map(|entity| {
+            Some(serde_json::json!({
+                "purpose": "inspect_low_scoring_entity",
+                "tool": "get_metadata_score",
+                "arguments": {
+                    "scope": "entity",
+                    "id_or_name": entity.get("unique_id")?.clone(),
+                    "resource_type": entity.get("resource_type").cloned().unwrap_or(JsonValue::Null),
+                    "persona": entity.get("persona")?.clone(),
+                    "include_breakdown": true,
+                    "include_recommendations": true
+                }
+            }))
+        })
+        .collect()
+}
+
+fn ingest_audit_categories(
+    categories: &mut BTreeMap<(String, String), AuditCategoryAggregate>,
+    persona: &str,
+    value: &JsonValue,
+) {
+    let Some(map) = value.as_object() else {
+        return;
+    };
+    for (category, details) in map {
+        let Some(score) = details.get("score").and_then(JsonValue::as_u64) else {
+            continue;
+        };
+        let weight = details
+            .get("weight")
+            .and_then(JsonValue::as_f64)
+            .unwrap_or(0.0);
+        let entry = categories
+            .entry((persona.to_string(), category.clone()))
+            .or_default();
+        entry.total_score += score;
+        entry.count += 1;
+        let score_gap = 100_u64.saturating_sub(score);
+        entry.point_gap += score_gap;
+        entry.weighted_point_gap += f64::from(u32::try_from(score_gap).unwrap_or(100)) * weight;
+    }
+}
+
+fn ingest_audit_recommendations(
+    recommendations: &mut BTreeMap<String, AuditRecommendationAggregate>,
+    value: &JsonValue,
+) {
+    let Some(items) = value.as_array() else {
+        return;
+    };
+    for recommendation in items {
+        let field = recommendation
+            .get("field")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("metadata")
+            .to_string();
+        let entry = recommendations.entry(field).or_default();
+        entry.count += 1;
+        entry.total_impact += recommendation
+            .get("impact")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0);
+        if entry.category.is_none() {
+            entry.category = recommendation
+                .get("category")
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string);
+        }
+    }
+}
+
+fn audit_score_bucket(score: u8) -> &'static str {
+    match score {
+        90..=100 => "90-100",
+        80..=89 => "80-89",
+        70..=79 => "70-79",
+        60..=69 => "60-69",
+        _ => "0-59",
+    }
+}
+
+fn average_u64(total: u64, count: u64) -> u8 {
+    if count == 0 {
+        return 0;
+    }
+    u8::try_from((total / count).min(100)).unwrap_or(100)
+}
+
+fn json_f64(value: &JsonValue, field: &str) -> f64 {
+    value.get(field).and_then(JsonValue::as_f64).unwrap_or(0.0)
 }
 
 async fn score_entity(
@@ -732,6 +1025,7 @@ fn render_markdown_report(report: &MetadataAuditReport) -> String {
         append_no_target_markdown(&mut out, report);
         return out;
     }
+    append_audit_triage_markdown(&mut out, report);
 
     if let Some(project_summary) = &report.project_summary {
         out.push_str("## Project Summary\n\n");
@@ -821,6 +1115,63 @@ fn render_markdown_report(report: &MetadataAuditReport) -> String {
     }
 
     out
+}
+
+fn append_audit_triage_markdown(out: &mut String, report: &MetadataAuditReport) {
+    let weak_spots = report
+        .summary
+        .category_weak_spots
+        .as_array()
+        .map_or(&[][..], Vec::as_slice);
+    let repeated_fields = report
+        .summary
+        .top_recommendation_fields
+        .as_array()
+        .map_or(&[][..], Vec::as_slice);
+    if weak_spots.is_empty() && repeated_fields.is_empty() {
+        return;
+    }
+
+    out.push_str("## Triage Summary\n\n");
+    out.push_str("- grade_bands: `A >= 90`, `B >= 80`, `C >= 70`, `D >= 60`, `F < 60`\n");
+    for weak_spot in weak_spots.iter().take(5) {
+        let persona = weak_spot
+            .get("persona")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("project");
+        let category = weak_spot
+            .get("category")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("metadata");
+        let average_score = weak_spot
+            .get("average_score")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0);
+        let gap = weak_spot
+            .get("estimated_point_gap")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0);
+        let _ = writeln!(
+            out,
+            "- `{persona}` `{category}` average score `{average_score}`, estimated point gap `{gap}`"
+        );
+    }
+    for field in repeated_fields.iter().take(5) {
+        let field_name = field
+            .get("field")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("metadata");
+        let count = field.get("count").and_then(JsonValue::as_u64).unwrap_or(0);
+        let impact = field
+            .get("estimated_point_impact")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0);
+        let _ = writeln!(
+            out,
+            "- repeated field `{field_name}` appears `{count}` time(s), estimated point impact `{impact}`"
+        );
+    }
+    out.push('\n');
 }
 
 fn append_no_target_markdown(out: &mut String, report: &MetadataAuditReport) {
@@ -1176,6 +1527,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn metadata_audit_summary_answers_agent_triage_questions() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let args = MetadataAuditArgs {
+            selection_mode: MetadataAuditSelectionModeArg::Project,
+            resource_types_json: Some("[\"model\"]".to_string()),
+            personas_json: Some("[\"governance\"]".to_string()),
+            manifest_path: Some(fixture_path_string("metadata_diagnostics.json")),
+            storage_instance_id: Some("metadata-audit-triage-summary-test".to_string()),
+            cleanup_storage_on_start: true,
+            include_recommendations: Some(true),
+            ..MetadataAuditArgs::default()
+        };
+        let inputs = super::parse_audit_inputs(&args).expect("audit inputs");
+        let load_args = crate::cli::args::ManifestLoadArgs {
+            manifest_path: args.manifest_path.clone(),
+            storage_instance_id: args.storage_instance_id.clone(),
+            cleanup_storage_on_start: args.cleanup_storage_on_start,
+            ..crate::cli::args::ManifestLoadArgs::default()
+        };
+        let mut config = build_manifest_load_config(&load_args).expect("config");
+        config.storage_dir = temp_dir.path().to_string_lossy().to_string();
+        let loaded = execute_manifest_load(config).await.expect("load");
+        let report = super::build_metadata_audit_report(&loaded.search, &inputs, &args)
+            .await
+            .expect("report");
+
+        assert!(report.scoring_contract["grade_bands"].is_array());
+        assert!(
+            report
+                .summary
+                .worst_entities_by_persona
+                .as_array()
+                .is_some_and(|rows| rows
+                    .iter()
+                    .any(|row| row["unique_id"] == json!("model.pkg.bad_grain_orders")))
+        );
+        assert!(
+            report
+                .summary
+                .category_weak_spots
+                .as_array()
+                .is_some_and(|rows| !rows.is_empty())
+        );
+        assert!(
+            report
+                .summary
+                .top_recommendation_fields
+                .as_array()
+                .is_some_and(|rows| rows
+                    .iter()
+                    .any(|row| row["estimated_point_impact"].as_u64().unwrap_or(0) > 0))
+        );
+        assert!(
+            report
+                .summary
+                .drill_down_hints
+                .as_array()
+                .is_some_and(|rows| rows
+                    .iter()
+                    .any(|row| row["tool"] == json!("get_metadata_score")))
+        );
+    }
+
+    #[tokio::test]
     async fn changed_selection_no_target_for_model_yaml_is_advisory() {
         let temp_dir = TempDir::new().expect("temp dir");
         let args = MetadataAuditArgs {
@@ -1285,6 +1700,7 @@ mod tests {
             manifest_hash: "abc".to_string(),
             manifest_version: "abc".to_string(),
             manifest_source: "file:///tmp/manifest.json".to_string(),
+            scoring_contract: json!({}),
             resource_types: vec!["model".to_string()],
             personas: vec!["engineer".to_string()],
             changed_files: vec!["models/marts/orders.sql".to_string()],
@@ -1298,6 +1714,12 @@ mod tests {
                 pass_count: 0,
                 no_target: false,
                 no_target_reason: None,
+                score_buckets: json!({}),
+                grade_buckets: json!({}),
+                worst_entities_by_persona: json!([]),
+                category_weak_spots: json!([]),
+                top_recommendation_fields: json!([]),
+                drill_down_hints: json!([]),
             },
             project_summary: None,
             entities: vec![super::EntityAuditReport {

--- a/src/tests/metadata_score.rs
+++ b/src/tests/metadata_score.rs
@@ -1,6 +1,7 @@
 //! Tests for metadata scoring logic and outputs.
 use super::common::*;
 use crate::tools::metadata_score::{array_tier_score, description_tier_score, grade_from_score};
+use serde_json::json;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_metadata_score_entity_not_found() {
@@ -224,6 +225,129 @@ fn test_grade_boundaries() {
     assert_eq!(grade_from_score(60), "D");
     assert_eq!(grade_from_score(59), "F");
     assert_eq!(grade_from_score(0), "F");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn metadata_score_diagnostics_cover_agent_feedback_cases() {
+    let searcher = get_searcher_with_fixture("metadata_diagnostics.json");
+    let params = GetMetadataScoreParams {
+        id_or_name: Some("model.pkg.bad_grain_orders".to_string()),
+        persona: Some("governance".to_string()),
+        scope: Some("entity".to_string()),
+        include_breakdown: true,
+        include_recommendations: true,
+        ..Default::default()
+    };
+    let result = searcher.get_metadata_score(&params).await.json();
+    let data = result.get("data").expect("data");
+    assert_eq!(
+        data["scoring_contract"]["grade_bands"][0],
+        json!({"grade": "A", "min_score": 90, "max_score": 100})
+    );
+
+    let diagnostics = data["diagnostics"].as_array().expect("diagnostics array");
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic["code"] == json!("invalid_grain_shape")
+            && diagnostic["field"] == json!("meta.nova.grain")
+            && diagnostic["observed_type"] == json!("string")
+            && diagnostic["expected_shape"]["primary_key"] == json!(["order_id"])
+    }));
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic["code"] == json!("array_tier_progress")
+            && diagnostic["field"] == json!("meta.nova.governance.compliance")
+            && diagnostic["count"] == json!(1)
+            && diagnostic["full_credit_count"] == json!(3)
+    }));
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic["code"] == json!("description_tier_progress")
+            && diagnostic["field"] == json!("description")
+            && diagnostic["good_enough_chars"] == json!(50)
+            && diagnostic["full_credit_chars"] == json!(100)
+    }));
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic["code"] == json!("primary_key_integrity_missing_tests")
+            && diagnostic["column"] == json!("order_id")
+            && diagnostic["missing_tests"] == json!(["not_null"])
+            && diagnostic["warehouse_introspection"] == json!(false)
+    }));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn metadata_score_column_diagnostics_expose_description_and_array_tiers() {
+    let searcher = get_searcher_with_fixture("metadata_diagnostics.json");
+    let params = GetMetadataScoreParams {
+        id_or_name: Some("model.pkg.bad_grain_orders".to_string()),
+        persona: Some("analyst".to_string()),
+        scope: Some("column".to_string()),
+        include_breakdown: true,
+        include_recommendations: true,
+        ..Default::default()
+    };
+    let result = searcher.get_metadata_score(&params).await.json();
+    let columns = result["data"]["columns"].as_array().expect("columns array");
+    let order_id = columns
+        .iter()
+        .find(|column| column["column"] == json!("order_id"))
+        .expect("order_id column");
+    let diagnostics = order_id["diagnostics"]
+        .as_array()
+        .expect("column diagnostics");
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic["code"] == json!("description_tier_progress")
+            && diagnostic["field"] == json!("columns.order_id.description")
+            && diagnostic["full_credit_chars"] == json!(100)
+    }));
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic["code"] == json!("array_tier_progress")
+            && diagnostic["field"] == json!("columns.order_id.meta.nova.synonyms")
+            && diagnostic["count"] == json!(1)
+            && diagnostic["next_useful_count"] == json!(2)
+            && diagnostic["full_credit_count"] == json!(3)
+    }));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn metadata_score_project_summary_answers_agent_triage_questions() {
+    let searcher = get_searcher_with_fixture("metadata_diagnostics.json");
+    let params = GetMetadataScoreParams {
+        persona: Some("governance".to_string()),
+        scope: Some("project".to_string()),
+        resource_types: vec!["model".to_string()],
+        include_recommendations: true,
+        limit: Some(10),
+        ..Default::default()
+    };
+    let result = searcher.get_metadata_score(&params).await.json();
+    let summary = result["data"]["summary"].as_object().expect("summary");
+    assert_eq!(summary["scope"], json!("all_entities"));
+    assert_eq!(summary["entities"], json!(2));
+    assert_eq!(summary["entities_total"], json!(2));
+    assert_eq!(summary["truncated"], json!(false));
+    assert_eq!(summary["page"]["limit"], json!(10));
+    assert_eq!(summary["page"]["offset"], json!(0));
+    assert!(summary["page"]["next_offset"].is_null());
+    assert!(summary.contains_key("score_buckets"));
+    assert!(summary.contains_key("grade_buckets"));
+    assert!(summary["worst_entities"].as_array().is_some_and(|rows| {
+        rows.iter()
+            .any(|row| row["unique_id"] == json!("model.pkg.bad_grain_orders"))
+    }));
+    assert!(
+        summary["category_weak_spots"]
+            .as_array()
+            .is_some_and(|rows| !rows.is_empty())
+    );
+    assert!(
+        summary["top_recommendation_fields"]
+            .as_array()
+            .is_some_and(|rows| rows
+                .iter()
+                .any(|row| row["estimated_point_impact"].as_u64().unwrap_or(0) > 0))
+    );
+    assert!(summary["drill_down_hints"].as_array().is_some_and(|rows| {
+        rows.iter()
+            .any(|row| row["tool"] == json!("get_metadata_score"))
+    }));
 }
 
 #[tokio::test]

--- a/src/tests/modeling.rs
+++ b/src/tests/modeling.rs
@@ -119,6 +119,33 @@ async fn test_modelling_consistency_report_surfaces_duplicate_indicators() {
         .json();
 
     let data = result.get("data").expect("data");
+    let summary = data.get("summary").expect("summary");
+    assert!(
+        summary["section_counts"]["duplicate_indicators"]
+            .as_u64()
+            .is_some_and(|count| count > 0)
+    );
+    assert!(
+        summary["top_duplicate_indicator_groups"]
+            .as_array()
+            .is_some_and(|rows| !rows.is_empty())
+    );
+    assert!(
+        summary["overlap_evidence_categories"]["shared_column_names"]
+            .as_u64()
+            .is_some_and(|count| count > 0)
+    );
+    assert!(
+        summary["overlap_examples"]
+            .as_array()
+            .is_some_and(|rows| rows.iter().any(|row| row["shared_column_examples"]
+                .as_array()
+                .is_some_and(|examples| !examples.is_empty())))
+    );
+    assert!(summary["drill_down_hints"].as_array().is_some_and(|rows| {
+        rows.iter()
+            .any(|row| row["tool"].as_str() == Some("find_entity_overlap"))
+    }));
     let duplicate_indicators = data
         .get("duplicate_indicators")
         .and_then(JsonValue::as_array)

--- a/src/tools/metadata_score/column/column_score.rs
+++ b/src/tools/metadata_score/column/column_score.rs
@@ -5,6 +5,9 @@ use crate::manifest::search::ManifestSearch;
 
 use super::super::CategoryScore;
 use crate::tools::metadata_score::helpers::{clamp_to_u8, grade_from_score};
+use crate::tools::metadata_score::{
+    build_column_score_diagnostics, metadata_score_scoring_contract,
+};
 
 impl ManifestSearch {
     pub(crate) fn score_column(
@@ -92,6 +95,14 @@ impl ManifestSearch {
                 "governance": { "score": governance.score, "weight": governance.weight, "weighted": governance.weighted() },
                 "quality": { "score": quality.score, "weight": quality.weight, "weighted": quality.weighted() }
             }),
+        );
+        obj.insert(
+            "diagnostics".to_string(),
+            build_column_score_diagnostics(column_name, column_info),
+        );
+        obj.insert(
+            "scoring_contract".to_string(),
+            metadata_score_scoring_contract(),
         );
 
         if include_breakdown {

--- a/src/tools/metadata_score/column/entity.rs
+++ b/src/tools/metadata_score/column/entity.rs
@@ -4,6 +4,7 @@ use crate::config::MetadataCategoryWeights;
 use crate::manifest::search::ManifestSearch;
 
 use super::super::{CategoryScore, ScoredMetadata};
+use crate::tools::metadata_score::build_entity_score_diagnostics;
 use crate::tools::metadata_score::helpers::{clamp_to_u8, grade_from_score};
 
 impl ManifestSearch {
@@ -118,6 +119,7 @@ impl ManifestSearch {
             grade: grade_from_score(overall).to_string(),
             categories,
             breakdown,
+            diagnostics: build_entity_score_diagnostics(self, unique_id, entity_json),
             recommendations: if include_recommendations {
                 recommendations
             } else {

--- a/src/tools/metadata_score/column/scope.rs
+++ b/src/tools/metadata_score/column/scope.rs
@@ -7,6 +7,7 @@ use crate::params::GetMetadataScoreParams;
 use crate::responses::SuccessResponse;
 
 use crate::tools::metadata_score::helpers::{average_score, grade_from_score};
+use crate::tools::metadata_score::metadata_score_scoring_contract;
 
 impl ManifestSearch {
     #[allow(clippy::unused_async)]
@@ -53,6 +54,7 @@ impl ManifestSearch {
             "persona": persona,
             "overall_score": avg_overall,
             "grade": grade_from_score(avg_overall),
+            "scoring_contract": metadata_score_scoring_contract(),
             "columns": scored_columns
         });
 

--- a/src/tools/metadata_score/diagnostics.rs
+++ b/src/tools/metadata_score/diagnostics.rs
@@ -1,0 +1,437 @@
+use serde_json::{Map as JsonMap, Value as JsonValue, json};
+
+use crate::manifest::entity::{
+    column_nova_meta_json, column_primary_key_bool, entity_nova_meta_json,
+};
+use crate::manifest::search::ManifestSearch;
+
+use super::helpers::{array_tier_score, description_tier_score};
+
+const DESCRIPTION_FULL_CREDIT_CHARS: usize = 100;
+const DESCRIPTION_GOOD_ENOUGH_CHARS: usize = 50;
+const ARRAY_FULL_CREDIT_COUNT: usize = 3;
+const MAX_COLUMN_DIAGNOSTICS: usize = 12;
+
+#[must_use]
+pub(crate) fn metadata_score_scoring_contract() -> JsonValue {
+    json!({
+        "schema_version": "metadata_score_contract.v1",
+        "grade_bands": grade_bands_json(),
+        "description_tiers": [
+            {"min_chars": 0, "max_chars": 0, "credit_percent": 0},
+            {"min_chars": 1, "max_chars": 19, "credit_percent": 20},
+            {"min_chars": 20, "max_chars": 49, "credit_percent": 50},
+            {"min_chars": 50, "max_chars": 99, "credit_percent": 80},
+            {"min_chars": 100, "max_chars": null, "credit_percent": 100}
+        ],
+        "array_count_tiers": [
+            {"count": 0, "credit_percent": 0},
+            {"count": 1, "credit_percent": 40},
+            {"count": 2, "credit_percent": 70},
+            {"count": 3, "credit_percent": 100, "applies_to": "3+"}
+        ],
+        "grain_shape": {
+            "required_type": "object",
+            "canonical_fields": {
+                "primary_key": "array of primary-key column names",
+                "time_field": "time column name",
+                "dimensions": "optional array of dimension column names"
+            }
+        },
+        "primary_key_integrity": {
+            "required_manifest_tests": ["unique", "not_null"],
+            "evidence_source": "dbt manifest test metadata only",
+            "warehouse_introspection": false
+        }
+    })
+}
+
+#[must_use]
+pub(crate) fn grade_bands_json() -> JsonValue {
+    json!([
+        {"grade": "A", "min_score": 90, "max_score": 100},
+        {"grade": "B", "min_score": 80, "max_score": 89},
+        {"grade": "C", "min_score": 70, "max_score": 79},
+        {"grade": "D", "min_score": 60, "max_score": 69},
+        {"grade": "F", "min_score": 0, "max_score": 59}
+    ])
+}
+
+pub(crate) fn build_entity_score_diagnostics(
+    search: &ManifestSearch,
+    unique_id: &str,
+    entity_json: &JsonValue,
+) -> JsonValue {
+    let mut diagnostics = Vec::new();
+    let nova = entity_nova_meta_json(entity_json);
+    let nova = nova.as_deref();
+
+    push_description_diagnostic(
+        &mut diagnostics,
+        "description",
+        "documentation",
+        entity_json
+            .get("description")
+            .and_then(JsonValue::as_str)
+            .unwrap_or(""),
+        30,
+        "entity description",
+    );
+
+    push_entity_column_description_diagnostics(&mut diagnostics, entity_json);
+    push_array_diagnostic(
+        &mut diagnostics,
+        "meta.nova.synonyms",
+        "semantic",
+        array_len(nova.and_then(|value| value.get("synonyms"))),
+        12,
+        "synonyms improve retrieval recall and receive full array-tier credit at three or more items",
+    );
+    push_array_diagnostic(
+        &mut diagnostics,
+        "meta.nova.domains",
+        "semantic",
+        array_len(nova.and_then(|value| value.get("domains"))),
+        12,
+        "domains improve routing and receive full array-tier credit at three or more items",
+    );
+    push_array_diagnostic(
+        &mut diagnostics,
+        "meta.nova.use_cases",
+        "semantic",
+        array_len(nova.and_then(|value| value.get("use_cases"))),
+        12,
+        "use cases help agents choose the right asset and receive full array-tier credit at three or more items",
+    );
+    push_array_diagnostic(
+        &mut diagnostics,
+        "meta.nova.governance.compliance",
+        "governance",
+        array_len(
+            nova.and_then(|value| value.get("governance"))
+                .and_then(|value| value.get("compliance")),
+        ),
+        20,
+        "compliance tags receive partial credit for one or two items and full array-tier credit at three or more items",
+    );
+
+    push_grain_shape_diagnostics(&mut diagnostics, nova);
+    push_primary_key_integrity_diagnostics(&mut diagnostics, search, unique_id, entity_json);
+
+    JsonValue::Array(diagnostics)
+}
+
+pub(crate) fn build_column_score_diagnostics(
+    column_name: &str,
+    column_info: &JsonValue,
+) -> JsonValue {
+    let mut diagnostics = Vec::new();
+    let nova = column_nova_meta_json(column_info);
+    let nova = nova.as_deref();
+
+    push_description_diagnostic(
+        &mut diagnostics,
+        &format!("columns.{column_name}.description"),
+        "documentation",
+        column_info
+            .get("description")
+            .and_then(JsonValue::as_str)
+            .unwrap_or(""),
+        50,
+        "column description",
+    );
+    push_array_diagnostic(
+        &mut diagnostics,
+        &format!("columns.{column_name}.meta.nova.synonyms"),
+        "semantic",
+        array_len(nova.and_then(|value| value.get("synonyms"))),
+        40,
+        "column synonyms receive full array-tier credit at three or more items",
+    );
+    push_array_diagnostic(
+        &mut diagnostics,
+        &format!("columns.{column_name}.meta.nova.governance.compliance"),
+        "governance",
+        array_len(
+            nova.and_then(|value| value.get("governance"))
+                .and_then(|value| value.get("compliance")),
+        ),
+        20,
+        "column compliance tags receive full array-tier credit at three or more items",
+    );
+    push_array_diagnostic(
+        &mut diagnostics,
+        &format!("columns.{column_name}.constraints"),
+        "quality",
+        constraint_count(column_info),
+        20,
+        "constraints receive full array-tier credit at three or more not_null, unique, or foreign_key entries",
+    );
+
+    JsonValue::Array(diagnostics)
+}
+
+fn push_entity_column_description_diagnostics(
+    diagnostics: &mut Vec<JsonValue>,
+    entity_json: &JsonValue,
+) {
+    let Some(columns) = entity_json.get("columns").and_then(JsonValue::as_object) else {
+        return;
+    };
+
+    for (column_name, column) in columns.iter().take(MAX_COLUMN_DIAGNOSTICS) {
+        push_description_diagnostic(
+            diagnostics,
+            &format!("columns.{column_name}.description"),
+            "documentation",
+            column
+                .get("description")
+                .and_then(JsonValue::as_str)
+                .unwrap_or(""),
+            100,
+            "column description",
+        );
+    }
+}
+
+fn push_description_diagnostic(
+    diagnostics: &mut Vec<JsonValue>,
+    field: &str,
+    category: &str,
+    text: &str,
+    max_points: u8,
+    label: &str,
+) {
+    let chars = text.trim().len();
+    let score = description_tier_score(text, max_points);
+    if score >= max_points {
+        return;
+    }
+    diagnostics.push(json!({
+        "code": "description_tier_progress",
+        "category": category,
+        "field": field,
+        "label": label,
+        "observed_chars": chars,
+        "score": score,
+        "max": max_points,
+        "good_enough_chars": DESCRIPTION_GOOD_ENOUGH_CHARS,
+        "full_credit_chars": DESCRIPTION_FULL_CREDIT_CHARS,
+        "next_threshold_chars": next_description_threshold(chars),
+        "message": format!("{label} has {chars} character(s); 50-99 chars receive 80% description-tier credit and 100+ chars receive full credit")
+    }));
+}
+
+fn next_description_threshold(chars: usize) -> Option<usize> {
+    match chars {
+        0 => Some(1),
+        1..=19 => Some(20),
+        20..=49 => Some(DESCRIPTION_GOOD_ENOUGH_CHARS),
+        50..=99 => Some(DESCRIPTION_FULL_CREDIT_CHARS),
+        _ => None,
+    }
+}
+
+fn push_array_diagnostic(
+    diagnostics: &mut Vec<JsonValue>,
+    field: &str,
+    category: &str,
+    count: usize,
+    max_points: u8,
+    message: &str,
+) {
+    if count >= ARRAY_FULL_CREDIT_COUNT {
+        return;
+    }
+    diagnostics.push(json!({
+        "code": "array_tier_progress",
+        "category": category,
+        "field": field,
+        "count": count,
+        "score": array_tier_score(count, max_points),
+        "max": max_points,
+        "next_useful_count": next_array_count(count),
+        "full_credit_count": ARRAY_FULL_CREDIT_COUNT,
+        "message": message
+    }));
+}
+
+fn next_array_count(count: usize) -> usize {
+    match count {
+        0 => 1,
+        1 => 2,
+        _ => ARRAY_FULL_CREDIT_COUNT,
+    }
+}
+
+fn push_grain_shape_diagnostics(diagnostics: &mut Vec<JsonValue>, nova: Option<&JsonValue>) {
+    let Some(nova) = nova else {
+        return;
+    };
+    push_grain_shape_diagnostic(diagnostics, "meta.nova.grain", nova.get("grain"));
+    push_grain_shape_diagnostic(
+        diagnostics,
+        "meta.nova.metric.grain",
+        nova.get("metric").and_then(|metric| metric.get("grain")),
+    );
+    if let Some(metrics) = nova.get("metrics").and_then(JsonValue::as_array) {
+        for (index, metric) in metrics.iter().enumerate() {
+            let label = metric
+                .get("name")
+                .and_then(JsonValue::as_str)
+                .map_or_else(|| index.to_string(), ToString::to_string);
+            push_grain_shape_diagnostic(
+                diagnostics,
+                &format!("meta.nova.metrics[{label}].grain"),
+                metric.get("grain"),
+            );
+        }
+    }
+}
+
+fn push_grain_shape_diagnostic(
+    diagnostics: &mut Vec<JsonValue>,
+    field: &str,
+    grain: Option<&JsonValue>,
+) {
+    let Some(grain) = grain else {
+        return;
+    };
+    let invalid_reason = match grain {
+        JsonValue::Object(map) if map.is_empty() => Some("empty object"),
+        JsonValue::Object(map) if !has_known_grain_field(map) => {
+            Some("object without canonical grain fields")
+        }
+        JsonValue::Object(_) => None,
+        JsonValue::String(_) => Some("string"),
+        JsonValue::Array(_) => Some("array"),
+        JsonValue::Bool(_) => Some("boolean"),
+        JsonValue::Number(_) => Some("number"),
+        JsonValue::Null => Some("null"),
+    };
+    let Some(invalid_reason) = invalid_reason else {
+        return;
+    };
+    diagnostics.push(json!({
+        "code": "invalid_grain_shape",
+        "category": "semantic",
+        "field": field,
+        "observed_type": json_type_label(grain),
+        "invalid_reason": invalid_reason,
+        "expected_shape": {
+            "primary_key": ["order_id"],
+            "time_field": "order_date",
+            "dimensions": ["country_code"]
+        },
+        "message": format!("{field} must be a non-empty object with canonical grain fields; {invalid_reason} values score as missing")
+    }));
+}
+
+fn has_known_grain_field(map: &JsonMap<String, JsonValue>) -> bool {
+    ["primary_key", "time_field", "dimensions"]
+        .iter()
+        .any(|field| map.contains_key(*field))
+}
+
+fn json_type_label(value: &JsonValue) -> &'static str {
+    match value {
+        JsonValue::Null => "null",
+        JsonValue::Bool(_) => "boolean",
+        JsonValue::Number(_) => "number",
+        JsonValue::String(_) => "string",
+        JsonValue::Array(_) => "array",
+        JsonValue::Object(_) => "object",
+    }
+}
+
+fn push_primary_key_integrity_diagnostics(
+    diagnostics: &mut Vec<JsonValue>,
+    search: &ManifestSearch,
+    unique_id: &str,
+    entity_json: &JsonValue,
+) {
+    let Some(columns) = entity_json.get("columns").and_then(JsonValue::as_object) else {
+        return;
+    };
+    for (column_name, column) in columns {
+        if !column_primary_key_bool(column) {
+            continue;
+        }
+        let missing_tests = missing_primary_key_tests(search, unique_id, column_name);
+        if missing_tests.is_empty() {
+            continue;
+        }
+        diagnostics.push(json!({
+            "code": "primary_key_integrity_missing_tests",
+            "category": "quality",
+            "field": format!("columns.{column_name}"),
+            "column": column_name,
+            "missing_tests": missing_tests,
+            "required_tests": ["unique", "not_null"],
+            "evidence_source": "dbt manifest test metadata only",
+            "warehouse_introspection": false,
+            "message": format!("primary key column '{column_name}' is missing required dbt manifest test evidence; Nova does not infer uniqueness from compiled SQL or warehouse introspection")
+        }));
+    }
+}
+
+fn missing_primary_key_tests(
+    search: &ManifestSearch,
+    unique_id: &str,
+    column_name: &str,
+) -> Vec<&'static str> {
+    let key = format!("{unique_id}:{column_name}");
+    let tests = search
+        .tests_by_column
+        .get(&key)
+        .cloned()
+        .unwrap_or_default();
+    let mut has_unique = false;
+    let mut has_not_null = false;
+    for test_id in &tests {
+        if let Ok(Some(test)) = search.get_entity_archived(test_id) {
+            let test_json = test.to_json_value();
+            let name = test_json
+                .get("test_metadata")
+                .and_then(|metadata| metadata.get("name"))
+                .and_then(JsonValue::as_str);
+            if name == Some("unique") {
+                has_unique = true;
+            } else if name == Some("not_null") {
+                has_not_null = true;
+            }
+        }
+    }
+
+    let mut missing = Vec::new();
+    if !has_unique {
+        missing.push("unique");
+    }
+    if !has_not_null {
+        missing.push("not_null");
+    }
+    missing
+}
+
+fn array_len(value: Option<&JsonValue>) -> usize {
+    value
+        .and_then(JsonValue::as_array)
+        .map_or(0, std::vec::Vec::len)
+}
+
+fn constraint_count(column: &JsonValue) -> usize {
+    column
+        .get("constraints")
+        .and_then(JsonValue::as_array)
+        .map_or(0, |constraints| {
+            constraints
+                .iter()
+                .filter(|constraint| {
+                    constraint
+                        .get("type")
+                        .and_then(JsonValue::as_str)
+                        .is_some_and(|kind| matches!(kind, "not_null" | "unique" | "foreign_key"))
+                })
+                .count()
+        })
+}

--- a/src/tools/metadata_score/entry/mod.rs
+++ b/src/tools/metadata_score/entry/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use serde_json::Value as JsonValue;
 use tracing::instrument;
 
@@ -7,6 +9,7 @@ use crate::manifest::search::ManifestSearch;
 use crate::params::{DEFAULT_ENTITY_SCOPE, DEFAULT_METADATA_SCORE_LIMIT, GetMetadataScoreParams};
 use crate::responses::SuccessResponse;
 use crate::tools::metadata_score::helpers::{average_score, grade_from_score};
+use crate::tools::metadata_score::metadata_score_scoring_contract;
 
 impl ManifestSearch {
     /// Compute metadata scores for an entity, column, or project scope.
@@ -67,6 +70,8 @@ impl ManifestSearch {
             "grade": score.grade,
             "categories": score.categories,
             "breakdown": score.breakdown,
+            "diagnostics": score.diagnostics,
+            "scoring_contract": metadata_score_scoring_contract(),
             "recommendations": score.recommendations
         });
 
@@ -94,6 +99,7 @@ impl ManifestSearch {
         let offset = params.offset.unwrap_or(0);
         let mut total_available = 0usize;
         let mut coverage = CoverageAggregate::default();
+        let mut project_summary = ProjectScoreSummaryBuilder::default();
         let mut ordered_entity_ids = Vec::new();
 
         for resource_type in &resource_types {
@@ -118,6 +124,15 @@ impl ManifestSearch {
 
                 total_scores.push(u64::from(score.overall_score));
                 coverage.ingest(&score.categories);
+                project_summary.ingest(ProjectScoreInput {
+                    unique_id: &entity_id,
+                    name: entity.name_str(),
+                    resource_type: entity.resource_type_str(),
+                    overall_score: score.overall_score,
+                    grade: &score.grade,
+                    categories: &score.categories,
+                    recommendations: &score.recommendations,
+                });
                 entity_scores.push(serde_json::json!({
                     "unique_id": entity_id,
                     "name": entity.name_str(),
@@ -141,7 +156,17 @@ impl ManifestSearch {
             "limit": limit,
             "offset": offset,
             "entities": entity_scores,
-            "quality_summary": quality_summary
+            "quality_summary": quality_summary,
+            "summary": project_summary.build(ProjectSummaryContext {
+                persona,
+                entities: count,
+                total_available,
+                limit,
+                offset,
+                truncated,
+                next_offset: truncated.then_some(scanned),
+            }),
+            "scoring_contract": metadata_score_scoring_contract()
         });
 
         let mut response = SuccessResponse::new(response, count).with_total(total_available);
@@ -163,6 +188,257 @@ impl ManifestSearch {
 
         (weights, persona)
     }
+}
+
+#[derive(Clone, Copy)]
+struct ProjectScoreInput<'a> {
+    unique_id: &'a str,
+    name: Option<&'a str>,
+    resource_type: Option<&'a str>,
+    overall_score: u8,
+    grade: &'a str,
+    categories: &'a JsonValue,
+    recommendations: &'a [JsonValue],
+}
+
+#[derive(Default)]
+struct ProjectScoreSummaryBuilder {
+    score_buckets: BTreeMap<String, usize>,
+    grade_buckets: BTreeMap<String, usize>,
+    worst_entities: Vec<ScoredEntitySummary>,
+    categories: BTreeMap<String, CategoryAggregate>,
+    recommendations: BTreeMap<String, RecommendationAggregate>,
+}
+
+impl ProjectScoreSummaryBuilder {
+    fn ingest(&mut self, input: ProjectScoreInput<'_>) {
+        *self
+            .score_buckets
+            .entry(score_bucket(input.overall_score).to_string())
+            .or_default() += 1;
+        *self
+            .grade_buckets
+            .entry(input.grade.to_string())
+            .or_default() += 1;
+        self.worst_entities.push(ScoredEntitySummary {
+            unique_id: input.unique_id.to_string(),
+            name: input.name.map(ToString::to_string),
+            resource_type: input.resource_type.map(ToString::to_string),
+            overall_score: input.overall_score,
+            grade: input.grade.to_string(),
+        });
+        ingest_category_scores(&mut self.categories, input.categories);
+        ingest_recommendations(&mut self.recommendations, input.recommendations);
+    }
+
+    fn build(mut self, context: ProjectSummaryContext<'_>) -> JsonValue {
+        self.worst_entities.sort_by(|left, right| {
+            left.overall_score
+                .cmp(&right.overall_score)
+                .then_with(|| left.unique_id.cmp(&right.unique_id))
+        });
+        self.worst_entities.truncate(10);
+
+        let mut category_weak_spots = self
+            .categories
+            .into_iter()
+            .filter(|(_, aggregate)| aggregate.count > 0)
+            .map(|(category, aggregate)| {
+                let average = aggregate.average_score();
+                serde_json::json!({
+                    "category": category,
+                    "average_score": average,
+                    "entity_count": aggregate.count,
+                    "estimated_point_gap": aggregate.point_gap,
+                    "estimated_weighted_point_gap": aggregate.weighted_point_gap
+                })
+            })
+            .collect::<Vec<_>>();
+        category_weak_spots.sort_by(|left, right| {
+            json_f64(right, "estimated_weighted_point_gap")
+                .partial_cmp(&json_f64(left, "estimated_weighted_point_gap"))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        let mut recommendation_fields = self
+            .recommendations
+            .into_iter()
+            .map(|(field, aggregate)| {
+                serde_json::json!({
+                    "field": field,
+                    "category": aggregate.category,
+                    "count": aggregate.count,
+                    "estimated_point_impact": aggregate.total_impact
+                })
+            })
+            .collect::<Vec<_>>();
+        recommendation_fields.sort_by(|left, right| {
+            right
+                .get("count")
+                .and_then(JsonValue::as_u64)
+                .cmp(&left.get("count").and_then(JsonValue::as_u64))
+                .then_with(|| {
+                    right
+                        .get("estimated_point_impact")
+                        .and_then(JsonValue::as_u64)
+                        .cmp(
+                            &left
+                                .get("estimated_point_impact")
+                                .and_then(JsonValue::as_u64),
+                        )
+                })
+                .then_with(|| {
+                    left.get("field")
+                        .and_then(JsonValue::as_str)
+                        .cmp(&right.get("field").and_then(JsonValue::as_str))
+                })
+        });
+        recommendation_fields.truncate(10);
+
+        let drill_down_hints = self
+            .worst_entities
+            .iter()
+            .take(5)
+            .map(|entity| {
+                serde_json::json!({
+                    "purpose": "inspect_low_scoring_entity",
+                    "tool": "get_metadata_score",
+                    "arguments": {
+                        "scope": "entity",
+                        "id_or_name": entity.unique_id,
+                        "resource_type": entity.resource_type,
+                        "persona": context.persona,
+                        "include_breakdown": true,
+                        "include_recommendations": true
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        serde_json::json!({
+            "scope": if context.truncated { "included_entities" } else { "all_entities" },
+            "entities": context.entities,
+            "entities_total": context.total_available,
+            "truncated": context.truncated,
+            "page": {
+                "limit": context.limit,
+                "offset": context.offset,
+                "next_offset": context.next_offset
+            },
+            "score_buckets": self.score_buckets,
+            "grade_buckets": self.grade_buckets,
+            "worst_entities": self.worst_entities,
+            "category_weak_spots": category_weak_spots,
+            "top_recommendation_fields": recommendation_fields,
+            "drill_down_hints": drill_down_hints
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ProjectSummaryContext<'a> {
+    persona: &'a str,
+    entities: usize,
+    total_available: usize,
+    limit: usize,
+    offset: usize,
+    truncated: bool,
+    next_offset: Option<usize>,
+}
+
+#[derive(serde::Serialize)]
+struct ScoredEntitySummary {
+    unique_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resource_type: Option<String>,
+    overall_score: u8,
+    grade: String,
+}
+
+#[derive(Default)]
+struct CategoryAggregate {
+    total_score: u64,
+    count: u64,
+    point_gap: u64,
+    weighted_point_gap: f64,
+}
+
+impl CategoryAggregate {
+    fn average_score(&self) -> u8 {
+        if self.count == 0 {
+            return 0;
+        }
+        average_score(std::iter::once(Some(self.total_score / self.count)))
+    }
+}
+
+#[derive(Default)]
+struct RecommendationAggregate {
+    category: Option<String>,
+    count: usize,
+    total_impact: u64,
+}
+
+fn score_bucket(score: u8) -> &'static str {
+    match score {
+        90..=100 => "90-100",
+        80..=89 => "80-89",
+        70..=79 => "70-79",
+        60..=69 => "60-69",
+        _ => "0-59",
+    }
+}
+
+fn ingest_category_scores(categories: &mut BTreeMap<String, CategoryAggregate>, value: &JsonValue) {
+    let Some(map) = value.as_object() else {
+        return;
+    };
+    for (category, details) in map {
+        let Some(score) = details.get("score").and_then(JsonValue::as_u64) else {
+            continue;
+        };
+        let weight = details
+            .get("weight")
+            .and_then(JsonValue::as_f64)
+            .unwrap_or(0.0);
+        let entry = categories.entry(category.clone()).or_default();
+        entry.total_score += score;
+        entry.count += 1;
+        let score_gap = 100_u64.saturating_sub(score);
+        entry.point_gap += score_gap;
+        entry.weighted_point_gap += f64::from(u32::try_from(score_gap).unwrap_or(100)) * weight;
+    }
+}
+
+fn ingest_recommendations(
+    recommendations: &mut BTreeMap<String, RecommendationAggregate>,
+    values: &[JsonValue],
+) {
+    for recommendation in values {
+        let field = recommendation
+            .get("field")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("metadata")
+            .to_string();
+        let entry = recommendations.entry(field).or_default();
+        entry.count += 1;
+        entry.total_impact += recommendation
+            .get("impact")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0);
+        if entry.category.is_none() {
+            entry.category = recommendation
+                .get("category")
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string);
+        }
+    }
+}
+
+fn json_f64(value: &JsonValue, field: &str) -> f64 {
+    value.get(field).and_then(JsonValue::as_f64).unwrap_or(0.0)
 }
 
 #[derive(Default)]

--- a/src/tools/metadata_score/mod.rs
+++ b/src/tools/metadata_score/mod.rs
@@ -1,4 +1,5 @@
 mod column;
+mod diagnostics;
 mod documentation;
 mod entry;
 mod governance;
@@ -6,6 +7,9 @@ mod helpers;
 mod quality;
 mod semantic;
 
+pub(crate) use diagnostics::{
+    build_column_score_diagnostics, build_entity_score_diagnostics, metadata_score_scoring_contract,
+};
 pub use helpers::{array_tier_score, description_tier_score, grade_from_score};
 
 use serde_json::Value as JsonValue;
@@ -37,5 +41,6 @@ pub(crate) struct ScoredMetadata {
     pub(crate) grade: String,
     pub(crate) categories: JsonValue,
     pub(crate) breakdown: Option<JsonValue>,
+    pub(crate) diagnostics: JsonValue,
     pub(crate) recommendations: Vec<JsonValue>,
 }

--- a/src/tools/modeling.rs
+++ b/src/tools/modeling.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use rkyv::string::ArchivedString;
 use serde::Serialize;
-use serde_json::Value as JsonValue;
+use serde_json::{Value as JsonValue, json};
 use tracing::instrument;
 
 use crate::error::{DbtNovaError, Result};
@@ -109,12 +109,12 @@ impl ManifestSearch {
         let section_limit = self.page_limit(params.pagination.limit);
         let section_offset = params.pagination.offset;
 
-        let mut overlap = overlap_rows(&profiles, None);
+        let mut overlap_rows_all = overlap_rows(&profiles, None);
         if let Some(min_score) = params.min_score {
-            overlap.retain(|row| row.score >= min_score);
+            overlap_rows_all.retain(|row| row.score >= min_score);
         }
-        let overlap_count = overlap.len();
-        let overlap = paginate_section(overlap, section_offset, section_limit);
+        let overlap_count = overlap_rows_all.len();
+        let overlap = paginate_section(overlap_rows_all.clone(), section_offset, section_limit);
 
         let duplicate_indicator_rows = duplicate_indicator_rows(&profiles, usize::MAX);
         let duplicate_indicator_count = duplicate_indicator_rows.len();
@@ -124,18 +124,35 @@ impl ManifestSearch {
             section_limit,
         );
         let canonical_conflict_rows: Vec<DuplicateIndicatorRow> = duplicate_indicator_rows
-            .into_iter()
+            .iter()
             .filter(|row| row.canonical_parent_count > 1)
+            .cloned()
             .collect();
         let canonical_conflict_count = canonical_conflict_rows.len();
-        let canonical_conflicts =
-            paginate_section(canonical_conflict_rows, section_offset, section_limit);
-        let mut multi_grain_entities = multi_grain_entity_rows(&profiles);
-        let multi_grain_entity_count = multi_grain_entities.len();
-        multi_grain_entities =
-            paginate_section(multi_grain_entities, section_offset, section_limit);
+        let canonical_conflicts = paginate_section(
+            canonical_conflict_rows.clone(),
+            section_offset,
+            section_limit,
+        );
+        let multi_grain_entity_rows_all = multi_grain_entity_rows(&profiles);
+        let multi_grain_entity_count = multi_grain_entity_rows_all.len();
+        let multi_grain_entities = paginate_section(
+            multi_grain_entity_rows_all.clone(),
+            section_offset,
+            section_limit,
+        );
+        let summary = build_modelling_consistency_summary(
+            params,
+            section_limit,
+            section_offset,
+            &overlap_rows_all,
+            &duplicate_indicator_rows,
+            &canonical_conflict_rows,
+            &multi_grain_entity_rows_all,
+        );
 
         let report = ModellingConsistencyReport {
+            summary,
             entity_count: profiles.len(),
             overlap_candidate_count: overlap_count,
             duplicate_indicator_count,
@@ -279,6 +296,7 @@ struct MultiGrainEntityRow {
 
 #[derive(Debug, Clone, Serialize)]
 struct ModellingConsistencyReport {
+    summary: JsonValue,
     entity_count: usize,
     overlap_candidate_count: usize,
     duplicate_indicator_count: usize,
@@ -870,6 +888,209 @@ fn multi_grain_entity_rows(profiles: &[EntityOverlapProfile]) -> Vec<MultiGrainE
             .then_with(|| left.entity.unique_id.cmp(&right.entity.unique_id))
     });
     rows
+}
+
+fn build_modelling_consistency_summary(
+    params: &ModellingConsistencyReportParams,
+    section_limit: usize,
+    section_offset: usize,
+    overlap_rows: &[EntityOverlapRow],
+    duplicate_indicator_rows: &[DuplicateIndicatorRow],
+    canonical_conflict_rows: &[DuplicateIndicatorRow],
+    multi_grain_entity_rows: &[MultiGrainEntityRow],
+) -> JsonValue {
+    let overlap_evidence_categories = overlap_evidence_category_counts(overlap_rows);
+    let overlap_examples = overlap_rows
+        .iter()
+        .take(5)
+        .map(|row| {
+            json!({
+                "entity1": &row.entity1.unique_id,
+                "entity2": &row.entity2.unique_id,
+                "score": row.score,
+                "surface_overlap_count": row.surface_overlap_count,
+                "evidence_categories": overlap_evidence_categories_for_row(row),
+                "shared_column_examples": row.evidence.shared_column_names.iter().take(5).collect::<Vec<_>>(),
+                "shared_name_token_examples": row.evidence.shared_name_tokens.iter().take(5).collect::<Vec<_>>(),
+                "shared_indicator_examples": row.evidence.shared_indicators.iter().take(5).collect::<Vec<_>>(),
+                "shared_domain_examples": row.evidence.shared_domains.iter().take(5).collect::<Vec<_>>(),
+                "shared_time_field": row.evidence.shared_time_field
+            })
+        })
+        .collect::<Vec<_>>();
+    let top_duplicate_indicator_groups = duplicate_indicator_rows
+        .iter()
+        .take(5)
+        .map(duplicate_indicator_summary_row)
+        .collect::<Vec<_>>();
+    let top_canonical_conflicts = canonical_conflict_rows
+        .iter()
+        .take(5)
+        .map(duplicate_indicator_summary_row)
+        .collect::<Vec<_>>();
+    let top_multi_grain_entities = multi_grain_entity_rows
+        .iter()
+        .take(5)
+        .map(|row| {
+            json!({
+                "unique_id": &row.entity.unique_id,
+                "name": &row.entity.name,
+                "resource_type": &row.entity.resource_type,
+                "grain_variant_count": row.grain_variant_count,
+                "variant_sources": row.grain_variants.iter().flat_map(|variant| variant.sources.iter()).take(8).collect::<Vec<_>>()
+            })
+        })
+        .collect::<Vec<_>>();
+    let next_offset = modelling_has_next_page(
+        section_limit,
+        section_offset,
+        overlap_rows,
+        multi_grain_entity_rows,
+    )
+    .then_some(section_offset.saturating_add(section_limit));
+
+    json!({
+        "section_counts": {
+            "overlap_candidates": overlap_rows.len(),
+            "duplicate_indicators": duplicate_indicator_rows.len(),
+            "canonical_indicator_conflicts": canonical_conflict_rows.len(),
+            "entities_with_multiple_grain_variants": multi_grain_entity_rows.len()
+        },
+        "page": {
+            "limit": section_limit,
+            "offset": section_offset,
+            "next_offset": next_offset
+        },
+        "overlap_evidence_categories": overlap_evidence_categories,
+        "overlap_examples": overlap_examples,
+        "top_duplicate_indicator_groups": top_duplicate_indicator_groups,
+        "top_canonical_conflicts": top_canonical_conflicts,
+        "top_multi_grain_entities": top_multi_grain_entities,
+        "drill_down_hints": modelling_drill_down_hints(params, section_limit, section_offset, overlap_rows, multi_grain_entity_rows)
+    })
+}
+
+fn overlap_evidence_category_counts(rows: &[EntityOverlapRow]) -> JsonValue {
+    let mut counts = BTreeMap::<String, usize>::new();
+    for row in rows {
+        for category in overlap_evidence_categories_for_row(row) {
+            if let Some(category) = category.as_str() {
+                *counts.entry(category.to_string()).or_default() += 1;
+            }
+        }
+    }
+    serde_json::to_value(counts).unwrap_or(JsonValue::Null)
+}
+
+fn overlap_evidence_categories_for_row(row: &EntityOverlapRow) -> Vec<JsonValue> {
+    let mut categories = Vec::new();
+    if !row.evidence.shared_name_tokens.is_empty() {
+        categories.push(json!("shared_name_tokens"));
+    }
+    if !row.evidence.shared_column_names.is_empty() {
+        categories.push(json!("shared_column_names"));
+    }
+    if !row.evidence.shared_parent_synonyms.is_empty() {
+        categories.push(json!("shared_parent_synonyms"));
+    }
+    if !row.evidence.shared_domains.is_empty() {
+        categories.push(json!("shared_domains"));
+    }
+    if !row.evidence.shared_indicators.is_empty() {
+        categories.push(json!("shared_indicators"));
+    }
+    if !row.evidence.shared_column_semantic_types.is_empty() {
+        categories.push(json!("shared_column_semantic_types"));
+    }
+    if !row.evidence.shared_dimensions.is_empty() {
+        categories.push(json!("shared_dimensions"));
+    }
+    if row.evidence.shared_time_field.is_some() {
+        categories.push(json!("shared_time_field"));
+    }
+    categories
+}
+
+fn duplicate_indicator_summary_row(row: &DuplicateIndicatorRow) -> JsonValue {
+    json!({
+        "indicator_name": &row.indicator_name,
+        "indicator_type": &row.indicator_type,
+        "parent_count": row.parent_count,
+        "canonical_parent_count": row.canonical_parent_count,
+        "parents_without_grain": row.parents_without_grain,
+        "inconsistent_grains": row.inconsistent_grains,
+        "parent_examples": row.parents.iter().take(5).map(|parent| {
+            json!({
+                "unique_id": &parent.unique_id,
+                "name": &parent.name,
+                "resource_type": &parent.resource_type,
+                "canonical": parent.canonical
+            })
+        }).collect::<Vec<_>>(),
+        "grain_variant_count": row.grain_signatures.len()
+    })
+}
+
+fn modelling_drill_down_hints(
+    params: &ModellingConsistencyReportParams,
+    section_limit: usize,
+    section_offset: usize,
+    overlap_rows: &[EntityOverlapRow],
+    multi_grain_entity_rows: &[MultiGrainEntityRow],
+) -> Vec<JsonValue> {
+    let mut hints = Vec::new();
+    if modelling_has_next_page(
+        section_limit,
+        section_offset,
+        overlap_rows,
+        multi_grain_entity_rows,
+    ) {
+        hints.push(json!({
+            "purpose": "fetch_next_report_page",
+            "tool": "modelling_consistency_report",
+            "arguments": {
+                "resource_types": &params.resource_types,
+                "limit": section_limit,
+                "offset": section_offset.saturating_add(section_limit),
+                "min_score": params.min_score
+            }
+        }));
+    }
+    if let Some(row) = overlap_rows.first() {
+        hints.push(json!({
+            "purpose": "inspect_top_overlap_pair",
+            "tool": "find_entity_overlap",
+            "arguments": {
+                "id_or_name": &row.entity1.unique_id,
+                "resource_type": &row.entity1.resource_type,
+                "resource_types": &params.resource_types,
+                "limit": 10,
+                "offset": 0
+            }
+        }));
+    }
+    if let Some(row) = multi_grain_entity_rows.first() {
+        hints.push(json!({
+            "purpose": "compare_multi_grain_entity_with_related_model",
+            "tool": "compare_grains",
+            "arguments": {
+                "entity1": &row.entity.unique_id,
+                "entity2": "__RELATED_ENTITY_ID__"
+            }
+        }));
+    }
+    hints
+}
+
+fn modelling_has_next_page(
+    section_limit: usize,
+    section_offset: usize,
+    overlap_rows: &[EntityOverlapRow],
+    multi_grain_entity_rows: &[MultiGrainEntityRow],
+) -> bool {
+    [overlap_rows.len(), multi_grain_entity_rows.len()]
+        .into_iter()
+        .any(|total| section_offset.saturating_add(section_limit) < total)
 }
 
 fn grain_signature_key(grain: &GrainVariant) -> String {

--- a/tests/fixtures/metadata_diagnostics.json
+++ b/tests/fixtures/metadata_diagnostics.json
@@ -1,0 +1,158 @@
+{
+  "metadata": {
+    "dbt_version": "1.10.2",
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json"
+  },
+  "nodes": {
+    "model.pkg.bad_grain_orders": {
+      "name": "bad_grain_orders",
+      "resource_type": "model",
+      "package_name": "pkg",
+      "database": "analytics",
+      "schema": "mart",
+      "raw_code": "select 1 as order_id, current_date as order_date",
+      "description": "Orders",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "data_type": "int",
+          "description": "Short identifier",
+          "meta": {
+            "primary_key": true,
+            "nova": {
+              "role": "identifier",
+              "semantic_type": "order_id",
+              "synonyms": ["order id"]
+            }
+          },
+          "constraints": [{"type": "unique"}]
+        },
+        "order_date": {
+          "name": "order_date",
+          "data_type": "date",
+          "description": "Date when the order was placed for daily order analysis and time-bounded reporting.",
+          "meta": {
+            "nova": {
+              "role": "time",
+              "semantic_type": "date"
+            }
+          }
+        }
+      },
+      "meta": {
+        "owner": "analytics",
+        "nova": {
+          "synonyms": ["orders"],
+          "domains": ["commerce"],
+          "use_cases": ["order reporting"],
+          "grain": "daily",
+          "governance": {
+            "sensitivity": "internal",
+            "pii": false,
+            "compliance": ["SOX"]
+          }
+        }
+      },
+      "original_file_path": "models/marts/bad_grain_orders.sql"
+    },
+    "model.pkg.good_orders": {
+      "name": "good_orders",
+      "resource_type": "model",
+      "package_name": "pkg",
+      "database": "analytics",
+      "schema": "mart",
+      "raw_code": "select 1 as order_id, current_date as order_date",
+      "description": "Canonical orders model with enough business context for agents to understand grain, ownership, usage, and governance.",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "data_type": "int",
+          "description": "Primary order identifier at the order grain for commerce reporting and reconciliation.",
+          "meta": {
+            "primary_key": true,
+            "nova": {
+              "role": "identifier",
+              "semantic_type": "order_id",
+              "synonyms": ["order id", "order key", "transaction id"]
+            }
+          },
+          "constraints": [{"type": "unique"}, {"type": "not_null"}]
+        },
+        "order_date": {
+          "name": "order_date",
+          "data_type": "date",
+          "description": "Date when the order was placed, used as the default time field for daily reporting.",
+          "meta": {
+            "nova": {
+              "role": "time",
+              "semantic_type": "date"
+            }
+          }
+        }
+      },
+      "meta": {
+        "owner": "analytics",
+        "nova": {
+          "synonyms": ["orders", "sales orders", "transactions"],
+          "domains": ["commerce", "finance", "operations"],
+          "use_cases": ["order reporting", "revenue analysis", "daily operations"],
+          "grain": {
+            "primary_key": ["order_id"],
+            "time_field": "order_date",
+            "dimensions": ["country_code"]
+          },
+          "governance": {
+            "sensitivity": "internal",
+            "pii": false,
+            "compliance": ["SOX", "GDPR", "CCPA"]
+          }
+        }
+      },
+      "original_file_path": "models/marts/good_orders.sql"
+    },
+    "test.pkg.unique_bad_grain_orders_order_id": {
+      "name": "unique_bad_grain_orders_order_id",
+      "resource_type": "test",
+      "package_name": "pkg",
+      "unique_id": "test.pkg.unique_bad_grain_orders_order_id",
+      "attached_node": "model.pkg.bad_grain_orders",
+      "column_name": "order_id",
+      "test_metadata": {"name": "unique"}
+    },
+    "test.pkg.unique_good_orders_order_id": {
+      "name": "unique_good_orders_order_id",
+      "resource_type": "test",
+      "package_name": "pkg",
+      "unique_id": "test.pkg.unique_good_orders_order_id",
+      "attached_node": "model.pkg.good_orders",
+      "column_name": "order_id",
+      "test_metadata": {"name": "unique"}
+    },
+    "test.pkg.not_null_good_orders_order_id": {
+      "name": "not_null_good_orders_order_id",
+      "resource_type": "test",
+      "package_name": "pkg",
+      "unique_id": "test.pkg.not_null_good_orders_order_id",
+      "attached_node": "model.pkg.good_orders",
+      "column_name": "order_id",
+      "test_metadata": {"name": "not_null"}
+    }
+  },
+  "sources": {},
+  "macros": {},
+  "docs": {},
+  "groups": {},
+  "exposures": {},
+  "metrics": {},
+  "parent_map": {
+    "model.pkg.bad_grain_orders": [],
+    "model.pkg.good_orders": [],
+    "test.pkg.unique_bad_grain_orders_order_id": ["model.pkg.bad_grain_orders"],
+    "test.pkg.unique_good_orders_order_id": ["model.pkg.good_orders"],
+    "test.pkg.not_null_good_orders_order_id": ["model.pkg.good_orders"]
+  },
+  "child_map": {
+    "model.pkg.bad_grain_orders": ["test.pkg.unique_bad_grain_orders_order_id"],
+    "model.pkg.good_orders": ["test.pkg.unique_good_orders_order_id", "test.pkg.not_null_good_orders_order_id"]
+  }
+}

--- a/tests/snapshots/snapshots__metadata_score_orders.snap
+++ b/tests/snapshots/snapshots__metadata_score_orders.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/snapshots.rs
-assertion_line: 39
+assertion_line: 94
 expression: result
 ---
 {
@@ -40,6 +40,78 @@ expression: result
         "weighted": 0.0
       }
     },
+    "diagnostics": [
+      {
+        "category": "documentation",
+        "code": "description_tier_progress",
+        "field": "description",
+        "full_credit_chars": 100,
+        "good_enough_chars": 50,
+        "label": "entity description",
+        "max": 30,
+        "message": "entity description has 18 character(s); 50-99 chars receive 80% description-tier credit and 100+ chars receive full credit",
+        "next_threshold_chars": 20,
+        "observed_chars": 18,
+        "score": 6
+      },
+      {
+        "category": "documentation",
+        "code": "description_tier_progress",
+        "field": "columns.order_id.description",
+        "full_credit_chars": 100,
+        "good_enough_chars": 50,
+        "label": "column description",
+        "max": 100,
+        "message": "column description has 2 character(s); 50-99 chars receive 80% description-tier credit and 100+ chars receive full credit",
+        "next_threshold_chars": 20,
+        "observed_chars": 2,
+        "score": 20
+      },
+      {
+        "category": "semantic",
+        "code": "array_tier_progress",
+        "count": 0,
+        "field": "meta.nova.synonyms",
+        "full_credit_count": 3,
+        "max": 12,
+        "message": "synonyms improve retrieval recall and receive full array-tier credit at three or more items",
+        "next_useful_count": 1,
+        "score": 0
+      },
+      {
+        "category": "semantic",
+        "code": "array_tier_progress",
+        "count": 0,
+        "field": "meta.nova.domains",
+        "full_credit_count": 3,
+        "max": 12,
+        "message": "domains improve routing and receive full array-tier credit at three or more items",
+        "next_useful_count": 1,
+        "score": 0
+      },
+      {
+        "category": "semantic",
+        "code": "array_tier_progress",
+        "count": 0,
+        "field": "meta.nova.use_cases",
+        "full_credit_count": 3,
+        "max": 12,
+        "message": "use cases help agents choose the right asset and receive full array-tier credit at three or more items",
+        "next_useful_count": 1,
+        "score": 0
+      },
+      {
+        "category": "governance",
+        "code": "array_tier_progress",
+        "count": 0,
+        "field": "meta.nova.governance.compliance",
+        "full_credit_count": 3,
+        "max": 20,
+        "message": "compliance tags receive partial credit for one or two items and full array-tier credit at three or more items",
+        "next_useful_count": 1,
+        "score": 0
+      }
+    ],
     "grade": "F",
     "name": "fct__orders",
     "overall_score": 2,
@@ -47,6 +119,98 @@ expression: result
     "recommendations": [],
     "resource_type": "model",
     "scope": "entity",
+    "scoring_contract": {
+      "array_count_tiers": [
+        {
+          "count": 0,
+          "credit_percent": 0
+        },
+        {
+          "count": 1,
+          "credit_percent": 40
+        },
+        {
+          "count": 2,
+          "credit_percent": 70
+        },
+        {
+          "applies_to": "3+",
+          "count": 3,
+          "credit_percent": 100
+        }
+      ],
+      "description_tiers": [
+        {
+          "credit_percent": 0,
+          "max_chars": 0,
+          "min_chars": 0
+        },
+        {
+          "credit_percent": 20,
+          "max_chars": 19,
+          "min_chars": 1
+        },
+        {
+          "credit_percent": 50,
+          "max_chars": 49,
+          "min_chars": 20
+        },
+        {
+          "credit_percent": 80,
+          "max_chars": 99,
+          "min_chars": 50
+        },
+        {
+          "credit_percent": 100,
+          "max_chars": null,
+          "min_chars": 100
+        }
+      ],
+      "grade_bands": [
+        {
+          "grade": "A",
+          "max_score": 100,
+          "min_score": 90
+        },
+        {
+          "grade": "B",
+          "max_score": 89,
+          "min_score": 80
+        },
+        {
+          "grade": "C",
+          "max_score": 79,
+          "min_score": 70
+        },
+        {
+          "grade": "D",
+          "max_score": 69,
+          "min_score": 60
+        },
+        {
+          "grade": "F",
+          "max_score": 59,
+          "min_score": 0
+        }
+      ],
+      "grain_shape": {
+        "canonical_fields": {
+          "dimensions": "optional array of dimension column names",
+          "primary_key": "array of primary-key column names",
+          "time_field": "time column name"
+        },
+        "required_type": "object"
+      },
+      "primary_key_integrity": {
+        "evidence_source": "dbt manifest test metadata only",
+        "required_manifest_tests": [
+          "unique",
+          "not_null"
+        ],
+        "warehouse_introspection": false
+      },
+      "schema_version": "metadata_score_contract.v1"
+    },
     "unique_id": "model.nova_test.fct__orders"
   },
   "success": true


### PR DESCRIPTION
## Summary

- Add a shared `metadata_score_contract.v1` plus machine-readable diagnostics for description tiers, array tier progress, invalid Nova grain shapes, and primary-key integrity test gaps.
- Add compact triage summaries to metadata score project scope, metadata audit, agent readiness, and modelling consistency outputs so agents can answer "what should I inspect next?" without fetching every detail row.
- Teach agent readiness to consume score diagnostics for invalid `meta.nova.grain` values and suggest a safe whole-object replacement instead of nested edits under non-object values.
- Update docs, changelog, snapshots, and fixtures for the new response contract.

Refs JOE-244
Refs JOE-245

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked metadata_score --all-features`
- `cargo test --locked modeling --all-features`
- `cargo test --locked audit_cmd --all-features`
- `cargo test --locked readiness_uses_score_diagnostics_for_invalid_grain_patch --all-features`
- `uv run --with-requirements docs/requirements.txt mkdocs build --strict`
- `bash scripts/check_config_reference.sh`
- `cargo deny check` (passed with existing duplicate dependency warnings)
- `bash scripts/check_dependency_watchlist.sh`
- `cargo test --locked --all-features`
- `git diff --check`
