### PR TITLE
Add trace inspection and redaction tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `dbt-nova eval gate <NAME> --json` reads the latest full-suite telemetry and
   reports allowed/blocked status, pass rate, and failed case/assertion ids,
   blocking stale suite-file telemetry before allowing configured gates.
+- Added `dbt-nova trace inspect`, `trace summarize`, and `trace redact`, plus
+  MCP/CLI `tool call` parity through `inspect_tool_trace`,
+  `summarize_tool_trace`, and `redact_tool_trace`, for inspecting sanitized
+  tool-call JSONL, writing Markdown trace summaries, and producing conservative
+  redacted trace artifacts for safe sharing. MCP trace writes require
+  `DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1`.
 - Added `dbt-nova audit agent-readiness` for metadata-only agent readiness
   reports that combine project metadata scores, entity signal gaps, Nova
   indicator checks, optional eval gate evidence, JSON/Markdown artifacts, and

--- a/docs/api/mcp-cli-parity.md
+++ b/docs/api/mcp-cli-parity.md
@@ -5,7 +5,7 @@ dbt-nova exposes two callable product surfaces:
 - MCP tools, used by MCP clients and hosted deployments.
 - CLI commands, used for one-shot local workflows and CI automation.
 
-The MCP catalog currently contains 48 MCP tools. `dbt-nova tool call` is the
+The MCP catalog currently contains 51 MCP tools. `dbt-nova tool call` is the
 CLI bridge to that same canonical tool catalog. Other CLI leaf commands are
 tracked below so each capability is either MCP-equivalent, a known parity gap,
 explicitly safety-gated, or a lifecycle exception.
@@ -31,7 +31,7 @@ sets the documented opt-in environment variable for local execution or writes.
 | `manifest load` | `health` | Lifecycle exception | - | MCP server startup performs the initial manifest load; `health` reports the active loaded manifest and `reload_manifest` replaces it. |
 | `manifest reload` | `reload_manifest` | Equivalent | - | MCP starts a background reload for the live server; CLI `manifest reload` and CLI `tool call reload_manifest` are one-shot reloads. |
 | `manifest warm` | `warm_manifest` | SafetyGated | - | MCP semantic cache warmup requires `DBT_NOVA_MCP_ENABLE_MANIFEST_WARM=1` and uses the current manifest source. |
-| `tool call <tool_name>` | 48 MCP tools | Equivalent | - | CLI tool-call mode supports the canonical MCP tool catalog. |
+| `tool call <tool_name>` | 51 MCP tools | Equivalent | - | CLI tool-call mode supports the canonical MCP tool catalog. |
 | `audit agent-readiness` | `get_agent_readiness` | Equivalent | - | MCP returns the same `agent_readiness.v1` report without CLI file writes. |
 | `audit metadata-score` | `get_metadata_audit` | Equivalent | - | MCP returns the same metadata audit report without CLI file writes or exit semantics. |
 | `audit nova-meta` | `validate_nova_meta` | Equivalent | - | MCP returns the same nova-meta validation report with scoped local path access. |
@@ -46,6 +46,9 @@ sets the documented opt-in environment variable for local execution or writes.
 | `eval agent run` | `run_agent_eval` | SafetyGated | - | MCP provider execution requires `DBT_NOVA_MCP_ENABLE_AGENT_EVAL=1`; custom commands also require `DBT_NOVA_MCP_ENABLE_CUSTOM_AGENT_PROVIDER=1`. |
 | `eval gate` | `get_eval_gate` | Equivalent | - | MCP returns the same eval gate report data. |
 | `eval history` | `get_eval_history` | Equivalent | - | MCP returns filtered eval telemetry rows in a standard envelope. |
+| `trace inspect` | `inspect_tool_trace` | Equivalent | - | MCP returns the same trace rows, parse warnings, and summary while scoping local paths under the server working directory. |
+| `trace summarize` | `summarize_tool_trace` | SafetyGated | - | MCP returns the same summary data; Markdown report writes require `DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1`. |
+| `trace redact` | `redact_tool_trace` | SafetyGated | - | MCP safe-sharing redaction writes require `DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1`. |
 | `health check` | `health` | Equivalent | - | Both surfaces report manifest/server readiness. |
 
 ## Drift Guards

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -1,6 +1,6 @@
 # Tools Quick Reference
 
-One-page cheatsheet for all 48 dbt-nova MCP tools.
+One-page cheatsheet for all 51 dbt-nova MCP tools.
 
 ## Discovery
 
@@ -71,6 +71,14 @@ One-page cheatsheet for all 48 dbt-nova MCP tools.
 | `run_eval` | Run deterministic bridge evals against loaded manifest | `suite`, `output_dir`, `telemetry`, `case_ids`, `fail_under` |
 | `init_eval_suite` | Write a starter eval suite | `persona`, `out`, `force` |
 | `run_agent_eval` | Run provider-backed agent evals | `suite`, `provider`, `manifest_path`, `output_dir`, `case_ids`, `timeout_secs`, `fail_under` |
+
+## Trace Review
+
+| Tool | Purpose | Key Parameters |
+|------|---------|----------------|
+| `inspect_tool_trace` | Inspect tool-call trace JSONL rows and parse warnings | `path` |
+| `summarize_tool_trace` | Summarize trace order, budgets, errors, IDs, and semantic-first signal | `path`, `report_md_path` |
+| `redact_tool_trace` | Redact trace JSONL for safe sharing | `path`, `out` |
 
 ## Metadata Inventory
 

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-This reference lists all 48 MCP tools exposed by dbt‑nova, grouped by category.
+This reference lists all 51 MCP tools exposed by dbt‑nova, grouped by category.
 All tools return the standard envelope described in [Response Format](response-format.md).
 For CLI equivalents and known parity gaps, see
 [MCP/CLI Parity](mcp-cli-parity.md).
@@ -868,6 +868,53 @@ arguments also require `DBT_NOVA_MCP_ENABLE_CUSTOM_AGENT_PROVIDER=1`.
 
 ```json
 {"name":"run_agent_eval","arguments":{"suite":"evals/analyst-smoke.yml","provider":"opencode","case_ids":["metric_lookup_flow"]}}
+```
+
+## Trace Review
+
+### `inspect_tool_trace`
+Inspect a local Nova tool-call trace JSONL file and return valid rows, malformed
+row warnings, tool order, counts, response byte budgets, truncation, errors, and
+semantic-first signals.
+
+Required:
+- `path`: trace JSONL path under the MCP server working directory
+
+```json
+{"name":"inspect_tool_trace","arguments":{"path":".nova/eval-runs/agent/tool-calls/metric_lookup_flow.jsonl"}}
+```
+
+### `summarize_tool_trace`
+Summarize a local trace JSONL file for PRs, eval artifacts, and review handoffs.
+When `report_md_path` is provided, Nova writes the Markdown summary under the
+server working directory.
+
+Required:
+- `path`: trace JSONL path under the MCP server working directory
+
+Optional:
+- `report_md_path`
+
+Markdown report writes are disabled unless
+`DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1` is set.
+
+```json
+{"name":"summarize_tool_trace","arguments":{"path":".nova/eval-runs/agent/tool-calls/metric_lookup_flow.redacted.jsonl","report_md_path":".nova/eval-runs/agent/tool-calls/metric_lookup_flow.redacted.md"}}
+```
+
+### `redact_tool_trace`
+Redact a local trace JSONL file for safe sharing. The output preserves tool name,
+call index, status, response bytes, truncation flags, selected IDs, top IDs, and
+sanitized scalar parameter summaries.
+
+Required:
+- `path`: input trace JSONL path under the MCP server working directory
+- `out`: redacted JSONL output path under the MCP server working directory
+
+Redaction writes are disabled unless `DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1` is set.
+
+```json
+{"name":"redact_tool_trace","arguments":{"path":".nova/eval-runs/agent/tool-calls/metric_lookup_flow.jsonl","out":".nova/eval-runs/agent/tool-calls/metric_lookup_flow.redacted.jsonl"}}
 ```
 
 ### `get_undocumented`

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -27,7 +27,7 @@ flowchart TD
 
 ## Architecture Overview (Detailed)
 
-### Tool Map (48 MCP tools)
+### Tool Map (51 MCP tools)
 
 <div class="diagram-large diagram-vertical" markdown>
 
@@ -90,6 +90,9 @@ flowchart LR
     TR --> T_run_eval["run_eval"]
     TR --> T_init_eval_suite["init_eval_suite"]
     TR --> T_run_agent_eval["run_agent_eval"]
+    TR --> T_inspect_tool_trace["inspect_tool_trace"]
+    TR --> T_summarize_tool_trace["summarize_tool_trace"]
+    TR --> T_redact_tool_trace["redact_tool_trace"]
     TR --> T_metadata_score["get_metadata_score"]
     TR --> T_metadata_audit["get_metadata_audit"]
     TR --> T_agent_readiness["get_agent_readiness"]

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -402,6 +402,10 @@ Trace rows deliberately do not record SQL recipe parameter maps or credential
 values. Keep eval artifacts out of public bug reports unless you have reviewed
 them for project-specific identifiers.
 
+Use [Trace Inspection And Redaction](traces.md) to inspect trace JSONL, write a
+Markdown summary, and create a redacted JSONL artifact before sharing trace
+evidence.
+
 ## CI Pattern
 
 Use bridge evals as a fast metadata quality gate after producing a manifest:

--- a/docs/features/traces.md
+++ b/docs/features/traces.md
@@ -1,0 +1,134 @@
+# Trace Inspection And Redaction
+
+Nova can record sanitized tool-call traces when
+`DBT_NOVA_TRACE_TOOL_CALLS_PATH` is set. Trace files are JSONL: one JSON object
+per observed Nova tool call. Use the `trace` commands to inspect, summarize, and
+redact those files before attaching them to PRs, eval artifacts, or support
+threads.
+
+Trace commands operate on local files only. They do not replay tool calls, call
+providers, execute SQL, upload artifacts, or read arbitrary provider logs.
+
+## Capture A Trace
+
+```bash
+DBT_NOVA_TRACE_TOOL_CALLS_PATH=out/tool-calls/analyst-smoke.jsonl \
+dbt-nova tool call search_indicator \
+  --params-json '{"query":"gross margin","indicator_types":["metric"],"limit":5}' \
+  --manifest-path target/manifest.json \
+  --json
+```
+
+Agent evals set the same trace environment for provider processes when local
+trace inheritance is available. See [Nova Evals](evals.md#tool-trace) for eval
+trace details.
+
+## Inspect
+
+```bash
+dbt-nova trace inspect \
+  --path out/tool-calls/analyst-smoke.jsonl \
+  --json
+```
+
+`trace inspect` reads valid rows, normalizes `tool_call_index` by file order,
+and reports malformed JSONL lines as parse warnings instead of panicking.
+Missing files fail with a clear error. Empty files return a successful report
+with `row_count: 0`.
+
+The JSON report includes:
+
+- raw valid trace rows
+- malformed row warnings with line numbers
+- tool order and tool counts
+- distinct tools
+- selected unique IDs and top ranked unique IDs
+- total and per-tool response byte budgets
+- response truncation counts
+- failed tool-call counts and error codes
+- semantic-first signal for `search_indicator` before `execute_sql` when the
+  trace contains enough evidence
+
+## Summarize
+
+```bash
+dbt-nova trace summarize \
+  --path out/tool-calls/analyst-smoke.jsonl \
+  --report-md-path out/tool-calls/analyst-smoke.trace.md
+```
+
+`trace summarize` produces a compact Markdown report for PR comments, release
+evidence, and eval artifacts. The report includes overview counters, ordered
+tool calls, tool counts, response budgets, semantic-first status, selected
+entity IDs, top ranked IDs, and parse warnings.
+
+Use `--json` when automation needs the same summary contract in a CLI envelope.
+Omit `--report-md-path` to print the Markdown report to stdout.
+
+## MCP And Tool-Call Parity
+
+The same trace review surface is available to MCP clients and
+`dbt-nova tool call`:
+
+- `inspect_tool_trace` maps to `trace inspect`
+- `summarize_tool_trace` maps to `trace summarize`
+- `redact_tool_trace` maps to `trace redact`
+
+MCP trace paths are scoped under the server working directory. Read-only inspect
+and summarize calls can return JSON data directly. Markdown report writes and
+redacted JSONL writes require `DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1`.
+
+## Redact
+
+```bash
+dbt-nova trace redact \
+  --path out/tool-calls/analyst-smoke.jsonl \
+  --out out/tool-calls/analyst-smoke.redacted.jsonl \
+  --json
+```
+
+`trace redact` writes valid JSONL using a conservative allowlist. It preserves:
+
+- `timestamp_ms`, `tool_call_index`, `transport`, and `tool`
+- `success`, `duration_ms`, and `error_code`
+- safe scalar parameter summaries such as `query`, `persona`, `id_or_name`,
+  `resource_type`, `indicator_types`, `limit`, and `offset`
+- `response_bytes`, `response_truncated`, `result_count`, and
+  `total_available`
+- `selected_unique_ids` and `top_unique_ids`
+
+It removes or masks:
+
+- raw nested `params`, SQL parameter maps, and arbitrary nested objects
+- credentials, tokens, passwords, private keys, and authorization-like fields
+- provider raw output fields if they appear in a trace row
+- manifest, artifact, or storage URIs outside the allowlist
+- URI query strings or path segments that contain token-like values
+- malformed JSONL rows, which are reported in the redaction summary
+
+Redacted output remains compatible with `trace inspect` and `trace summarize`.
+
+## Safe To Share Checklist
+
+Before sharing trace artifacts:
+
+- Share the redacted JSONL file, not the raw trace.
+- Share the Markdown summary when reviewers only need behavior evidence.
+- Review `selected_unique_ids`, `top_unique_ids`, and safe scalar query text;
+  they may still reveal project model names or business terms.
+- Keep raw traces, provider stdout/stderr, warehouse logs, and eval working
+  directories private unless they have been reviewed separately.
+- Do not attach traces that include binary artifacts, third-party provider logs,
+  raw SQL parameter maps, credentials, private keys, tokens, or private
+  manifest/artifact URIs.
+- Treat redaction as a local safety workflow, not a guarantee that arbitrary
+  third-party logs are safe.
+
+## Limitations
+
+Trace summaries prove tool-use behavior, not answer correctness. Use bridge or
+provider-backed evals when you need assertions about ranked results, selected
+entities, or final answers.
+
+The redactor intentionally drops detail when it cannot prove a field is safe.
+This can remove useful debugging context, but avoids leaking sensitive values.

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -4,7 +4,7 @@ Use `dbt-nova` in two modes:
 
 - No subcommand: start MCP server (backward compatible behavior)
 - Subcommand: run one-shot CLI commands and exit
-- CLI surface: 20 CLI leaf commands, including `tool call` access to all 48 MCP tools
+- CLI surface: 23 CLI leaf commands, including `tool call` access to all 51 MCP tools
 
 For the command-by-command MCP equivalent map, see
 [MCP/CLI Parity](../api/mcp-cli-parity.md).
@@ -26,6 +26,9 @@ dbt-nova
 ├── storage inspect [--storage-instance-id] [--json]
 ├── storage prune [--max-keep] [--max-bytes] [--storage-instance-id] [--json]
 ├── storage cleanup [--storage-instance-id] [--json]
+├── trace inspect --path <PATH> [--json]
+├── trace summarize --path <PATH> [--report-md-path <PATH>] [--json]
+├── trace redact --path <PATH> --out <PATH> [--json]
 ├── eval init --out <PATH> [--persona] [--force]
 ├── eval validate --suite <PATH> [--json]
 ├── eval run --suite <PATH> [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--telemetry] [--telemetry-retention] [--case-id <ID>...] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
@@ -135,6 +138,26 @@ dbt-nova tool call search_indicator \
   --manifest-path /path/to/target/manifest.json \
   --json
 ```
+
+### Inspect, summarize, and redact tool traces
+
+```bash
+dbt-nova trace inspect \
+  --path out/nova-evals/tool-calls/analyst-smoke.jsonl \
+  --json
+
+dbt-nova trace summarize \
+  --path out/nova-evals/tool-calls/analyst-smoke.jsonl \
+  --report-md-path out/nova-evals/tool-calls/analyst-smoke.trace.md
+
+dbt-nova trace redact \
+  --path out/nova-evals/tool-calls/analyst-smoke.jsonl \
+  --out out/nova-evals/tool-calls/analyst-smoke.redacted.jsonl \
+  --json
+```
+
+See [Trace Inspection And Redaction](../features/traces.md) for safe-sharing
+guidance and Markdown report fields.
 
 ### Agent-readiness report for CI
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,8 +105,8 @@ dbt-nova
 
 | Feature | Description |
 |---------|-------------|
-| **48 MCP Tools** | Server-exposed MCP surface for search, lineage, coverage, scoring, SQL execution, reports, evals, cache warming, config, storage, and recipes |
-| **20 CLI Leaf Commands** | One-shot commands for server startup, manifest lifecycle, audits, config, storage, evals, health, and tool calls |
+| **51 MCP Tools** | Server-exposed MCP surface for search, lineage, coverage, scoring, SQL execution, reports, evals, trace review, cache warming, config, storage, and recipes |
+| **23 CLI Leaf Commands** | One-shot commands for server startup, manifest lifecycle, audits, config, storage, evals, trace review, health, and tool calls |
 | **Hybrid Search** | Tantivy BM25 + vector + sparse + reranking |
 | **Multi-Source** | Local files, HTTP, S3, GCS, DBFS |
 | **Personas** | Analyst, Engineer, Governance profiles |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,7 @@ nav:
     - Metrics Reference: api/metrics-reference.md
   - Features:
     - Nova Evals: features/evals.md
+    - Trace Inspection And Redaction: features/traces.md
     - Analysis Recipes: features/recipes.md
     - Column Lineage: features/column-lineage.md
     - Agent Readiness Audit: features/agent-readiness.md

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -15,6 +15,7 @@ pub enum Command {
     Audit(AuditArgs),
     Config(ConfigArgs),
     Storage(StorageArgs),
+    Trace(TraceArgs),
     Health(HealthArgs),
     Eval(EvalArgs),
 }
@@ -150,6 +151,47 @@ pub struct ToolCallArgs {
     pub cleanup_storage_on_start: bool,
     #[arg(long, default_value_t = false)]
     pub read_only: bool,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct TraceArgs {
+    #[command(subcommand)]
+    pub command: TraceCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum TraceCommand {
+    Inspect(TraceInspectArgs),
+    Summarize(TraceSummarizeArgs),
+    Redact(TraceRedactArgs),
+}
+
+#[derive(Debug, Clone, Args, Default)]
+pub struct TraceInspectArgs {
+    #[arg(long, value_name = "PATH")]
+    pub path: String,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Args, Default)]
+pub struct TraceSummarizeArgs {
+    #[arg(long, value_name = "PATH")]
+    pub path: String,
+    #[arg(long, value_name = "PATH")]
+    pub report_md_path: Option<String>,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Args, Default)]
+pub struct TraceRedactArgs {
+    #[arg(long, value_name = "PATH")]
+    pub path: String,
+    #[arg(long, value_name = "PATH")]
+    pub out: String,
     #[arg(long, default_value_t = false)]
     pub json: bool,
 }
@@ -617,7 +659,7 @@ mod tests {
     use super::{
         AuditCommand, Cli, Command, ConfigCommand, EvalAgentCommand, EvalCommand, HealthCommand,
         ManifestCommand, MetadataAuditSelectionModeArg, NovaMetaResourceKindArg, ServerCommand,
-        ServerTransportArg, StorageCommand, ToolCommand,
+        ServerTransportArg, StorageCommand, ToolCommand, TraceCommand,
     };
 
     #[test]
@@ -948,6 +990,77 @@ mod tests {
             }
             _ => panic!("expected tool command"),
         }
+    }
+
+    #[test]
+    fn trace_commands_parse_flags() {
+        let inspect = Cli::parse_from([
+            "dbt-nova",
+            "trace",
+            "inspect",
+            "--path",
+            "tool-calls.jsonl",
+            "--json",
+        ]);
+        match inspect.command.expect("command") {
+            Command::Trace(trace) => {
+                let TraceCommand::Inspect(args) = trace.command else {
+                    panic!("expected trace inspect command");
+                };
+                assert_eq!(args.path, "tool-calls.jsonl");
+                assert!(args.json);
+            }
+            _ => panic!("expected trace command"),
+        }
+
+        let summarize = Cli::parse_from([
+            "dbt-nova",
+            "trace",
+            "summarize",
+            "--path",
+            "tool-calls.jsonl",
+            "--report-md-path",
+            "trace.md",
+        ]);
+        match summarize.command.expect("command") {
+            Command::Trace(trace) => {
+                let TraceCommand::Summarize(args) = trace.command else {
+                    panic!("expected trace summarize command");
+                };
+                assert_eq!(args.path, "tool-calls.jsonl");
+                assert_eq!(args.report_md_path.as_deref(), Some("trace.md"));
+            }
+            _ => panic!("expected trace command"),
+        }
+
+        let redact = Cli::parse_from([
+            "dbt-nova",
+            "trace",
+            "redact",
+            "--path",
+            "tool-calls.jsonl",
+            "--out",
+            "tool-calls.redacted.jsonl",
+            "--json",
+        ]);
+        match redact.command.expect("command") {
+            Command::Trace(trace) => {
+                let TraceCommand::Redact(args) = trace.command else {
+                    panic!("expected trace redact command");
+                };
+                assert_eq!(args.path, "tool-calls.jsonl");
+                assert_eq!(args.out, "tool-calls.redacted.jsonl");
+                assert!(args.json);
+            }
+            _ => panic!("expected trace command"),
+        }
+    }
+
+    #[test]
+    fn trace_redact_requires_output_path() {
+        let parsed =
+            Cli::try_parse_from(["dbt-nova", "trace", "redact", "--path", "tool-calls.jsonl"]);
+        assert!(parsed.is_err());
     }
 
     #[test]

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -25,6 +25,7 @@ use crate::params::{
     RunEvalParams, ValidateEvalSuiteParams,
 };
 use crate::responses::SuccessResponse;
+use crate::utils::tool_trace::{normalize_tool_trace_indices, read_tool_trace_file};
 
 const DEFAULT_TOP_K: usize = 5;
 const DEFAULT_FAIL_UNDER: f64 = 1.0;
@@ -1661,55 +1662,23 @@ fn reset_trace_file(path: &Path) -> std::io::Result<()> {
 }
 
 fn read_tool_trace(path: &Path) -> ToolTraceRead {
-    let raw = match fs::read_to_string(path) {
-        Ok(raw) => raw,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return ToolTraceRead {
-                rows: Vec::new(),
-                errors: Vec::new(),
-                missing: true,
-            };
-        }
-        Err(error) => {
-            return ToolTraceRead {
-                rows: Vec::new(),
-                errors: vec![format!(
-                    "failed to read tool trace '{}': {error}",
-                    path.display()
-                )],
-                missing: false,
-            };
-        }
-    };
-
-    let mut rows = Vec::new();
+    let read = read_tool_trace_file(path);
     let mut errors = Vec::new();
-    for (index, line) in raw.lines().enumerate() {
-        if line.trim().is_empty() {
-            continue;
-        }
-        match serde_json::from_str::<JsonValue>(line) {
-            Ok(row) => rows.push(row),
-            Err(error) => errors.push(format!(
-                "failed to parse tool trace line {} in '{}': {error}",
-                index + 1,
-                path.display()
-            )),
-        }
+    if let Some(error) = read.read_error {
+        errors.push(error);
     }
-    normalize_tool_trace_indices(&mut rows);
+    errors.extend(read.parse_warnings.into_iter().map(|warning| {
+        format!(
+            "failed to parse tool trace line {} in '{}': {}",
+            warning.line,
+            path.display(),
+            warning.message
+        )
+    }));
     ToolTraceRead {
-        rows,
+        rows: read.rows,
         errors,
-        missing: false,
-    }
-}
-
-fn normalize_tool_trace_indices(rows: &mut [JsonValue]) {
-    for (index, row) in rows.iter_mut().enumerate() {
-        if let Some(obj) = row.as_object_mut() {
-            obj.insert("tool_call_index".to_string(), JsonValue::from(index as u64));
-        }
+        missing: read.missing,
     }
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -16,6 +16,7 @@ pub mod output;
 pub mod server_cmd;
 pub mod storage_cmd;
 pub mod tool;
+pub mod trace_cmd;
 
 pub struct DispatchError {
     pub error: DbtNovaError,
@@ -79,6 +80,15 @@ pub async fn dispatch(command: args::Command) -> DispatchResult {
             args::StorageCommand::Cleanup(cleanup_args) => {
                 storage_cmd::run_cleanup_command(&cleanup_args)
             }
+        },
+        args::Command::Trace(trace_args) => match trace_args.command {
+            args::TraceCommand::Inspect(inspect_args) => {
+                trace_cmd::run_inspect_command(&inspect_args)
+            }
+            args::TraceCommand::Summarize(summarize_args) => {
+                trace_cmd::run_summarize_command(&summarize_args)
+            }
+            args::TraceCommand::Redact(redact_args) => trace_cmd::run_redact_command(&redact_args),
         },
         args::Command::Health(health_args) => match health_args.command {
             args::HealthCommand::Check(check_args) => {

--- a/src/cli/tool.rs
+++ b/src/cli/tool.rs
@@ -28,6 +28,10 @@ use crate::cli::storage_cmd::{
     build_storage_cleanup_tool_response, build_storage_inspect_tool_response,
     build_storage_prune_tool_response,
 };
+use crate::cli::trace_cmd::{
+    build_trace_inspect_tool_response, build_trace_redact_tool_response,
+    build_trace_summarize_tool_response,
+};
 use crate::error::{DbtNovaError, Result};
 use crate::manifest::search::ManifestSearch;
 use crate::params::{
@@ -40,8 +44,9 @@ use crate::params::{
     InitEvalSuiteParams, ListEntitiesParams, ModellingConsistencyReportParams,
     ReloadManifestParams, RunAgentEvalParams, RunEvalParams, RunRecipeParams, SearchColumnsParams,
     SearchIndicatorParams, SearchParams, SearchRecipesParams, StorageCleanupParams,
-    StorageInspectParams, StoragePruneParams, ValidateDagParams, ValidateEvalSuiteParams,
-    ValidateNovaMetaParams, WarmManifestParams,
+    StorageInspectParams, StoragePruneParams, TraceInspectParams, TraceRedactParams,
+    TraceSummarizeParams, ValidateDagParams, ValidateEvalSuiteParams, ValidateNovaMetaParams,
+    WarmManifestParams,
 };
 use crate::responses::SuccessResponse;
 
@@ -56,7 +61,7 @@ struct ToolRegistryEntry {
     dispatch: ToolDispatchFn,
 }
 
-const TOOL_REGISTRY: [ToolRegistryEntry; 48] = [
+const TOOL_REGISTRY: [ToolRegistryEntry; 51] = [
     ToolRegistryEntry {
         name: "search",
         dispatch: dispatch_search,
@@ -148,6 +153,18 @@ const TOOL_REGISTRY: [ToolRegistryEntry; 48] = [
     ToolRegistryEntry {
         name: "run_agent_eval",
         dispatch: dispatch_run_agent_eval,
+    },
+    ToolRegistryEntry {
+        name: "inspect_tool_trace",
+        dispatch: dispatch_inspect_tool_trace,
+    },
+    ToolRegistryEntry {
+        name: "summarize_tool_trace",
+        dispatch: dispatch_summarize_tool_trace,
+    },
+    ToolRegistryEntry {
+        name: "redact_tool_trace",
+        dispatch: dispatch_redact_tool_trace,
     },
     ToolRegistryEntry {
         name: "show_metadata",
@@ -773,6 +790,27 @@ fn dispatch_run_agent_eval(_searcher: &ManifestSearch, params: JsonValue) -> Too
     Box::pin(async move {
         let decoded: RunAgentEvalParams = decode_tool_params("run_agent_eval", params)?;
         build_agent_eval_tool_response(&decoded).await
+    })
+}
+
+fn dispatch_inspect_tool_trace(_searcher: &ManifestSearch, params: JsonValue) -> ToolFuture<'_> {
+    Box::pin(async move {
+        let decoded: TraceInspectParams = decode_tool_params("inspect_tool_trace", params)?;
+        build_trace_inspect_tool_response(&decoded)
+    })
+}
+
+fn dispatch_summarize_tool_trace(_searcher: &ManifestSearch, params: JsonValue) -> ToolFuture<'_> {
+    Box::pin(async move {
+        let decoded: TraceSummarizeParams = decode_tool_params("summarize_tool_trace", params)?;
+        build_trace_summarize_tool_response(&decoded)
+    })
+}
+
+fn dispatch_redact_tool_trace(_searcher: &ManifestSearch, params: JsonValue) -> ToolFuture<'_> {
+    Box::pin(async move {
+        let decoded: TraceRedactParams = decode_tool_params("redact_tool_trace", params)?;
+        build_trace_redact_tool_response(&decoded)
     })
 }
 

--- a/src/cli/trace_cmd.rs
+++ b/src/cli/trace_cmd.rs
@@ -1,0 +1,777 @@
+use std::fmt::Write as _;
+use std::fs::{self, create_dir_all};
+use std::path::{Component, Path, PathBuf};
+use std::time::Instant;
+
+use serde::Serialize;
+use serde_json::Value as JsonValue;
+
+use crate::cli::args::{TraceInspectArgs, TraceRedactArgs, TraceSummarizeArgs};
+use crate::cli::output::{CliEnvelope, error_envelope};
+use crate::error::{DbtNovaError, Result as DbtNovaResult};
+use crate::params::{TraceInspectParams, TraceRedactParams, TraceSummarizeParams};
+use crate::responses::SuccessResponse;
+use crate::utils::tool_trace::{
+    ToolTraceParseWarning, ToolTraceRead, ToolTraceRedactionReport, ToolTraceSummary,
+    read_tool_trace_file, redact_tool_trace_file, summarize_tool_trace,
+};
+
+use super::{DispatchError, DispatchResult};
+
+pub const MCP_ENABLE_TRACE_WRITES_ENV: &str = "DBT_NOVA_MCP_ENABLE_TRACE_WRITES";
+
+#[derive(Debug, Serialize)]
+struct TraceInspectData {
+    schema_version: &'static str,
+    path: String,
+    rows: Vec<serde_json::Value>,
+    parse_warnings: Vec<ToolTraceParseWarning>,
+    summary: ToolTraceSummary,
+}
+
+#[derive(Debug, Serialize)]
+struct TraceSummarizeData {
+    schema_version: &'static str,
+    path: String,
+    report_md_path: Option<String>,
+    parse_warnings: Vec<ToolTraceParseWarning>,
+    summary: ToolTraceSummary,
+}
+
+#[derive(Debug, Serialize)]
+struct TraceMcpSafetyPolicy {
+    filesystem_root: String,
+    trace_writes_enabled_env: &'static str,
+    local_paths_must_stay_under_filesystem_root: bool,
+    write_operations_require_opt_in: bool,
+}
+
+/// Runs the `trace inspect` CLI command.
+///
+/// # Errors
+/// Returns an error when the trace cannot be read or output cannot be rendered.
+pub fn run_inspect_command(args: &TraceInspectArgs) -> DispatchResult {
+    let started = Instant::now();
+    let read = read_trace_path(Path::new(&args.path)).map_err(|error| {
+        render_or_propagate_error(
+            args.json,
+            "trace inspect",
+            error,
+            started.elapsed().as_millis(),
+        )
+    })?;
+    let summary = summarize_tool_trace(&read);
+    let payload = TraceInspectData {
+        schema_version: "trace_inspect.v1",
+        path: read.path,
+        rows: read.rows,
+        parse_warnings: read.parse_warnings,
+        summary,
+    };
+    print_or_json(
+        "trace inspect",
+        args.json,
+        &payload,
+        started.elapsed().as_millis(),
+    )
+}
+
+/// Runs the `trace summarize` CLI command.
+///
+/// # Errors
+/// Returns an error when the trace cannot be read, Markdown cannot be written,
+/// or output cannot be rendered.
+pub fn run_summarize_command(args: &TraceSummarizeArgs) -> DispatchResult {
+    let started = Instant::now();
+    let read = read_trace_path(Path::new(&args.path)).map_err(|error| {
+        render_or_propagate_error(
+            args.json,
+            "trace summarize",
+            error,
+            started.elapsed().as_millis(),
+        )
+    })?;
+    let summary = summarize_tool_trace(&read);
+    let markdown = render_markdown_summary(&read, &summary);
+    if let Some(path) = args.report_md_path.as_deref() {
+        write_text_path(Path::new(path), &markdown).map_err(|error| {
+            render_or_propagate_error(
+                args.json,
+                "trace summarize",
+                error,
+                started.elapsed().as_millis(),
+            )
+        })?;
+    }
+    let payload = TraceSummarizeData {
+        schema_version: "trace_summarize.v1",
+        path: read.path,
+        report_md_path: args.report_md_path.clone(),
+        parse_warnings: read.parse_warnings,
+        summary,
+    };
+
+    if args.json {
+        print_json_envelope("trace summarize", &payload, started.elapsed().as_millis())
+    } else if args.report_md_path.is_some() {
+        println!("trace summary written");
+        if let Some(path) = args.report_md_path.as_deref() {
+            println!("  report_md_path: {path}");
+        }
+        println!("  row_count: {}", payload.summary.row_count);
+        println!("  parse_warnings: {}", payload.summary.parse_warning_count);
+        Ok(())
+    } else {
+        println!("{markdown}");
+        Ok(())
+    }
+}
+
+/// Runs the `trace redact` CLI command.
+///
+/// # Errors
+/// Returns an error when redaction fails or output cannot be rendered.
+pub fn run_redact_command(args: &TraceRedactArgs) -> DispatchResult {
+    let started = Instant::now();
+    let report =
+        redact_tool_trace_file(Path::new(&args.path), Path::new(&args.out)).map_err(|error| {
+            render_or_propagate_error(
+                args.json,
+                "trace redact",
+                error,
+                started.elapsed().as_millis(),
+            )
+        })?;
+
+    if args.json {
+        print_json_envelope("trace redact", &report, started.elapsed().as_millis())
+    } else {
+        print_redaction_human(&report);
+        Ok(())
+    }
+}
+
+/// Builds the MCP/CLI-tool response for trace inspection.
+///
+/// # Errors
+/// Returns an error when the trace path is unsafe, missing, or unreadable.
+pub fn build_trace_inspect_tool_response(params: &TraceInspectParams) -> DbtNovaResult<JsonValue> {
+    let path = resolve_mcp_trace_existing_file(&params.path, "path")?;
+    let read = read_trace_path(&path)?;
+    let summary = summarize_tool_trace(&read);
+    let count = summary.row_count;
+    let payload = with_trace_safety_policy(serde_json::to_value(TraceInspectData {
+        schema_version: "trace_inspect.v1",
+        path: read.path,
+        rows: read.rows,
+        parse_warnings: read.parse_warnings,
+        summary,
+    })?)?;
+    success_value(payload, count)
+}
+
+/// Builds the MCP/CLI-tool response for trace summarization.
+///
+/// # Errors
+/// Returns an error when paths are unsafe, the trace is unreadable, or a report
+/// write is requested without explicit trace write opt-in.
+pub fn build_trace_summarize_tool_response(
+    params: &TraceSummarizeParams,
+) -> DbtNovaResult<JsonValue> {
+    let path = resolve_mcp_trace_existing_file(&params.path, "path")?;
+    let read = read_trace_path(&path)?;
+    let summary = summarize_tool_trace(&read);
+    let count = summary.row_count;
+    let markdown = render_markdown_summary(&read, &summary);
+    let report_md_path = params
+        .report_md_path
+        .as_deref()
+        .map(|path| {
+            require_mcp_trace_writes("summarize_tool_trace")?;
+            resolve_mcp_trace_writable_path(path, "report_md_path")
+        })
+        .transpose()?;
+    if let Some(path) = report_md_path.as_ref() {
+        write_text_path(path, &markdown)?;
+    }
+    let payload = with_trace_safety_policy(serde_json::to_value(TraceSummarizeData {
+        schema_version: "trace_summarize.v1",
+        path: read.path,
+        report_md_path: report_md_path.map(|path| path.display().to_string()),
+        parse_warnings: read.parse_warnings,
+        summary,
+    })?)?;
+    success_value(payload, count)
+}
+
+/// Builds the MCP/CLI-tool response for trace redaction.
+///
+/// # Errors
+/// Returns an error when trace writes are disabled, paths are unsafe, or
+/// redaction cannot read/write the requested files.
+pub fn build_trace_redact_tool_response(params: &TraceRedactParams) -> DbtNovaResult<JsonValue> {
+    require_mcp_trace_writes("redact_tool_trace")?;
+    let path = resolve_mcp_trace_existing_file(&params.path, "path")?;
+    let out = resolve_mcp_trace_writable_path(&params.out, "out")?;
+    let report = redact_tool_trace_file(&path, &out)?;
+    let count = report.rows_written;
+    let payload = with_trace_safety_policy(serde_json::to_value(report)?)?;
+    success_value(payload, count)
+}
+
+#[cfg(test)]
+fn read_trace_for_cli(path: &str) -> Result<ToolTraceRead, DbtNovaError> {
+    read_trace_path(Path::new(path))
+}
+
+fn read_trace_path(path: &Path) -> Result<ToolTraceRead, DbtNovaError> {
+    let read = read_tool_trace_file(path);
+    if read.missing {
+        let path = path.display();
+        return Err(DbtNovaError::InvalidParams(format!(
+            "trace file '{path}' does not exist"
+        )));
+    }
+    if let Some(error) = &read.read_error {
+        return Err(DbtNovaError::ServerError(error.clone()));
+    }
+    Ok(read)
+}
+
+fn print_or_json<T>(
+    command: &'static str,
+    json: bool,
+    payload: &T,
+    elapsed_ms: u128,
+) -> DispatchResult
+where
+    T: Serialize,
+{
+    if json {
+        print_json_envelope(command, payload, elapsed_ms)
+    } else {
+        let out = serde_json::to_string_pretty(payload).map_err(|error| DispatchError {
+            error: DbtNovaError::ServerError(error.to_string()),
+            rendered: false,
+        })?;
+        println!("{out}");
+        Ok(())
+    }
+}
+
+fn print_json_envelope<T>(command: &'static str, payload: &T, elapsed_ms: u128) -> DispatchResult
+where
+    T: Serialize,
+{
+    let envelope = CliEnvelope::success(command, payload, elapsed_ms);
+    let out = serde_json::to_string_pretty(&envelope).map_err(|error| DispatchError {
+        error: DbtNovaError::ServerError(error.to_string()),
+        rendered: false,
+    })?;
+    println!("{out}");
+    Ok(())
+}
+
+fn render_or_propagate_error(
+    json: bool,
+    command: &'static str,
+    error: DbtNovaError,
+    elapsed_ms: u128,
+) -> DispatchError {
+    if json {
+        let envelope = error_envelope(command, &error, elapsed_ms);
+        if let Ok(json) = serde_json::to_string_pretty(&envelope) {
+            println!("{json}");
+            return DispatchError {
+                error,
+                rendered: true,
+            };
+        }
+    }
+    DispatchError {
+        error,
+        rendered: false,
+    }
+}
+
+fn write_text_path(path: &Path, contents: &str) -> Result<(), DbtNovaError> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        create_dir_all(parent)?;
+    }
+    fs::write(path, contents)?;
+    Ok(())
+}
+
+fn success_value(payload: JsonValue, count: usize) -> DbtNovaResult<JsonValue> {
+    serde_json::to_value(SuccessResponse::new(payload, count))
+        .map_err(|error| DbtNovaError::ServerError(error.to_string()))
+}
+
+fn with_trace_safety_policy(mut payload: JsonValue) -> DbtNovaResult<JsonValue> {
+    let safety_policy = serde_json::to_value(trace_mcp_safety_policy()?)
+        .map_err(|error| DbtNovaError::ServerError(error.to_string()))?;
+    let Some(object) = payload.as_object_mut() else {
+        return Err(DbtNovaError::ServerError(
+            "trace tool payload must be a JSON object".to_string(),
+        ));
+    };
+    object.insert("safety_policy".to_string(), safety_policy);
+    Ok(payload)
+}
+
+fn trace_mcp_safety_policy() -> DbtNovaResult<TraceMcpSafetyPolicy> {
+    Ok(TraceMcpSafetyPolicy {
+        filesystem_root: mcp_trace_filesystem_root()?.display().to_string(),
+        trace_writes_enabled_env: MCP_ENABLE_TRACE_WRITES_ENV,
+        local_paths_must_stay_under_filesystem_root: true,
+        write_operations_require_opt_in: true,
+    })
+}
+
+fn require_mcp_trace_writes(tool_name: &str) -> DbtNovaResult<()> {
+    if mcp_trace_writes_enabled() {
+        return Ok(());
+    }
+    Err(DbtNovaError::InvalidParams(format!(
+        "{tool_name} is disabled for MCP/tool-call use; set {MCP_ENABLE_TRACE_WRITES_ENV}=1 to enable trace report and redaction writes"
+    )))
+}
+
+fn mcp_trace_writes_enabled() -> bool {
+    std::env::var(MCP_ENABLE_TRACE_WRITES_ENV)
+        .ok()
+        .map(|value| value.trim().to_ascii_lowercase())
+        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "yes" | "on"))
+}
+
+fn resolve_mcp_trace_existing_file(raw_path: &str, label: &str) -> DbtNovaResult<PathBuf> {
+    let (_root, candidate) = mcp_trace_candidate_path(raw_path, label)?;
+    let canonical = candidate.canonicalize().map_err(|error| {
+        DbtNovaError::InvalidParams(format!(
+            "failed to resolve {label} '{}': {error}",
+            candidate.display()
+        ))
+    })?;
+    let root = mcp_trace_filesystem_root()?;
+    ensure_mcp_trace_path_under_root(&canonical, &root, label)?;
+    if !canonical.is_file() {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "{label} '{}' is not a file",
+            canonical.display()
+        )));
+    }
+    Ok(canonical)
+}
+
+fn resolve_mcp_trace_writable_path(raw_path: &str, label: &str) -> DbtNovaResult<PathBuf> {
+    let (root, candidate) = mcp_trace_candidate_path(raw_path, label)?;
+    if candidate.exists() {
+        let canonical = candidate.canonicalize().map_err(|error| {
+            DbtNovaError::InvalidParams(format!(
+                "failed to resolve {label} '{}': {error}",
+                candidate.display()
+            ))
+        })?;
+        ensure_mcp_trace_path_under_root(&canonical, &root, label)?;
+        return Ok(canonical);
+    }
+    ensure_existing_ancestor_under_trace_root(&candidate, &root, label)?;
+    Ok(candidate)
+}
+
+fn mcp_trace_candidate_path(raw_path: &str, label: &str) -> DbtNovaResult<(PathBuf, PathBuf)> {
+    let trimmed = raw_path.trim();
+    if trimmed.is_empty() {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "{label} must not be empty"
+        )));
+    }
+    let root = mcp_trace_filesystem_root()?;
+    let path = PathBuf::from(trimmed);
+    reject_mcp_trace_parent_dirs(&path, label)?;
+    if !path.is_absolute() {
+        reject_mcp_trace_relative_traversal(&path, label)?;
+    }
+    let candidate = if path.is_absolute() {
+        path
+    } else {
+        root.join(path)
+    };
+    ensure_mcp_trace_path_under_root(&candidate, &root, label)?;
+    Ok((root, candidate))
+}
+
+fn reject_mcp_trace_parent_dirs(path: &Path, label: &str) -> DbtNovaResult<()> {
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "{label} must stay under the server working directory"
+        )));
+    }
+    Ok(())
+}
+
+fn reject_mcp_trace_relative_traversal(path: &Path, label: &str) -> DbtNovaResult<()> {
+    for component in path.components() {
+        match component {
+            Component::Normal(_) | Component::CurDir => {}
+            Component::ParentDir => {
+                return Err(DbtNovaError::InvalidParams(format!(
+                    "{label} must stay under the server working directory"
+                )));
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(DbtNovaError::InvalidParams(format!(
+                    "{label} must be relative or resolve under the server working directory"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn ensure_existing_ancestor_under_trace_root(
+    candidate: &Path,
+    root: &Path,
+    label: &str,
+) -> DbtNovaResult<()> {
+    let mut ancestor = candidate.parent();
+    while let Some(path) = ancestor {
+        if path.exists() {
+            let canonical = path.canonicalize().map_err(|error| {
+                DbtNovaError::InvalidParams(format!(
+                    "failed to resolve parent for {label} '{}': {error}",
+                    path.display()
+                ))
+            })?;
+            return ensure_mcp_trace_path_under_root(&canonical, root, label);
+        }
+        ancestor = path.parent();
+    }
+    Err(DbtNovaError::InvalidParams(format!(
+        "{label} has no existing parent under '{}'",
+        root.display()
+    )))
+}
+
+fn ensure_mcp_trace_path_under_root(path: &Path, root: &Path, label: &str) -> DbtNovaResult<()> {
+    if path.starts_with(root) {
+        return Ok(());
+    }
+    Err(DbtNovaError::InvalidParams(format!(
+        "{label} '{}' is outside server working directory '{}'",
+        path.display(),
+        root.display()
+    )))
+}
+
+fn mcp_trace_filesystem_root() -> DbtNovaResult<PathBuf> {
+    std::env::current_dir()
+        .and_then(|path| path.canonicalize())
+        .map_err(|error| {
+            DbtNovaError::InvalidParams(format!(
+                "failed to resolve server working directory: {error}"
+            ))
+        })
+}
+
+fn render_markdown_summary(read: &ToolTraceRead, summary: &ToolTraceSummary) -> String {
+    let mut out = String::new();
+    out.push_str("# Nova Tool Trace Summary\n\n");
+    append_markdown_overview(&mut out, read, summary);
+    append_markdown_tool_order(&mut out, summary);
+    append_markdown_tool_counts(&mut out, summary);
+    append_markdown_response_budget(&mut out, summary);
+    append_markdown_semantic_signal(&mut out, summary);
+    append_id_list(
+        &mut out,
+        "Selected Unique IDs",
+        &summary.selected_unique_ids,
+    );
+    append_id_list(&mut out, "Top Unique IDs", &summary.top_unique_ids);
+    append_markdown_parse_warnings(&mut out, read);
+
+    out
+}
+
+fn append_markdown_overview(out: &mut String, read: &ToolTraceRead, summary: &ToolTraceSummary) {
+    out.push_str("## Overview\n\n");
+    let _ = writeln!(out, "- path: `{}`", escape_inline(&read.path));
+    let _ = writeln!(out, "- rows: `{}`", summary.row_count);
+    let _ = writeln!(out, "- malformed_rows: `{}`", summary.parse_warning_count);
+    let _ = writeln!(out, "- distinct_tools: `{}`", summary.distinct_tools.len());
+    let _ = writeln!(
+        out,
+        "- total_response_bytes: `{}`",
+        summary.response_budget.total_response_bytes
+    );
+    let _ = writeln!(
+        out,
+        "- response_truncated_count: `{}`",
+        summary.truncation.response_truncated_count
+    );
+    out.push('\n');
+}
+
+fn append_markdown_tool_order(out: &mut String, summary: &ToolTraceSummary) {
+    out.push_str("## Tool Order\n\n");
+    if summary.tool_order.is_empty() {
+        out.push_str("No valid tool-call rows were found.\n\n");
+    } else {
+        out.push_str("| # | tool | success | response_bytes | truncated | error |\n");
+        out.push_str("|---|------|---------|----------------|-----------|-------|\n");
+        for call in &summary.tool_order {
+            let _ = writeln!(
+                out,
+                "| {} | `{}` | {} | {} | {} | {} |",
+                call.tool_call_index,
+                escape_table(&call.tool),
+                call.success
+                    .map_or("unknown".to_string(), |value| value.to_string()),
+                call.response_bytes
+                    .map_or(String::new(), |value| value.to_string()),
+                call.response_truncated,
+                call.error_code
+                    .as_deref()
+                    .map_or(String::new(), escape_table)
+            );
+        }
+        out.push('\n');
+    }
+}
+
+fn append_markdown_tool_counts(out: &mut String, summary: &ToolTraceSummary) {
+    out.push_str("## Tool Counts\n\n");
+    if summary.tool_counts.is_empty() {
+        out.push_str("No tool counts available.\n\n");
+    } else {
+        out.push_str("| tool | calls |\n");
+        out.push_str("|------|-------|\n");
+        for (tool, count) in &summary.tool_counts {
+            let _ = writeln!(out, "| `{}` | {} |", escape_table(tool), count);
+        }
+        out.push('\n');
+    }
+}
+
+fn append_markdown_response_budget(out: &mut String, summary: &ToolTraceSummary) {
+    out.push_str("## Response Budget\n\n");
+    out.push_str("| tool | calls | total_response_bytes | max_response_bytes |\n");
+    out.push_str("|------|-------|----------------------|--------------------|\n");
+    for row in &summary.response_budget.by_tool {
+        let _ = writeln!(
+            out,
+            "| `{}` | {} | {} | {} |",
+            escape_table(&row.tool),
+            row.call_count,
+            row.total_response_bytes,
+            row.max_response_bytes
+                .map_or(String::new(), |value| value.to_string())
+        );
+    }
+    out.push('\n');
+}
+
+fn append_markdown_semantic_signal(out: &mut String, summary: &ToolTraceSummary) {
+    out.push_str("## Semantic-First Signal\n\n");
+    let _ = writeln!(out, "- status: `{}`", summary.semantic_first.status);
+    let _ = writeln!(out, "- message: {}", summary.semantic_first.message);
+    if !summary.semantic_first.metric_like_queries.is_empty() {
+        out.push_str("- metric_like_queries:\n");
+        for query in &summary.semantic_first.metric_like_queries {
+            let _ = writeln!(out, "  - `{}`", escape_inline(query));
+        }
+    }
+    out.push('\n');
+}
+
+fn append_markdown_parse_warnings(out: &mut String, read: &ToolTraceRead) {
+    if !read.parse_warnings.is_empty() {
+        out.push_str("## Parse Warnings\n\n");
+        out.push_str("| line | warning |\n");
+        out.push_str("|------|---------|\n");
+        for warning in &read.parse_warnings {
+            let _ = writeln!(
+                out,
+                "| {} | {} |",
+                warning.line,
+                escape_table(&warning.message)
+            );
+        }
+        out.push('\n');
+    }
+}
+
+fn append_id_list(out: &mut String, title: &str, ids: &[String]) {
+    let _ = writeln!(out, "## {title}\n");
+    if ids.is_empty() {
+        out.push_str("No ids observed.\n\n");
+        return;
+    }
+    for id in ids.iter().take(25) {
+        let _ = writeln!(out, "- `{}`", escape_inline(id));
+    }
+    if ids.len() > 25 {
+        let remaining = ids.len() - 25;
+        let _ = writeln!(out, "- ... {remaining} more");
+    }
+    out.push('\n');
+}
+
+fn print_redaction_human(report: &ToolTraceRedactionReport) {
+    println!("trace redacted");
+    println!("  input_path: {}", report.input_path);
+    println!("  output_path: {}", report.output_path);
+    println!("  rows_read: {}", report.rows_read);
+    println!("  rows_written: {}", report.rows_written);
+    println!("  malformed_rows: {}", report.malformed_rows);
+    println!("  fields_removed: {}", report.fields_removed);
+    println!("  fields_masked: {}", report.fields_masked);
+}
+
+fn escape_inline(value: &str) -> String {
+    value.replace('`', "'")
+}
+
+fn escape_table(value: &str) -> String {
+    escape_inline(value).replace('|', "\\|")
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::{NamedTempFile, TempDir};
+
+    use super::{
+        MCP_ENABLE_TRACE_WRITES_ENV, build_trace_inspect_tool_response,
+        build_trace_redact_tool_response, read_trace_for_cli, render_markdown_summary,
+        run_redact_command, run_summarize_command,
+    };
+    use crate::cli::args::{TraceRedactArgs, TraceSummarizeArgs};
+    use crate::params::{TraceInspectParams, TraceRedactParams};
+    use crate::utils::tool_trace::{read_tool_trace_file, summarize_tool_trace};
+
+    #[test]
+    fn read_trace_for_cli_rejects_missing_file() {
+        let error = read_trace_for_cli("/tmp/dbt-nova-missing-trace.jsonl")
+            .expect_err("missing trace should fail");
+        assert!(error.to_string().contains("does not exist"));
+    }
+
+    #[test]
+    fn summarize_writes_markdown_report() {
+        let trace = NamedTempFile::new().expect("trace");
+        std::fs::write(
+            trace.path(),
+            r#"{"tool":"search_indicator","success":true,"response_bytes":42,"response_truncated":false,"selected_unique_ids":["model.pkg.orders"],"top_unique_ids":["model.pkg.orders"],"params_summary":{"query":"revenue"}}"#,
+        )
+        .expect("write trace");
+        let dir = TempDir::new().expect("dir");
+        let report = dir.path().join("trace.md");
+        let args = TraceSummarizeArgs {
+            path: trace.path().display().to_string(),
+            report_md_path: Some(report.display().to_string()),
+            json: false,
+        };
+
+        assert!(run_summarize_command(&args).is_ok());
+
+        let markdown = std::fs::read_to_string(report).expect("markdown");
+        assert!(markdown.contains("Nova Tool Trace Summary"));
+        assert!(markdown.contains("search_indicator"));
+        assert!(markdown.contains("model.pkg.orders"));
+    }
+
+    #[test]
+    fn markdown_summary_handles_empty_trace() {
+        let trace = NamedTempFile::new().expect("trace");
+        let read = read_tool_trace_file(trace.path());
+        let summary = summarize_tool_trace(&read);
+        let markdown = render_markdown_summary(&read, &summary);
+        assert!(markdown.contains("No valid tool-call rows were found."));
+    }
+
+    #[test]
+    fn redact_command_fails_for_same_output_path() {
+        let trace = NamedTempFile::new().expect("trace");
+        let args = TraceRedactArgs {
+            path: trace.path().display().to_string(),
+            out: trace.path().display().to_string(),
+            json: false,
+        };
+        let error = run_redact_command(&args).expect_err("same path should fail");
+        assert!(error.error.to_string().contains("--out must be different"));
+    }
+
+    #[test]
+    fn trace_inspect_tool_response_returns_summary_contract() {
+        let root = std::env::current_dir()
+            .expect("cwd")
+            .canonicalize()
+            .expect("canonical cwd");
+        let dir = TempDir::new_in(&root).expect("dir");
+        let trace = dir.path().join("trace.jsonl");
+        std::fs::write(
+            &trace,
+            r#"{"tool":"search_indicator","success":true,"response_bytes":42,"response_truncated":false,"params_summary":{"query":"total revenue"}}"#,
+        )
+        .expect("write trace");
+
+        let response = build_trace_inspect_tool_response(&TraceInspectParams {
+            path: trace.display().to_string(),
+        })
+        .expect("trace inspect response");
+
+        assert_eq!(response["success"], serde_json::json!(true));
+        assert_eq!(response["count"], serde_json::json!(1));
+        assert_eq!(
+            response["data"]["summary"]["semantic_first"]["status"],
+            serde_json::json!("observed_without_sql")
+        );
+        assert!(response["data"]["safety_policy"].is_object());
+    }
+
+    #[test]
+    fn trace_redact_tool_response_requires_write_opt_in() {
+        let previous = std::env::var(MCP_ENABLE_TRACE_WRITES_ENV).ok();
+        unsafe { std::env::remove_var(MCP_ENABLE_TRACE_WRITES_ENV) };
+
+        let root = std::env::current_dir()
+            .expect("cwd")
+            .canonicalize()
+            .expect("canonical cwd");
+        let dir = TempDir::new_in(&root).expect("dir");
+        let trace = dir.path().join("trace.jsonl");
+        let out = dir.path().join("trace.redacted.jsonl");
+        std::fs::write(
+            &trace,
+            r#"{"tool":"execute_sql","success":true,"response_bytes":42,"response_truncated":false,"params_summary":{"query":"s3://bucket/path?token=secret"}}"#,
+        )
+        .expect("write trace");
+
+        let params = TraceRedactParams {
+            path: trace.display().to_string(),
+            out: out.display().to_string(),
+        };
+        let error = build_trace_redact_tool_response(&params).expect_err("write gate");
+        assert!(error.to_string().contains(MCP_ENABLE_TRACE_WRITES_ENV));
+
+        unsafe { std::env::set_var(MCP_ENABLE_TRACE_WRITES_ENV, "1") };
+        let response = build_trace_redact_tool_response(&params).expect("redact response");
+        assert_eq!(response["success"], serde_json::json!(true));
+        assert_eq!(response["count"], serde_json::json!(1));
+        assert!(
+            std::fs::read_to_string(out)
+                .expect("redacted")
+                .contains("[REDACTED]")
+        );
+
+        match previous {
+            Some(value) => unsafe { std::env::set_var(MCP_ENABLE_TRACE_WRITES_ENV, value) },
+            None => unsafe { std::env::remove_var(MCP_ENABLE_TRACE_WRITES_ENV) },
+        }
+    }
+}

--- a/src/params.rs
+++ b/src/params.rs
@@ -848,6 +848,32 @@ pub struct RunAgentEvalParams {
     pub read_only: bool,
 }
 
+/// Parameters for the inspect_tool_trace tool.
+#[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+pub struct TraceInspectParams {
+    /// JSONL tool trace path under the server working directory.
+    pub path: String,
+}
+
+/// Parameters for the summarize_tool_trace tool.
+#[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+pub struct TraceSummarizeParams {
+    /// JSONL tool trace path under the server working directory.
+    pub path: String,
+    /// Optional Markdown report path under the server working directory. Requires trace write opt-in.
+    #[serde(default)]
+    pub report_md_path: Option<String>,
+}
+
+/// Parameters for the redact_tool_trace tool.
+#[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+pub struct TraceRedactParams {
+    /// JSONL tool trace path under the server working directory.
+    pub path: String,
+    /// Output JSONL path under the server working directory. Requires trace write opt-in.
+    pub out: String,
+}
+
 /// Parameters for the show_config tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
 pub struct ConfigShowParams {

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -30,6 +30,10 @@ use crate::cli::storage_cmd::{
     build_storage_cleanup_tool_response, build_storage_inspect_tool_response,
     build_storage_prune_tool_response,
 };
+use crate::cli::trace_cmd::{
+    build_trace_inspect_tool_response, build_trace_redact_tool_response,
+    build_trace_summarize_tool_response,
+};
 use crate::config::DbtNovaConfig;
 use crate::error::DbtNovaError;
 use crate::manifest::search::{ManifestSearch, ManifestSearchHandle};
@@ -43,8 +47,9 @@ use crate::params::{
     InitEvalSuiteParams, ListEntitiesParams, ModellingConsistencyReportParams, PaginationParams,
     ParentGroupMode, ReloadManifestParams, RunAgentEvalParams, RunEvalParams, RunRecipeParams,
     SearchColumnsParams, SearchIndicatorParams, SearchParams, SearchRecipesParams,
-    StorageCleanupParams, StorageInspectParams, StoragePruneParams, ValidateDagParams,
-    ValidateEvalSuiteParams, ValidateNovaMetaParams, WarmManifestParams,
+    StorageCleanupParams, StorageInspectParams, StoragePruneParams, TraceInspectParams,
+    TraceRedactParams, TraceSummarizeParams, ValidateDagParams, ValidateEvalSuiteParams,
+    ValidateNovaMetaParams, WarmManifestParams,
 };
 use crate::responses::SuccessResponse;
 use crate::server::health::build_manifest_health_payload;
@@ -1747,6 +1752,45 @@ impl DbtNovaServer {
     async fn run_agent_eval(&self, params: Parameters<RunAgentEvalParams>) -> String {
         self.handle_async("run_agent_eval", None, |_searcher| async move {
             build_agent_eval_tool_response(&params.0).await
+        })
+        .await
+    }
+
+    /// Inspect a local tool-call trace JSONL file.
+    #[tool(
+        name = "inspect_tool_trace",
+        description = "Inspect a local Nova tool-call trace JSONL file and return rows, parse warnings, tool order, counts, response byte budgets, truncation, errors, and semantic-first signals. Trace paths are scoped under the server working directory."
+    )]
+    #[instrument(level = "info", skip(self, params))]
+    async fn inspect_tool_trace(&self, params: Parameters<TraceInspectParams>) -> String {
+        self.handle_async("inspect_tool_trace", None, |_searcher| async move {
+            build_trace_inspect_tool_response(&params.0)
+        })
+        .await
+    }
+
+    /// Summarize a local tool-call trace JSONL file.
+    #[tool(
+        name = "summarize_tool_trace",
+        description = "Summarize a local Nova tool-call trace JSONL file and optionally write a Markdown report. Report writes are disabled unless DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1 is set."
+    )]
+    #[instrument(level = "info", skip(self, params))]
+    async fn summarize_tool_trace(&self, params: Parameters<TraceSummarizeParams>) -> String {
+        self.handle_async("summarize_tool_trace", None, |_searcher| async move {
+            build_trace_summarize_tool_response(&params.0)
+        })
+        .await
+    }
+
+    /// Redact a local tool-call trace JSONL file.
+    #[tool(
+        name = "redact_tool_trace",
+        description = "Redact a local Nova tool-call trace JSONL file for safe sharing. Writes are disabled unless DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1 is set."
+    )]
+    #[instrument(level = "info", skip(self, params))]
+    async fn redact_tool_trace(&self, params: Parameters<TraceRedactParams>) -> String {
+        self.handle_async("redact_tool_trace", None, |_searcher| async move {
+            build_trace_redact_tool_response(&params.0)
         })
         .await
     }

--- a/src/tools/catalog.rs
+++ b/src/tools/catalog.rs
@@ -1,5 +1,5 @@
 /// Canonical MCP tool names exposed by dbt-nova.
-pub const MCP_TOOL_NAMES: [&str; 48] = [
+pub const MCP_TOOL_NAMES: [&str; 51] = [
     "search",
     "search_indicator",
     "indicator_inventory",
@@ -23,6 +23,9 @@ pub const MCP_TOOL_NAMES: [&str; 48] = [
     "run_eval",
     "init_eval_suite",
     "run_agent_eval",
+    "inspect_tool_trace",
+    "summarize_tool_trace",
+    "redact_tool_trace",
     "show_metadata",
     "health",
     "reload_manifest",
@@ -86,7 +89,7 @@ pub struct CliMcpParityEntry {
 /// Keep this matrix in sync with `docs/getting-started/cli.md` and
 /// `docs/api/mcp-cli-parity.md`. Product capabilities should trend from `Gap`
 /// to `Equivalent`; process lifecycle commands may remain `LifecycleException`.
-pub const CLI_MCP_PARITY_MATRIX: [CliMcpParityEntry; 20] = [
+pub const CLI_MCP_PARITY_MATRIX: [CliMcpParityEntry; 23] = [
     CliMcpParityEntry {
         cli_command: "server start",
         mcp_tool: None,
@@ -219,6 +222,27 @@ pub const CLI_MCP_PARITY_MATRIX: [CliMcpParityEntry; 20] = [
         status: CliMcpParityStatus::Equivalent,
         issue: None,
         notes: "MCP returns filtered eval telemetry rows in a standard envelope",
+    },
+    CliMcpParityEntry {
+        cli_command: "trace inspect",
+        mcp_tool: Some("inspect_tool_trace"),
+        status: CliMcpParityStatus::Equivalent,
+        issue: None,
+        notes: "MCP returns the same trace rows, parse warnings, and summary while scoping local paths under the server working directory",
+    },
+    CliMcpParityEntry {
+        cli_command: "trace summarize",
+        mcp_tool: Some("summarize_tool_trace"),
+        status: CliMcpParityStatus::SafetyGated,
+        issue: None,
+        notes: "MCP returns the same summary data; Markdown report writes require DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1",
+    },
+    CliMcpParityEntry {
+        cli_command: "trace redact",
+        mcp_tool: Some("redact_tool_trace"),
+        status: CliMcpParityStatus::SafetyGated,
+        issue: None,
+        notes: "MCP safe-sharing redaction writes require DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1",
     },
     CliMcpParityEntry {
         cli_command: "health check",

--- a/src/utils/tool_trace.rs
+++ b/src/utils/tool_trace.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, OpenOptions, create_dir_all};
 use std::io::Write;
 use std::path::Path;
@@ -9,6 +9,9 @@ use serde::Serialize;
 use serde_json::{Value, json};
 use tracing::warn;
 
+use crate::error::{DbtNovaError, Result};
+use crate::utils::sanitize_uri;
+
 pub const TRACE_ENV: &str = "DBT_NOVA_TRACE_TOOL_CALLS_PATH";
 const MAX_PARAM_KEYS: usize = 50;
 const MAX_ARRAY_ITEMS: usize = 20;
@@ -16,6 +19,45 @@ const MAX_SUMMARY_STRING_CHARS: usize = 256;
 const MAX_SELECTED_UNIQUE_IDS: usize = 200;
 const MAX_TOP_UNIQUE_IDS: usize = 20;
 const MAX_UNIQUE_ID_CHARS: usize = 512;
+const REDACTED_VALUE: &str = "[REDACTED]";
+const TRACE_SUMMARY_SCHEMA_VERSION: &str = "tool_trace_summary.v1";
+const TRACE_REDACTION_SCHEMA_VERSION: &str = "tool_trace_redaction.v1";
+const SAFE_PARAM_SUMMARY_KEYS: [&str; 19] = [
+    "query",
+    "persona",
+    "id_or_name",
+    "resource_type",
+    "resource_types",
+    "recipe_id",
+    "direction",
+    "detail",
+    "group_mode",
+    "indicator_types",
+    "include_support_signals",
+    "max_parent_groups",
+    "preflight_only",
+    "row_limit",
+    "byte_limit",
+    "max_poll_seconds",
+    "limit",
+    "offset",
+    "scope",
+];
+const SENSITIVE_KEY_FRAGMENTS: [&str; 13] = [
+    "authorization",
+    "credential",
+    "password",
+    "passwd",
+    "private_key",
+    "secret",
+    "session",
+    "token",
+    "access_key",
+    "api_key",
+    "apikey",
+    "proof_key",
+    "raw_output",
+];
 const UNINITIALIZED_TOOL_CALL_INDEX: u64 = u64::MAX;
 static TOOL_CALL_INDEX: AtomicU64 = AtomicU64::new(UNINITIALIZED_TOOL_CALL_INDEX);
 
@@ -39,6 +81,101 @@ struct ToolTraceRow {
     total_available: Option<u64>,
     selected_unique_ids: Vec<String>,
     top_unique_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ToolTraceParseWarning {
+    pub line: usize,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolTraceRead {
+    pub path: String,
+    pub rows: Vec<Value>,
+    pub parse_warnings: Vec<ToolTraceParseWarning>,
+    pub missing: bool,
+    pub read_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolTraceSummary {
+    pub schema_version: &'static str,
+    pub row_count: usize,
+    pub parse_warning_count: usize,
+    pub empty: bool,
+    pub message: String,
+    pub tool_order: Vec<ToolTraceCallSummary>,
+    pub tool_counts: BTreeMap<String, usize>,
+    pub distinct_tools: Vec<String>,
+    pub selected_unique_ids: Vec<String>,
+    pub top_unique_ids: Vec<String>,
+    pub response_budget: ToolTraceResponseBudget,
+    pub truncation: ToolTraceTruncationSummary,
+    pub errors: ToolTraceErrorSummary,
+    pub semantic_first: ToolTraceSemanticFirstSummary,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolTraceCallSummary {
+    pub tool_call_index: u64,
+    pub tool: String,
+    pub success: Option<bool>,
+    pub duration_ms: Option<u64>,
+    pub response_bytes: Option<u64>,
+    pub response_truncated: bool,
+    pub error_code: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolTraceResponseBudget {
+    pub total_response_bytes: u64,
+    pub max_response_bytes: Option<u64>,
+    pub max_response_tool: Option<String>,
+    pub rows_missing_response_bytes: usize,
+    pub by_tool: Vec<ToolTraceToolResponseBudget>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolTraceToolResponseBudget {
+    pub tool: String,
+    pub call_count: usize,
+    pub total_response_bytes: u64,
+    pub max_response_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolTraceTruncationSummary {
+    pub response_truncated_count: usize,
+    pub tools_with_truncation: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolTraceErrorSummary {
+    pub failed_tool_call_count: usize,
+    pub error_codes: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolTraceSemanticFirstSummary {
+    pub status: &'static str,
+    pub message: String,
+    pub first_search_indicator_index: Option<u64>,
+    pub first_execute_sql_index: Option<u64>,
+    pub metric_like_queries: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolTraceRedactionReport {
+    pub schema_version: &'static str,
+    pub input_path: String,
+    pub output_path: String,
+    pub rows_read: usize,
+    pub rows_written: usize,
+    pub malformed_rows: usize,
+    pub fields_removed: usize,
+    pub fields_masked: usize,
+    pub parse_warnings: Vec<ToolTraceParseWarning>,
 }
 
 /// Append a sanitized tool-call trace row when `DBT_NOVA_TRACE_TOOL_CALLS_PATH` is set.
@@ -114,6 +251,707 @@ pub fn record_tool_call(
         }
         Err(error) => {
             warn!(path = %trace_path.display(), error = %error, "failed to open tool trace file");
+        }
+    }
+}
+
+#[must_use]
+pub fn read_tool_trace_file(path: &Path) -> ToolTraceRead {
+    let path_display = path.display().to_string();
+    let raw = match fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return ToolTraceRead {
+                path: path_display,
+                rows: Vec::new(),
+                parse_warnings: Vec::new(),
+                missing: true,
+                read_error: None,
+            };
+        }
+        Err(error) => {
+            return ToolTraceRead {
+                path: path_display.clone(),
+                rows: Vec::new(),
+                parse_warnings: Vec::new(),
+                missing: false,
+                read_error: Some(format!(
+                    "failed to read tool trace '{path_display}': {error}"
+                )),
+            };
+        }
+    };
+
+    let mut rows = Vec::new();
+    let mut parse_warnings = Vec::new();
+    for (index, line) in raw.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<Value>(line) {
+            Ok(row) => rows.push(row),
+            Err(error) => parse_warnings.push(ToolTraceParseWarning {
+                line: index + 1,
+                message: error.to_string(),
+            }),
+        }
+    }
+    normalize_tool_trace_indices(&mut rows);
+    ToolTraceRead {
+        path: path_display,
+        rows,
+        parse_warnings,
+        missing: false,
+        read_error: None,
+    }
+}
+
+#[must_use]
+pub fn summarize_tool_trace(read: &ToolTraceRead) -> ToolTraceSummary {
+    let tool_order = build_tool_order(&read.rows);
+    let aggregate = ToolTraceSummaryAccumulator::from_rows(&read.rows);
+
+    ToolTraceSummary {
+        schema_version: TRACE_SUMMARY_SCHEMA_VERSION,
+        row_count: read.rows.len(),
+        parse_warning_count: read.parse_warnings.len(),
+        empty: read.rows.is_empty(),
+        message: trace_summary_message(read),
+        tool_order,
+        tool_counts: aggregate.tool_counts,
+        distinct_tools: aggregate.distinct_tools,
+        selected_unique_ids: aggregate.selected_unique_ids,
+        top_unique_ids: aggregate.top_unique_ids,
+        response_budget: aggregate.response_budget,
+        truncation: aggregate.truncation,
+        errors: aggregate.errors,
+        semantic_first: semantic_first_summary(&read.rows),
+    }
+}
+
+/// Redact a trace file into a conservative JSONL allowlist.
+///
+/// # Errors
+/// Returns an error when input/output paths are unsafe, unreadable, or unwritable.
+pub fn redact_tool_trace_file(path: &Path, out: &Path) -> Result<ToolTraceRedactionReport> {
+    if trace_paths_conflict(path, out) {
+        return Err(DbtNovaError::InvalidParams(
+            "--out must be different from --path".to_string(),
+        ));
+    }
+
+    let read = read_tool_trace_file(path);
+    if read.missing {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "trace file '{}' does not exist",
+            path.display()
+        )));
+    }
+    if let Some(error) = &read.read_error {
+        return Err(DbtNovaError::ServerError(error.clone()));
+    }
+
+    let mut fields_removed = 0usize;
+    let mut fields_masked = 0usize;
+    let mut lines = Vec::with_capacity(read.rows.len());
+    for row in &read.rows {
+        let redacted = redact_trace_row(row, &mut fields_removed, &mut fields_masked);
+        let serialized = serde_json::to_string(&redacted)
+            .map_err(|error| DbtNovaError::ServerError(error.to_string()))?;
+        lines.push(serialized);
+    }
+
+    if let Some(parent) = out.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        create_dir_all(parent)?;
+    }
+    let mut body = lines.join("\n");
+    if !body.is_empty() {
+        body.push('\n');
+    }
+    fs::write(out, body)?;
+
+    Ok(ToolTraceRedactionReport {
+        schema_version: TRACE_REDACTION_SCHEMA_VERSION,
+        input_path: path.display().to_string(),
+        output_path: out.display().to_string(),
+        rows_read: read.rows.len(),
+        rows_written: lines.len(),
+        malformed_rows: read.parse_warnings.len(),
+        fields_removed,
+        fields_masked,
+        parse_warnings: read.parse_warnings,
+    })
+}
+
+fn trace_paths_conflict(path: &Path, out: &Path) -> bool {
+    if path == out {
+        return true;
+    }
+    let Ok(path_canonical) = path.canonicalize() else {
+        return false;
+    };
+    if let Ok(out_canonical) = out.canonicalize() {
+        return path_canonical == out_canonical;
+    }
+
+    let Some(file_name) = out.file_name() else {
+        return false;
+    };
+    let parent = out.parent().filter(|parent| !parent.as_os_str().is_empty());
+    let parent = parent.unwrap_or_else(|| Path::new("."));
+    parent
+        .canonicalize()
+        .is_ok_and(|canonical| canonical.join(file_name) == path_canonical)
+}
+
+fn build_tool_order(rows: &[Value]) -> Vec<ToolTraceCallSummary> {
+    rows.iter()
+        .enumerate()
+        .map(|(index, row)| ToolTraceCallSummary {
+            tool_call_index: row
+                .get("tool_call_index")
+                .and_then(Value::as_u64)
+                .unwrap_or_else(|| u64::try_from(index).unwrap_or(u64::MAX)),
+            tool: row_tool(row),
+            success: row.get("success").and_then(Value::as_bool),
+            duration_ms: row.get("duration_ms").and_then(Value::as_u64),
+            response_bytes: row.get("response_bytes").and_then(Value::as_u64),
+            response_truncated: row
+                .get("response_truncated")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            error_code: row
+                .get("error_code")
+                .and_then(Value::as_str)
+                .map(ToString::to_string),
+        })
+        .collect()
+}
+
+#[derive(Debug, Default)]
+struct ToolBudgetAccumulator {
+    call_count: usize,
+    total_response_bytes: u64,
+    max_response_bytes: Option<u64>,
+}
+
+#[derive(Debug)]
+struct ToolTraceSummaryAccumulator {
+    tool_counts: BTreeMap<String, usize>,
+    distinct_tools: Vec<String>,
+    selected_unique_ids: Vec<String>,
+    top_unique_ids: Vec<String>,
+    response_budget: ToolTraceResponseBudget,
+    truncation: ToolTraceTruncationSummary,
+    errors: ToolTraceErrorSummary,
+}
+
+impl ToolTraceSummaryAccumulator {
+    fn from_rows(rows: &[Value]) -> Self {
+        let mut builder = ToolTraceSummaryBuilder::default();
+        for row in rows {
+            builder.ingest(row);
+        }
+        builder.finish()
+    }
+}
+
+#[derive(Debug, Default)]
+struct ToolTraceSummaryBuilder {
+    tool_counts: BTreeMap<String, usize>,
+    distinct_tools_set: BTreeSet<String>,
+    selected_unique_ids: BTreeSet<String>,
+    top_unique_ids: Vec<String>,
+    top_unique_id_seen: BTreeSet<String>,
+    total_response_bytes: u64,
+    max_response_bytes: Option<u64>,
+    max_response_tool: Option<String>,
+    rows_missing_response_bytes: usize,
+    by_tool: BTreeMap<String, ToolBudgetAccumulator>,
+    response_truncated_count: usize,
+    tools_with_truncation: BTreeSet<String>,
+    failed_tool_call_count: usize,
+    error_codes: BTreeMap<String, usize>,
+}
+
+impl ToolTraceSummaryBuilder {
+    fn ingest(&mut self, row: &Value) {
+        let tool = row_tool(row);
+        self.ingest_tool_counts(&tool);
+        self.ingest_errors(row);
+        self.ingest_unique_ids(row);
+        self.ingest_response_budget(row, &tool);
+        self.ingest_truncation(row, &tool);
+    }
+
+    fn ingest_tool_counts(&mut self, tool: &str) {
+        *self.tool_counts.entry(tool.to_string()).or_insert(0) += 1;
+        self.distinct_tools_set.insert(tool.to_string());
+    }
+
+    fn ingest_errors(&mut self, row: &Value) {
+        if row.get("success").and_then(Value::as_bool) == Some(false) {
+            self.failed_tool_call_count += 1;
+        }
+        if let Some(error_code) = row.get("error_code").and_then(Value::as_str) {
+            *self.error_codes.entry(error_code.to_string()).or_insert(0) += 1;
+        }
+    }
+
+    fn ingest_unique_ids(&mut self, row: &Value) {
+        if let Some(ids) = row.get("selected_unique_ids").and_then(Value::as_array) {
+            for id in ids.iter().filter_map(Value::as_str) {
+                self.selected_unique_ids.insert(id.to_string());
+            }
+        }
+        if let Some(ids) = row.get("top_unique_ids").and_then(Value::as_array) {
+            for id in ids.iter().filter_map(Value::as_str) {
+                let id = id.to_string();
+                if self.top_unique_id_seen.insert(id.clone()) {
+                    self.top_unique_ids.push(id);
+                }
+            }
+        }
+    }
+
+    fn ingest_response_budget(&mut self, row: &Value, tool: &str) {
+        let tool_budget = self.by_tool.entry(tool.to_string()).or_default();
+        tool_budget.call_count += 1;
+
+        let Some(bytes) = row.get("response_bytes").and_then(Value::as_u64) else {
+            self.rows_missing_response_bytes += 1;
+            return;
+        };
+
+        self.total_response_bytes = self.total_response_bytes.saturating_add(bytes);
+        tool_budget.total_response_bytes = tool_budget.total_response_bytes.saturating_add(bytes);
+        tool_budget.max_response_bytes = Some(
+            tool_budget
+                .max_response_bytes
+                .map_or(bytes, |max| max.max(bytes)),
+        );
+        if self.max_response_bytes.is_none_or(|max| bytes > max) {
+            self.max_response_bytes = Some(bytes);
+            self.max_response_tool = Some(tool.to_string());
+        }
+    }
+
+    fn ingest_truncation(&mut self, row: &Value, tool: &str) {
+        let truncated = row
+            .get("response_truncated")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if truncated {
+            self.response_truncated_count += 1;
+            self.tools_with_truncation.insert(tool.to_string());
+        }
+    }
+
+    fn finish(self) -> ToolTraceSummaryAccumulator {
+        let by_tool = self
+            .by_tool
+            .into_iter()
+            .map(|(tool, budget)| ToolTraceToolResponseBudget {
+                tool,
+                call_count: budget.call_count,
+                total_response_bytes: budget.total_response_bytes,
+                max_response_bytes: budget.max_response_bytes,
+            })
+            .collect();
+
+        ToolTraceSummaryAccumulator {
+            tool_counts: self.tool_counts,
+            distinct_tools: self.distinct_tools_set.into_iter().collect(),
+            selected_unique_ids: self.selected_unique_ids.into_iter().collect(),
+            top_unique_ids: self.top_unique_ids,
+            response_budget: ToolTraceResponseBudget {
+                total_response_bytes: self.total_response_bytes,
+                max_response_bytes: self.max_response_bytes,
+                max_response_tool: self.max_response_tool,
+                rows_missing_response_bytes: self.rows_missing_response_bytes,
+                by_tool,
+            },
+            truncation: ToolTraceTruncationSummary {
+                response_truncated_count: self.response_truncated_count,
+                tools_with_truncation: self.tools_with_truncation.into_iter().collect(),
+            },
+            errors: ToolTraceErrorSummary {
+                failed_tool_call_count: self.failed_tool_call_count,
+                error_codes: self.error_codes,
+            },
+        }
+    }
+}
+
+fn trace_summary_message(read: &ToolTraceRead) -> String {
+    let row_count = read.rows.len();
+    let warning_count = read.parse_warnings.len();
+    if read.rows.is_empty() {
+        "trace file contained no valid tool-call rows".to_string()
+    } else if read.parse_warnings.is_empty() {
+        format!("read {row_count} tool-call row(s)")
+    } else {
+        format!("read {row_count} tool-call row(s) with {warning_count} malformed row warning(s)")
+    }
+}
+
+fn row_tool(row: &Value) -> String {
+    row.get("tool")
+        .and_then(Value::as_str)
+        .filter(|tool| !tool.trim().is_empty())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn semantic_first_summary(rows: &[Value]) -> ToolTraceSemanticFirstSummary {
+    let first_search_indicator_index = first_tool_call_index(rows, "search_indicator");
+    let first_execute_sql_index = first_tool_call_index(rows, "execute_sql");
+    let metric_like_queries = metric_like_queries(rows);
+
+    match (first_search_indicator_index, first_execute_sql_index) {
+        (Some(search_index), Some(sql_index)) if search_index < sql_index => {
+            ToolTraceSemanticFirstSummary {
+                status: "pass",
+                message: "search_indicator ran before execute_sql".to_string(),
+                first_search_indicator_index: Some(search_index),
+                first_execute_sql_index: Some(sql_index),
+                metric_like_queries,
+            }
+        }
+        (Some(search_index), Some(sql_index)) => ToolTraceSemanticFirstSummary {
+            status: "warn",
+            message: "execute_sql ran before search_indicator; consider semantic discovery before SQL execution".to_string(),
+            first_search_indicator_index: Some(search_index),
+            first_execute_sql_index: Some(sql_index),
+            metric_like_queries,
+        },
+        (None, Some(sql_index)) if metric_like_queries.is_empty() => ToolTraceSemanticFirstSummary {
+            status: "not_observed",
+            message: "execute_sql was observed, but no metric-like query evidence was available to judge semantic-first behavior".to_string(),
+            first_search_indicator_index: None,
+            first_execute_sql_index: Some(sql_index),
+            metric_like_queries,
+        },
+        (None, Some(sql_index)) => ToolTraceSemanticFirstSummary {
+            status: "warn",
+            message: "metric-like query evidence reached execute_sql without an earlier search_indicator call".to_string(),
+            first_search_indicator_index: None,
+            first_execute_sql_index: Some(sql_index),
+            metric_like_queries,
+        },
+        (Some(search_index), None) => ToolTraceSemanticFirstSummary {
+            status: "observed_without_sql",
+            message: "search_indicator was observed and no execute_sql call was present".to_string(),
+            first_search_indicator_index: Some(search_index),
+            first_execute_sql_index: None,
+            metric_like_queries,
+        },
+        (None, None) => ToolTraceSemanticFirstSummary {
+            status: "not_applicable",
+            message: "trace did not include execute_sql or search_indicator calls".to_string(),
+            first_search_indicator_index: None,
+            first_execute_sql_index: None,
+            metric_like_queries,
+        },
+    }
+}
+
+fn first_tool_call_index(rows: &[Value], tool: &str) -> Option<u64> {
+    rows.iter()
+        .filter(|row| row.get("tool").and_then(Value::as_str) == Some(tool))
+        .filter_map(|row| row.get("tool_call_index").and_then(Value::as_u64))
+        .min()
+}
+
+fn metric_like_queries(rows: &[Value]) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut seen = BTreeSet::new();
+    for row in rows {
+        let Some(query) = row
+            .get("params_summary")
+            .and_then(|params| params.get("query"))
+            .and_then(Value::as_str)
+        else {
+            continue;
+        };
+        if is_metric_like_query(query) && seen.insert(query.to_ascii_lowercase()) {
+            out.push(query.to_string());
+        }
+    }
+    out
+}
+
+fn is_metric_like_query(query: &str) -> bool {
+    let lowered = query.to_ascii_lowercase();
+    [
+        "aov",
+        "average",
+        "conversion",
+        "cost",
+        "count",
+        "gmv",
+        "kpi",
+        "margin",
+        "measure",
+        "metric",
+        "rate",
+        "ratio",
+        "revenue",
+        "sales",
+        "total",
+    ]
+    .iter()
+    .any(|needle| lowered.contains(needle))
+}
+
+fn redact_trace_row(row: &Value, fields_removed: &mut usize, fields_masked: &mut usize) -> Value {
+    let Some(map) = row.as_object() else {
+        return json!({"redaction_warning": "trace row was not an object"});
+    };
+    let mut out = serde_json::Map::new();
+    copy_u128ish_field(map, &mut out, "timestamp_ms", fields_removed);
+    copy_u64_field(map, &mut out, "tool_call_index", fields_removed);
+    copy_string_field(map, &mut out, "transport", fields_removed, fields_masked);
+    copy_string_field(map, &mut out, "tool", fields_removed, fields_masked);
+    copy_bool_field(map, &mut out, "success", fields_removed);
+    copy_u64_field(map, &mut out, "duration_ms", fields_removed);
+    copy_string_field(map, &mut out, "error_code", fields_removed, fields_masked);
+    if let Some(params) = map.get("params_summary") {
+        let redacted = redact_params_summary(params, fields_removed, fields_masked);
+        if !redacted.as_object().is_some_and(serde_json::Map::is_empty) {
+            out.insert("params_summary".to_string(), redacted);
+        }
+    }
+    copy_u64_field(map, &mut out, "response_bytes", fields_removed);
+    copy_bool_field(map, &mut out, "response_truncated", fields_removed);
+    copy_u64_field(map, &mut out, "result_count", fields_removed);
+    copy_u64_field(map, &mut out, "total_available", fields_removed);
+    copy_string_array_field(
+        map,
+        &mut out,
+        "selected_unique_ids",
+        fields_removed,
+        fields_masked,
+    );
+    copy_string_array_field(
+        map,
+        &mut out,
+        "top_unique_ids",
+        fields_removed,
+        fields_masked,
+    );
+
+    for key in map.keys() {
+        if !is_redacted_top_level_key(key) && key != "params_summary" {
+            *fields_removed += 1;
+        }
+    }
+    Value::Object(out)
+}
+
+fn is_redacted_top_level_key(key: &str) -> bool {
+    matches!(
+        key,
+        "timestamp_ms"
+            | "tool_call_index"
+            | "transport"
+            | "tool"
+            | "success"
+            | "duration_ms"
+            | "error_code"
+            | "response_bytes"
+            | "response_truncated"
+            | "result_count"
+            | "total_available"
+            | "selected_unique_ids"
+            | "top_unique_ids"
+    )
+}
+
+fn copy_u128ish_field(
+    input: &serde_json::Map<String, Value>,
+    output: &mut serde_json::Map<String, Value>,
+    key: &str,
+    fields_removed: &mut usize,
+) {
+    if let Some(value) = input.get(key) {
+        if value.as_u64().is_some() {
+            output.insert(key.to_string(), value.clone());
+        } else {
+            *fields_removed += 1;
+        }
+    }
+}
+
+fn copy_u64_field(
+    input: &serde_json::Map<String, Value>,
+    output: &mut serde_json::Map<String, Value>,
+    key: &str,
+    fields_removed: &mut usize,
+) {
+    if let Some(value) = input.get(key) {
+        if value.as_u64().is_some() {
+            output.insert(key.to_string(), value.clone());
+        } else {
+            *fields_removed += 1;
+        }
+    }
+}
+
+fn copy_bool_field(
+    input: &serde_json::Map<String, Value>,
+    output: &mut serde_json::Map<String, Value>,
+    key: &str,
+    fields_removed: &mut usize,
+) {
+    if let Some(value) = input.get(key) {
+        if value.as_bool().is_some() {
+            output.insert(key.to_string(), value.clone());
+        } else {
+            *fields_removed += 1;
+        }
+    }
+}
+
+fn copy_string_field(
+    input: &serde_json::Map<String, Value>,
+    output: &mut serde_json::Map<String, Value>,
+    key: &str,
+    fields_removed: &mut usize,
+    fields_masked: &mut usize,
+) {
+    if let Some(value) = input.get(key) {
+        if let Some(value) = value.as_str() {
+            output.insert(
+                key.to_string(),
+                Value::String(redact_string_value(key, value, fields_masked)),
+            );
+        } else {
+            *fields_removed += 1;
+        }
+    }
+}
+
+fn copy_string_array_field(
+    input: &serde_json::Map<String, Value>,
+    output: &mut serde_json::Map<String, Value>,
+    key: &str,
+    fields_removed: &mut usize,
+    fields_masked: &mut usize,
+) {
+    if let Some(value) = input.get(key) {
+        let Some(items) = value.as_array() else {
+            *fields_removed += 1;
+            return;
+        };
+        let mut strings = Vec::new();
+        for item in items {
+            if let Some(item) = item.as_str() {
+                strings.push(Value::String(redact_string_value(key, item, fields_masked)));
+            } else {
+                *fields_removed += 1;
+            }
+        }
+        output.insert(key.to_string(), Value::Array(strings));
+    }
+}
+
+fn redact_params_summary(
+    params: &Value,
+    fields_removed: &mut usize,
+    fields_masked: &mut usize,
+) -> Value {
+    let Some(map) = params.as_object() else {
+        *fields_removed += 1;
+        return Value::Object(serde_json::Map::new());
+    };
+    let mut out = serde_json::Map::new();
+    for (key, value) in map {
+        if !SAFE_PARAM_SUMMARY_KEYS.contains(&key.as_str()) {
+            *fields_removed += 1;
+            continue;
+        }
+        if let Some(redacted) = redact_safe_summary_value(key, value, fields_masked) {
+            out.insert(key.clone(), redacted);
+        } else {
+            *fields_removed += 1;
+        }
+    }
+    Value::Object(out)
+}
+
+fn redact_safe_summary_value(key: &str, value: &Value, fields_masked: &mut usize) -> Option<Value> {
+    match value {
+        Value::Null | Value::Bool(_) | Value::Number(_) => Some(value.clone()),
+        Value::String(value) => Some(Value::String(redact_string_value(
+            key,
+            value,
+            fields_masked,
+        ))),
+        Value::Array(items) => Some(Value::Array(
+            items
+                .iter()
+                .filter_map(|item| redact_safe_summary_value(key, item, fields_masked))
+                .collect(),
+        )),
+        Value::Object(_) => None,
+    }
+}
+
+fn redact_string_value(key: &str, value: &str, fields_masked: &mut usize) -> String {
+    if sensitive_key(key) || sensitive_value(value) {
+        *fields_masked += 1;
+        return REDACTED_VALUE.to_string();
+    }
+    if looks_like_sensitive_uri(value) {
+        let sanitized = sanitize_uri(value);
+        if sanitized != value {
+            *fields_masked += 1;
+        }
+        return sanitized;
+    }
+    truncate_string(value, MAX_SUMMARY_STRING_CHARS)
+}
+
+fn sensitive_key(key: &str) -> bool {
+    let lowered = key.to_ascii_lowercase();
+    SENSITIVE_KEY_FRAGMENTS
+        .iter()
+        .any(|fragment| lowered.contains(fragment))
+}
+
+fn sensitive_value(value: &str) -> bool {
+    let lowered = value.to_ascii_lowercase();
+    lowered.contains("-----begin ")
+        || lowered.contains("authorization:")
+        || lowered.contains("bearer ")
+        || lowered.contains("snowflake token=")
+}
+
+fn looks_like_sensitive_uri(value: &str) -> bool {
+    let lowered = value.to_ascii_lowercase();
+    (lowered.contains("://") || lowered.contains('?'))
+        && [
+            "access_token",
+            "api_key",
+            "apikey",
+            "password",
+            "secret",
+            "token",
+        ]
+        .iter()
+        .any(|needle| lowered.contains(needle))
+}
+
+pub(crate) fn normalize_tool_trace_indices(rows: &mut [Value]) {
+    for (index, row) in rows.iter_mut().enumerate() {
+        if let Some(obj) = row.as_object_mut() {
+            obj.insert(
+                "tool_call_index".to_string(),
+                Value::from(u64::try_from(index).unwrap_or(u64::MAX)),
+            );
         }
     }
 }
@@ -389,10 +1227,12 @@ fn timestamp_ms() -> u128 {
 #[cfg(test)]
 mod tests {
     use serde_json::json;
+    use tempfile::{NamedTempFile, TempDir};
 
     use super::{
         MAX_SELECTED_UNIQUE_IDS, extract_response_truncated, extract_top_unique_ids,
-        extract_unique_ids, summarize_params,
+        extract_unique_ids, read_tool_trace_file, redact_tool_trace_file, summarize_params,
+        summarize_tool_trace,
     };
 
     #[test]
@@ -467,5 +1307,111 @@ mod tests {
                 "truncated": true
             }
         })));
+    }
+
+    #[test]
+    fn read_tool_trace_file_reports_parse_warnings() {
+        let trace = NamedTempFile::new().expect("trace");
+        std::fs::write(
+            trace.path(),
+            "{\"tool\":\"search\",\"tool_call_index\":99}\nnot-json\n{\"tool\":\"get_context\"}\n",
+        )
+        .expect("write trace");
+
+        let read = read_tool_trace_file(trace.path());
+
+        assert!(!read.missing);
+        assert_eq!(read.rows.len(), 2);
+        assert_eq!(read.parse_warnings.len(), 1);
+        assert_eq!(read.parse_warnings[0].line, 2);
+        assert_eq!(read.rows[0]["tool_call_index"], json!(0));
+        assert_eq!(read.rows[1]["tool_call_index"], json!(1));
+    }
+
+    #[test]
+    fn summarize_tool_trace_reports_order_budgets_and_semantic_first() {
+        let trace = NamedTempFile::new().expect("trace");
+        std::fs::write(
+            trace.path(),
+            concat!(
+                "{\"tool\":\"search_indicator\",\"success\":true,\"duration_ms\":12,",
+                "\"response_bytes\":40,\"response_truncated\":false,",
+                "\"selected_unique_ids\":[\"model.pkg.orders\"],",
+                "\"top_unique_ids\":[\"model.pkg.orders\"],",
+                "\"params_summary\":{\"query\":\"total revenue\"}}\n",
+                "{\"tool\":\"execute_sql\",\"success\":false,\"duration_ms\":30,",
+                "\"response_bytes\":80,\"response_truncated\":true,",
+                "\"error_code\":\"SQL_ERROR\"}\n"
+            ),
+        )
+        .expect("write trace");
+
+        let read = read_tool_trace_file(trace.path());
+        let summary = summarize_tool_trace(&read);
+
+        assert_eq!(summary.row_count, 2);
+        assert_eq!(summary.tool_order[0].tool, "search_indicator");
+        assert_eq!(summary.tool_counts["execute_sql"], 1);
+        assert_eq!(summary.response_budget.total_response_bytes, 120);
+        assert_eq!(summary.truncation.response_truncated_count, 1);
+        assert_eq!(summary.errors.failed_tool_call_count, 1);
+        assert_eq!(summary.errors.error_codes["SQL_ERROR"], 1);
+        assert_eq!(summary.selected_unique_ids, vec!["model.pkg.orders"]);
+        assert_eq!(summary.semantic_first.status, "pass");
+    }
+
+    #[test]
+    fn redact_tool_trace_file_drops_sensitive_fields_and_keeps_summary_evidence() {
+        let trace = NamedTempFile::new().expect("trace");
+        std::fs::write(
+            trace.path(),
+            concat!(
+                "{\"tool\":\"execute_sql\",\"success\":true,\"duration_ms\":1,",
+                "\"params\":{\"parameters\":{\"token\":\"secret\"}},",
+                "\"params_summary\":{\"query\":\"s3://bucket/path?token=secret\",",
+                "\"limit\":5,\"keys\":[\"query\",\"token\"],",
+                "\"parameters\":{\"password\":\"secret\"}},",
+                "\"manifest_uri\":\"s3://bucket/manifest.json?token=secret\",",
+                "\"provider_raw_output\":\"secret stdout\",",
+                "\"response_bytes\":10,\"response_truncated\":false,",
+                "\"selected_unique_ids\":[\"model.pkg.orders\"],",
+                "\"top_unique_ids\":[\"model.pkg.orders\"]}\n",
+                "not-json\n"
+            ),
+        )
+        .expect("write trace");
+        let dir = TempDir::new().expect("dir");
+        let out = dir.path().join("trace.redacted.jsonl");
+
+        let report = redact_tool_trace_file(trace.path(), &out).expect("redact");
+
+        assert_eq!(report.rows_written, 1);
+        assert_eq!(report.malformed_rows, 1);
+        assert!(report.fields_removed >= 4);
+        assert!(report.fields_masked >= 1);
+
+        let redacted = std::fs::read_to_string(out).expect("redacted");
+        assert!(!redacted.contains("secret"));
+        assert!(!redacted.contains("provider_raw_output"));
+        assert!(!redacted.contains("parameters"));
+        assert!(redacted.contains("[REDACTED]"));
+        assert!(redacted.contains("model.pkg.orders"));
+
+        let read = read_tool_trace_file(dir.path().join("trace.redacted.jsonl").as_path());
+        let summary = summarize_tool_trace(&read);
+        assert_eq!(summary.row_count, 1);
+        assert_eq!(summary.tool_order[0].tool, "execute_sql");
+    }
+
+    #[test]
+    fn redact_tool_trace_file_rejects_same_canonical_output_path() {
+        let dir = TempDir::new().expect("dir");
+        let trace = dir.path().join("trace.jsonl");
+        std::fs::write(&trace, "{\"tool\":\"search\"}\n").expect("write trace");
+        let out = dir.path().join(".").join("trace.jsonl");
+
+        let error = redact_tool_trace_file(&trace, &out).expect_err("same canonical path");
+
+        assert!(error.to_string().contains("--out must be different"));
     }
 }


### PR DESCRIPTION
## Summary
- Add direct CLI commands: `trace inspect`, `trace summarize`, and `trace redact`.
- Add MCP/tool-call parity through `inspect_tool_trace`, `summarize_tool_trace`, and `redact_tool_trace`, with write operations gated by `DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1`.
- Extract shared trace parsing/summarization helpers, preserve eval trace behavior, add conservative redaction, and document safe-sharing workflows.

Linear: JOE-112, JOE-113

## Validation
- `cargo fmt --check`
- `git diff --check`
- `uv run --with-requirements docs/requirements.txt mkdocs build --strict`
- `bash scripts/check_config_reference.sh`
- `cargo test --locked --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`

## Manual Smoke
- Captured a real tool-call trace with `DBT_NOVA_TRACE_TOOL_CALLS_PATH=.nova/trace-review-smoke/tool-calls.jsonl cargo run --locked -- tool call search_indicator ...`.
- Ran `cargo run --locked -- trace inspect --path .nova/trace-review-smoke/tool-calls.jsonl --json`.
- Ran `cargo run --locked -- trace redact --path .nova/trace-review-smoke/tool-calls.jsonl --out .nova/trace-review-smoke/tool-calls.redacted.jsonl --json`.
- Ran `cargo run --locked -- trace summarize --path .nova/trace-review-smoke/tool-calls.redacted.jsonl --report-md-path .nova/trace-review-smoke/tool-calls.redacted.md --json`.
- Checked redacted JSONL for obvious sensitive markers with `rg`; no matches.

## Review Notes
- Deep local review found one path-conflict issue before PR packaging; fixed by rejecting canonical input/output collisions for redaction.
- JOE-111 is already complete in Linear via #210; this PR closes the next trace UX tickets.