### PR TITLE
Add deterministic trace replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tool-call JSONL, writing Markdown trace summaries, and producing conservative
   redacted trace artifacts for safe sharing. MCP trace writes require
   `DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1`.
+- Added `dbt-nova trace replay` and MCP/CLI `tool call` parity through
+  `replay_tool_trace` to replay supported deterministic trace rows against a
+  manifest, compare compact response-shape evidence, and explicitly skip
+  unsupported, unsafe, under-specified, or SQL-execution rows.
 - Added `dbt-nova audit agent-readiness` for metadata-only agent readiness
   reports that combine project metadata scores, entity signal gaps, Nova
   indicator checks, optional eval gate evidence, JSON/Markdown artifacts, and

--- a/docs/api/mcp-cli-parity.md
+++ b/docs/api/mcp-cli-parity.md
@@ -5,7 +5,7 @@ dbt-nova exposes two callable product surfaces:
 - MCP tools, used by MCP clients and hosted deployments.
 - CLI commands, used for one-shot local workflows and CI automation.
 
-The MCP catalog currently contains 51 MCP tools. `dbt-nova tool call` is the
+The MCP catalog currently contains 52 MCP tools. `dbt-nova tool call` is the
 CLI bridge to that same canonical tool catalog. Other CLI leaf commands are
 tracked below so each capability is either MCP-equivalent, a known parity gap,
 explicitly safety-gated, or a lifecycle exception.
@@ -31,7 +31,7 @@ sets the documented opt-in environment variable for local execution or writes.
 | `manifest load` | `health` | Lifecycle exception | - | MCP server startup performs the initial manifest load; `health` reports the active loaded manifest and `reload_manifest` replaces it. |
 | `manifest reload` | `reload_manifest` | Equivalent | - | MCP starts a background reload for the live server; CLI `manifest reload` and CLI `tool call reload_manifest` are one-shot reloads. |
 | `manifest warm` | `warm_manifest` | SafetyGated | - | MCP semantic cache warmup requires `DBT_NOVA_MCP_ENABLE_MANIFEST_WARM=1` and uses the current manifest source. |
-| `tool call <tool_name>` | 51 MCP tools | Equivalent | - | CLI tool-call mode supports the canonical MCP tool catalog. |
+| `tool call <tool_name>` | 52 MCP tools | Equivalent | - | CLI tool-call mode supports the canonical MCP tool catalog. |
 | `audit agent-readiness` | `get_agent_readiness` | Equivalent | - | MCP returns the same `agent_readiness.v1` report without CLI file writes. |
 | `audit metadata-score` | `get_metadata_audit` | Equivalent | - | MCP returns the same metadata audit report without CLI file writes or exit semantics. |
 | `audit nova-meta` | `validate_nova_meta` | Equivalent | - | MCP returns the same nova-meta validation report with scoped local path access. |
@@ -49,6 +49,7 @@ sets the documented opt-in environment variable for local execution or writes.
 | `trace inspect` | `inspect_tool_trace` | Equivalent | - | MCP returns the same trace rows, parse warnings, and summary while scoping local paths under the server working directory. |
 | `trace summarize` | `summarize_tool_trace` | SafetyGated | - | MCP returns the same summary data; Markdown report writes require `DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1`. |
 | `trace redact` | `redact_tool_trace` | SafetyGated | - | MCP safe-sharing redaction writes require `DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1`. |
+| `trace replay` | `replay_tool_trace` | Equivalent | - | MCP replays supported deterministic trace rows against the currently loaded manifest; CLI replay loads an explicit manifest source. |
 | `health check` | `health` | Equivalent | - | Both surfaces report manifest/server readiness. |
 
 ## Drift Guards

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -1,6 +1,6 @@
 # Tools Quick Reference
 
-One-page cheatsheet for all 51 dbt-nova MCP tools.
+One-page cheatsheet for all 52 dbt-nova MCP tools.
 
 ## Discovery
 
@@ -79,6 +79,7 @@ One-page cheatsheet for all 51 dbt-nova MCP tools.
 | `inspect_tool_trace` | Inspect tool-call trace JSONL rows and parse warnings | `path` |
 | `summarize_tool_trace` | Summarize trace order, budgets, errors, IDs, and semantic-first signal | `path`, `report_md_path` |
 | `redact_tool_trace` | Redact trace JSONL for safe sharing | `path`, `out` |
+| `replay_tool_trace` | Replay supported deterministic trace rows against the loaded manifest | `path` |
 
 ## Metadata Inventory
 

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-This reference lists all 51 MCP tools exposed by dbt‑nova, grouped by category.
+This reference lists all 52 MCP tools exposed by dbt‑nova, grouped by category.
 All tools return the standard envelope described in [Response Format](response-format.md).
 For CLI equivalents and known parity gaps, see
 [MCP/CLI Parity](mcp-cli-parity.md).
@@ -915,6 +915,23 @@ Redaction writes are disabled unless `DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1` is set
 
 ```json
 {"name":"redact_tool_trace","arguments":{"path":".nova/eval-runs/agent/tool-calls/metric_lookup_flow.jsonl","out":".nova/eval-runs/agent/tool-calls/metric_lookup_flow.redacted.jsonl"}}
+```
+
+### `replay_tool_trace`
+Replay supported deterministic Nova tool calls from a local trace JSONL file
+against the currently loaded MCP manifest. Unsupported, unsafe,
+under-specified, and `execute_sql` rows are skipped with explicit reasons.
+Replay compares response-shape evidence such as success, result count,
+truncation, selected IDs, and top IDs; it does not return full response diffs.
+
+Required:
+- `path`: trace JSONL path under the MCP server working directory
+
+Supported replay tools are `search`, `search_indicator`, `search_columns`,
+`get_entity`, `get_context`, and `get_lineage`.
+
+```json
+{"name":"replay_tool_trace","arguments":{"path":".nova/eval-runs/agent/tool-calls/metric_lookup_flow.redacted.jsonl"}}
 ```
 
 ### `get_undocumented`

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -27,7 +27,7 @@ flowchart TD
 
 ## Architecture Overview (Detailed)
 
-### Tool Map (51 MCP tools)
+### Tool Map (52 MCP tools)
 
 <div class="diagram-large diagram-vertical" markdown>
 
@@ -93,6 +93,7 @@ flowchart LR
     TR --> T_inspect_tool_trace["inspect_tool_trace"]
     TR --> T_summarize_tool_trace["summarize_tool_trace"]
     TR --> T_redact_tool_trace["redact_tool_trace"]
+    TR --> T_replay_tool_trace["replay_tool_trace"]
     TR --> T_metadata_score["get_metadata_score"]
     TR --> T_metadata_audit["get_metadata_audit"]
     TR --> T_agent_readiness["get_agent_readiness"]

--- a/docs/features/traces.md
+++ b/docs/features/traces.md
@@ -2,12 +2,15 @@
 
 Nova can record sanitized tool-call traces when
 `DBT_NOVA_TRACE_TOOL_CALLS_PATH` is set. Trace files are JSONL: one JSON object
-per observed Nova tool call. Use the `trace` commands to inspect, summarize, and
-redact those files before attaching them to PRs, eval artifacts, or support
-threads.
+per observed Nova tool call. Use the `trace` commands to inspect, summarize,
+redact, and replay those files before attaching evidence to PRs, eval
+artifacts, or support threads.
 
-Trace commands operate on local files only. They do not replay tool calls, call
-providers, execute SQL, upload artifacts, or read arbitrary provider logs.
+Trace commands operate on local files only. Inspect, summarize, and redact do
+not replay tool calls, call providers, execute SQL, upload artifacts, or read
+arbitrary provider logs. `trace replay` replays only supported deterministic
+Nova tool calls against a local manifest; it still does not call providers or
+execute SQL.
 
 ## Capture A Trace
 
@@ -73,10 +76,12 @@ The same trace review surface is available to MCP clients and
 - `inspect_tool_trace` maps to `trace inspect`
 - `summarize_tool_trace` maps to `trace summarize`
 - `redact_tool_trace` maps to `trace redact`
+- `replay_tool_trace` maps to `trace replay`
 
 MCP trace paths are scoped under the server working directory. Read-only inspect
-and summarize calls can return JSON data directly. Markdown report writes and
-redacted JSONL writes require `DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1`.
+and summarize calls can return JSON data directly. `replay_tool_trace` replays
+against the currently loaded MCP manifest. Markdown report writes and redacted
+JSONL writes require `DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1`.
 
 ## Redact
 
@@ -91,8 +96,10 @@ dbt-nova trace redact \
 
 - `timestamp_ms`, `tool_call_index`, `transport`, and `tool`
 - `success`, `duration_ms`, and `error_code`
-- safe scalar parameter summaries such as `query`, `persona`, `id_or_name`,
-  `resource_type`, `indicator_types`, `limit`, and `offset`
+- safe scalar or string-array parameter summaries such as `query`, `persona`,
+  `id_or_name`, `resource_type`, `resource_types`, `roles`,
+  `semantic_types`, `indicator_types`, `direction`, `depth`, `limit`, and
+  `offset`
 - `response_bytes`, `response_truncated`, `result_count`, and
   `total_available`
 - `selected_unique_ids` and `top_unique_ids`
@@ -107,6 +114,53 @@ It removes or masks:
 - malformed JSONL rows, which are reported in the redaction summary
 
 Redacted output remains compatible with `trace inspect` and `trace summarize`.
+
+## Replay
+
+```bash
+dbt-nova trace replay \
+  --path out/tool-calls/analyst-smoke.redacted.jsonl \
+  --manifest-path target/manifest.json \
+  --json
+```
+
+`trace replay` is a narrow isolation tool. It re-executes supported,
+deterministic Nova tool calls from a trace against a supplied manifest and
+reports whether the current Nova response still succeeds and whether stable
+evidence changed.
+
+Replay uses only sanitized scalar or string-array values from `params_summary`.
+It never uses raw nested `params`, SQL parameter maps, provider prompts, or
+provider output. This means replay works with redacted traces and avoids
+accidentally turning a support artifact into a credential source.
+
+Supported replay tools:
+
+- `search`
+- `search_indicator`
+- `search_columns`
+- `get_entity`
+- `get_context`
+- `get_lineage`
+
+Each trace row receives one status:
+
+- `replayed`: the supported call ran and comparable evidence matched
+- `changed`: the call ran, but stable evidence such as selected/top IDs,
+  result count, success state, or truncation changed
+- `skipped`: the row was intentionally not replayed because it was
+  under-specified, unsafe, or `execute_sql`
+- `failed`: the replayed Nova tool returned an error
+- `unsupported`: the tool is outside the deterministic replay allowlist
+
+`execute_sql` is skipped by default and is not replayed from Nova traces because
+trace rows deliberately do not store raw SQL. Use evals or a reviewed SQL file
+when you need to re-run warehouse queries.
+
+The replay report includes manifest identity, parse warnings, supported tools,
+status counts, per-row reasons, compact original/replayed response-shape
+summaries, and a list of changed evidence fields. It does not include full
+response JSON diffs.
 
 ## Safe To Share Checklist
 
@@ -126,9 +180,10 @@ Before sharing trace artifacts:
 
 ## Limitations
 
-Trace summaries prove tool-use behavior, not answer correctness. Use bridge or
-provider-backed evals when you need assertions about ranked results, selected
-entities, or final answers.
+Trace summaries and replay reports prove tool-use behavior and deterministic
+Nova-tool stability, not final answer correctness. Use bridge or provider-backed
+evals when you need assertions about ranked results, selected entities, SQL
+logic, or final answers.
 
 The redactor intentionally drops detail when it cannot prove a field is safe.
 This can remove useful debugging context, but avoids leaking sensitive values.

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -4,7 +4,7 @@ Use `dbt-nova` in two modes:
 
 - No subcommand: start MCP server (backward compatible behavior)
 - Subcommand: run one-shot CLI commands and exit
-- CLI surface: 23 CLI leaf commands, including `tool call` access to all 51 MCP tools
+- CLI surface: 24 CLI leaf commands, including `tool call` access to all 52 MCP tools
 
 For the command-by-command MCP equivalent map, see
 [MCP/CLI Parity](../api/mcp-cli-parity.md).
@@ -29,6 +29,7 @@ dbt-nova
 ├── trace inspect --path <PATH> [--json]
 ├── trace summarize --path <PATH> [--report-md-path <PATH>] [--json]
 ├── trace redact --path <PATH> --out <PATH> [--json]
+├── trace replay --path <PATH> [--manifest-path|--manifest-uri] [--storage-instance-id] [--cleanup-storage-on-start] [--read-only] [--json]
 ├── eval init --out <PATH> [--persona] [--force]
 ├── eval validate --suite <PATH> [--json]
 ├── eval run --suite <PATH> [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--telemetry] [--telemetry-retention] [--case-id <ID>...] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
@@ -154,10 +155,15 @@ dbt-nova trace redact \
   --path out/nova-evals/tool-calls/analyst-smoke.jsonl \
   --out out/nova-evals/tool-calls/analyst-smoke.redacted.jsonl \
   --json
+
+dbt-nova trace replay \
+  --path out/nova-evals/tool-calls/analyst-smoke.redacted.jsonl \
+  --manifest-path /path/to/target/manifest.json \
+  --json
 ```
 
 See [Trace Inspection And Redaction](../features/traces.md) for safe-sharing
-guidance and Markdown report fields.
+guidance, Markdown report fields, and deterministic replay limits.
 
 ### Agent-readiness report for CI
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,8 +105,8 @@ dbt-nova
 
 | Feature | Description |
 |---------|-------------|
-| **51 MCP Tools** | Server-exposed MCP surface for search, lineage, coverage, scoring, SQL execution, reports, evals, trace review, cache warming, config, storage, and recipes |
-| **23 CLI Leaf Commands** | One-shot commands for server startup, manifest lifecycle, audits, config, storage, evals, trace review, health, and tool calls |
+| **52 MCP Tools** | Server-exposed MCP surface for search, lineage, coverage, scoring, SQL execution, reports, evals, trace review, cache warming, config, storage, and recipes |
+| **24 CLI Leaf Commands** | One-shot commands for server startup, manifest lifecycle, audits, config, storage, evals, trace review, health, and tool calls |
 | **Hybrid Search** | Tantivy BM25 + vector + sparse + reranking |
 | **Multi-Source** | Local files, HTTP, S3, GCS, DBFS |
 | **Personas** | Analyst, Engineer, Governance profiles |

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -166,6 +166,7 @@ pub enum TraceCommand {
     Inspect(TraceInspectArgs),
     Summarize(TraceSummarizeArgs),
     Redact(TraceRedactArgs),
+    Replay(TraceReplayArgs),
 }
 
 #[derive(Debug, Clone, Args, Default)]
@@ -192,6 +193,24 @@ pub struct TraceRedactArgs {
     pub path: String,
     #[arg(long, value_name = "PATH")]
     pub out: String,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Args, Default)]
+pub struct TraceReplayArgs {
+    #[arg(long, value_name = "PATH")]
+    pub path: String,
+    #[arg(long, value_name = "PATH", conflicts_with = "manifest_uri")]
+    pub manifest_path: Option<String>,
+    #[arg(long, value_name = "URI", conflicts_with = "manifest_path")]
+    pub manifest_uri: Option<String>,
+    #[arg(long, value_name = "INSTANCE_ID")]
+    pub storage_instance_id: Option<String>,
+    #[arg(long, default_value_t = false)]
+    pub cleanup_storage_on_start: bool,
+    #[arg(long, default_value_t = false)]
+    pub read_only: bool,
     #[arg(long, default_value_t = false)]
     pub json: bool,
 }
@@ -1050,6 +1069,33 @@ mod tests {
                 };
                 assert_eq!(args.path, "tool-calls.jsonl");
                 assert_eq!(args.out, "tool-calls.redacted.jsonl");
+                assert!(args.json);
+            }
+            _ => panic!("expected trace command"),
+        }
+
+        let replay = Cli::parse_from([
+            "dbt-nova",
+            "trace",
+            "replay",
+            "--path",
+            "tool-calls.redacted.jsonl",
+            "--manifest-path",
+            "target/manifest.json",
+            "--storage-instance-id",
+            "trace-replay",
+            "--read-only",
+            "--json",
+        ]);
+        match replay.command.expect("command") {
+            Command::Trace(trace) => {
+                let TraceCommand::Replay(args) = trace.command else {
+                    panic!("expected trace replay command");
+                };
+                assert_eq!(args.path, "tool-calls.redacted.jsonl");
+                assert_eq!(args.manifest_path.as_deref(), Some("target/manifest.json"));
+                assert_eq!(args.storage_instance_id.as_deref(), Some("trace-replay"));
+                assert!(args.read_only);
                 assert!(args.json);
             }
             _ => panic!("expected trace command"),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -89,6 +89,9 @@ pub async fn dispatch(command: args::Command) -> DispatchResult {
                 trace_cmd::run_summarize_command(&summarize_args)
             }
             args::TraceCommand::Redact(redact_args) => trace_cmd::run_redact_command(&redact_args),
+            args::TraceCommand::Replay(replay_args) => {
+                trace_cmd::run_replay_command(&replay_args).await
+            }
         },
         args::Command::Health(health_args) => match health_args.command {
             args::HealthCommand::Check(check_args) => {

--- a/src/cli/tool.rs
+++ b/src/cli/tool.rs
@@ -30,7 +30,7 @@ use crate::cli::storage_cmd::{
 };
 use crate::cli::trace_cmd::{
     build_trace_inspect_tool_response, build_trace_redact_tool_response,
-    build_trace_summarize_tool_response,
+    build_trace_replay_tool_response, build_trace_summarize_tool_response,
 };
 use crate::error::{DbtNovaError, Result};
 use crate::manifest::search::ManifestSearch;
@@ -45,8 +45,8 @@ use crate::params::{
     ReloadManifestParams, RunAgentEvalParams, RunEvalParams, RunRecipeParams, SearchColumnsParams,
     SearchIndicatorParams, SearchParams, SearchRecipesParams, StorageCleanupParams,
     StorageInspectParams, StoragePruneParams, TraceInspectParams, TraceRedactParams,
-    TraceSummarizeParams, ValidateDagParams, ValidateEvalSuiteParams, ValidateNovaMetaParams,
-    WarmManifestParams,
+    TraceReplayParams, TraceSummarizeParams, ValidateDagParams, ValidateEvalSuiteParams,
+    ValidateNovaMetaParams, WarmManifestParams,
 };
 use crate::responses::SuccessResponse;
 
@@ -61,7 +61,7 @@ struct ToolRegistryEntry {
     dispatch: ToolDispatchFn,
 }
 
-const TOOL_REGISTRY: [ToolRegistryEntry; 51] = [
+const TOOL_REGISTRY: [ToolRegistryEntry; 52] = [
     ToolRegistryEntry {
         name: "search",
         dispatch: dispatch_search,
@@ -165,6 +165,10 @@ const TOOL_REGISTRY: [ToolRegistryEntry; 51] = [
     ToolRegistryEntry {
         name: "redact_tool_trace",
         dispatch: dispatch_redact_tool_trace,
+    },
+    ToolRegistryEntry {
+        name: "replay_tool_trace",
+        dispatch: dispatch_replay_tool_trace,
     },
     ToolRegistryEntry {
         name: "show_metadata",
@@ -811,6 +815,13 @@ fn dispatch_redact_tool_trace(_searcher: &ManifestSearch, params: JsonValue) -> 
     Box::pin(async move {
         let decoded: TraceRedactParams = decode_tool_params("redact_tool_trace", params)?;
         build_trace_redact_tool_response(&decoded)
+    })
+}
+
+fn dispatch_replay_tool_trace(searcher: &ManifestSearch, params: JsonValue) -> ToolFuture<'_> {
+    Box::pin(async move {
+        let decoded: TraceReplayParams = decode_tool_params("replay_tool_trace", params)?;
+        build_trace_replay_tool_response(searcher, &decoded).await
     })
 }
 

--- a/src/cli/trace_cmd.rs
+++ b/src/cli/trace_cmd.rs
@@ -4,16 +4,24 @@ use std::path::{Component, Path, PathBuf};
 use std::time::Instant;
 
 use serde::Serialize;
-use serde_json::Value as JsonValue;
+use serde_json::{Map as JsonMap, Value as JsonValue};
 
-use crate::cli::args::{TraceInspectArgs, TraceRedactArgs, TraceSummarizeArgs};
+use crate::cli::args::{
+    ManifestLoadArgs, TraceInspectArgs, TraceRedactArgs, TraceReplayArgs, TraceSummarizeArgs,
+};
+use crate::cli::manifest::{build_manifest_load_config, execute_manifest_load};
 use crate::cli::output::{CliEnvelope, error_envelope};
+use crate::cli::tool::dispatch_tool;
 use crate::error::{DbtNovaError, Result as DbtNovaResult};
-use crate::params::{TraceInspectParams, TraceRedactParams, TraceSummarizeParams};
+use crate::manifest::search::ManifestSearch;
+use crate::params::{
+    TraceInspectParams, TraceRedactParams, TraceReplayParams, TraceSummarizeParams,
+};
 use crate::responses::SuccessResponse;
 use crate::utils::tool_trace::{
     ToolTraceParseWarning, ToolTraceRead, ToolTraceRedactionReport, ToolTraceSummary,
-    read_tool_trace_file, redact_tool_trace_file, summarize_tool_trace,
+    extract_response_truncated, extract_top_unique_ids, extract_unique_ids, read_tool_trace_file,
+    redact_tool_trace_file, summarize_tool_trace,
 };
 
 use super::{DispatchError, DispatchResult};
@@ -39,12 +47,81 @@ struct TraceSummarizeData {
 }
 
 #[derive(Debug, Serialize)]
+struct TraceReplayData {
+    schema_version: &'static str,
+    path: String,
+    manifest: TraceReplayManifest,
+    row_count: usize,
+    parse_warnings: Vec<ToolTraceParseWarning>,
+    supported_tools: Vec<&'static str>,
+    counts: TraceReplayCounts,
+    results: Vec<TraceReplayRow>,
+}
+
+#[derive(Debug, Serialize)]
+struct TraceReplayManifest {
+    manifest_hash: String,
+    manifest_version: String,
+    source: String,
+    entity_count: usize,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct TraceReplayCounts {
+    replayed: usize,
+    changed: usize,
+    skipped: usize,
+    failed: usize,
+    unsupported: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct TraceReplayRow {
+    tool_call_index: u64,
+    tool: String,
+    status: &'static str,
+    reason: Option<String>,
+    replay_duration_ms: Option<u64>,
+    original: TraceReplayShape,
+    replayed: Option<TraceReplayShape>,
+    changes: Vec<TraceReplayChange>,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct TraceReplayShape {
+    success: Option<bool>,
+    count: Option<u64>,
+    total_available: Option<u64>,
+    response_truncated: bool,
+    error_code: Option<String>,
+    selected_unique_ids: Vec<String>,
+    top_unique_ids: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct TraceReplayChange {
+    field: &'static str,
+    before: JsonValue,
+    after: JsonValue,
+}
+
+#[derive(Debug, Serialize)]
 struct TraceMcpSafetyPolicy {
     filesystem_root: String,
     trace_writes_enabled_env: &'static str,
     local_paths_must_stay_under_filesystem_root: bool,
     write_operations_require_opt_in: bool,
 }
+
+const TRACE_REPLAY_SCHEMA_VERSION: &str = "trace_replay.v1";
+const TRACE_REPLAY_SUPPORTED_TOOLS: [&str; 6] = [
+    "search",
+    "search_indicator",
+    "search_columns",
+    "get_entity",
+    "get_context",
+    "get_lineage",
+];
 
 /// Runs the `trace inspect` CLI command.
 ///
@@ -151,6 +228,64 @@ pub fn run_redact_command(args: &TraceRedactArgs) -> DispatchResult {
     }
 }
 
+/// Runs the `trace replay` CLI command.
+///
+/// # Errors
+/// Returns an error when the trace or manifest cannot be loaded, replay fails
+/// unexpectedly, or output cannot be rendered.
+pub async fn run_replay_command(args: &TraceReplayArgs) -> DispatchResult {
+    let started = Instant::now();
+    let read = read_trace_path(Path::new(&args.path)).map_err(|error| {
+        render_or_propagate_error(
+            args.json,
+            "trace replay",
+            error,
+            started.elapsed().as_millis(),
+        )
+    })?;
+    let config = build_manifest_load_config(&ManifestLoadArgs {
+        manifest_path: args.manifest_path.clone(),
+        manifest_uri: args.manifest_uri.clone(),
+        storage_instance_id: args.storage_instance_id.clone(),
+        cleanup_storage_on_start: args.cleanup_storage_on_start,
+        read_only: args.read_only,
+        json: false,
+    })
+    .map_err(|error| {
+        render_or_propagate_error(
+            args.json,
+            "trace replay",
+            error,
+            started.elapsed().as_millis(),
+        )
+    })?;
+    let load = execute_manifest_load(config).await.map_err(|error| {
+        render_or_propagate_error(
+            args.json,
+            "trace replay",
+            error,
+            started.elapsed().as_millis(),
+        )
+    })?;
+    let payload = replay_trace_read(&load.search, read)
+        .await
+        .map_err(|error| {
+            render_or_propagate_error(
+                args.json,
+                "trace replay",
+                error,
+                started.elapsed().as_millis(),
+            )
+        })?;
+
+    if args.json {
+        print_json_envelope("trace replay", &payload, started.elapsed().as_millis())
+    } else {
+        print_replay_human(&payload);
+        Ok(())
+    }
+}
+
 /// Builds the MCP/CLI-tool response for trace inspection.
 ///
 /// # Errors
@@ -217,6 +352,543 @@ pub fn build_trace_redact_tool_response(params: &TraceRedactParams) -> DbtNovaRe
     let count = report.rows_written;
     let payload = with_trace_safety_policy(serde_json::to_value(report)?)?;
     success_value(payload, count)
+}
+
+/// Builds the MCP/CLI-tool response for trace replay.
+///
+/// # Errors
+/// Returns an error when the trace path is unsafe, missing, unreadable, or the
+/// replay report cannot be serialized.
+pub async fn build_trace_replay_tool_response(
+    searcher: &ManifestSearch,
+    params: &TraceReplayParams,
+) -> DbtNovaResult<JsonValue> {
+    let path = resolve_mcp_trace_existing_file(&params.path, "path")?;
+    let read = read_trace_path(&path)?;
+    let count = read.rows.len();
+    let report = replay_trace_read(searcher, read).await?;
+    let payload = with_trace_safety_policy(serde_json::to_value(report)?)?;
+    success_value(payload, count)
+}
+
+async fn replay_trace_read(
+    searcher: &ManifestSearch,
+    read: ToolTraceRead,
+) -> DbtNovaResult<TraceReplayData> {
+    let mut counts = TraceReplayCounts::default();
+    let mut results = Vec::with_capacity(read.rows.len());
+    for (index, row) in read.rows.iter().enumerate() {
+        let result = replay_trace_row(searcher, row, index).await;
+        counts.ingest(result.status);
+        results.push(result);
+    }
+
+    Ok(TraceReplayData {
+        schema_version: TRACE_REPLAY_SCHEMA_VERSION,
+        path: read.path,
+        manifest: TraceReplayManifest {
+            manifest_hash: searcher.manifest_hash.clone(),
+            manifest_version: searcher.manifest_version.clone(),
+            source: crate::utils::sanitize_uri(&searcher.manifest_source_uri),
+            entity_count: searcher.entity_count(),
+        },
+        row_count: results.len(),
+        parse_warnings: read.parse_warnings,
+        supported_tools: TRACE_REPLAY_SUPPORTED_TOOLS.to_vec(),
+        counts,
+        results,
+    })
+}
+
+async fn replay_trace_row(
+    searcher: &ManifestSearch,
+    row: &JsonValue,
+    index: usize,
+) -> TraceReplayRow {
+    let tool = trace_row_tool(row);
+    let original = trace_shape_from_row(row);
+    let tool_call_index = trace_row_index(row, index);
+    if tool != "execute_sql" && !TRACE_REPLAY_SUPPORTED_TOOLS.contains(&tool.as_str()) {
+        return TraceReplayRow {
+            tool_call_index,
+            tool: tool.clone(),
+            status: "unsupported",
+            reason: Some(format!("tool '{tool}' is not supported by trace replay")),
+            replay_duration_ms: None,
+            original,
+            replayed: None,
+            changes: Vec::new(),
+        };
+    }
+    let Some(params) = replay_params_for_row(row, &tool) else {
+        return TraceReplayRow {
+            tool_call_index,
+            tool,
+            status: "skipped",
+            reason: Some(replay_skip_reason(row, tool_call_index)),
+            replay_duration_ms: None,
+            original,
+            replayed: None,
+            changes: Vec::new(),
+        };
+    };
+
+    let started = Instant::now();
+    match dispatch_tool(searcher, &tool, params).await {
+        Ok(response) => {
+            let replayed = trace_shape_from_response(&response);
+            let changes = compare_trace_shapes(&original, &replayed);
+            let status = if changes.is_empty() {
+                "replayed"
+            } else {
+                "changed"
+            };
+            TraceReplayRow {
+                tool_call_index,
+                tool,
+                status,
+                reason: None,
+                replay_duration_ms: Some(elapsed_ms_to_u64(started)),
+                original,
+                replayed: Some(replayed),
+                changes,
+            }
+        }
+        Err(error) => TraceReplayRow {
+            tool_call_index,
+            tool,
+            status: "failed",
+            reason: Some(error.to_string()),
+            replay_duration_ms: Some(elapsed_ms_to_u64(started)),
+            original,
+            replayed: Some(TraceReplayShape {
+                success: Some(false),
+                error_code: Some(error.error_code().to_string()),
+                ..TraceReplayShape::default()
+            }),
+            changes: Vec::new(),
+        },
+    }
+}
+
+impl TraceReplayCounts {
+    fn ingest(&mut self, status: &str) {
+        match status {
+            "replayed" => self.replayed += 1,
+            "changed" => self.changed += 1,
+            "skipped" => self.skipped += 1,
+            "failed" => self.failed += 1,
+            "unsupported" => self.unsupported += 1,
+            _ => {}
+        }
+    }
+}
+
+fn replay_params_for_row(row: &JsonValue, tool: &str) -> Option<JsonValue> {
+    if tool == "execute_sql" {
+        return None;
+    }
+    if !TRACE_REPLAY_SUPPORTED_TOOLS.contains(&tool) {
+        return None;
+    }
+    let params = row.get("params_summary")?.as_object()?;
+    if params_summary_has_sensitive_signal(params) {
+        return None;
+    }
+    build_replay_params(tool, params)
+}
+
+fn replay_skip_reason(row: &JsonValue, index: u64) -> String {
+    let tool = trace_row_tool(row);
+    if tool == "execute_sql" {
+        return "execute_sql is skipped by default because Nova traces do not store raw SQL"
+            .to_string();
+    }
+    if !TRACE_REPLAY_SUPPORTED_TOOLS.contains(&tool.as_str()) {
+        return format!("tool '{tool}' is not supported by trace replay");
+    }
+    let Some(params) = row.get("params_summary").and_then(JsonValue::as_object) else {
+        return format!("row {index} does not include params_summary");
+    };
+    if params_summary_has_sensitive_signal(params) {
+        return "params_summary contains sensitive or unsafe parameter evidence".to_string();
+    }
+    "params_summary is missing required safe scalar parameters for replay".to_string()
+}
+
+fn build_replay_params(tool: &str, params: &JsonMap<String, JsonValue>) -> Option<JsonValue> {
+    let mut out = JsonMap::new();
+    match tool {
+        "search" => {
+            copy_required_string(params, &mut out, "query")?;
+            copy_optional_string_array(params, &mut out, "resource_types")?;
+            copy_optional_string(params, &mut out, "persona")?;
+            copy_optional_string(params, &mut out, "detail")?;
+            copy_optional_f64(params, &mut out, "min_score")?;
+            copy_optional_bool(params, &mut out, "fuzzy")?;
+            copy_optional_bool(params, &mut out, "include_highlights")?;
+            copy_optional_bool(params, &mut out, "include_sql")?;
+            copy_optional_bool(params, &mut out, "explain")?;
+            copy_optional_u64(params, &mut out, "limit")?;
+            copy_optional_u64(params, &mut out, "offset")?;
+        }
+        "search_indicator" => {
+            copy_required_string(params, &mut out, "query")?;
+            copy_optional_string_array(params, &mut out, "resource_types")?;
+            copy_optional_string_array(params, &mut out, "indicator_types")?;
+            copy_optional_string(params, &mut out, "persona")?;
+            copy_optional_string(params, &mut out, "detail")?;
+            copy_optional_string(params, &mut out, "group_mode")?;
+            copy_optional_u64(params, &mut out, "max_parent_groups")?;
+            copy_optional_bool(params, &mut out, "include_support_signals")?;
+            copy_optional_f64(params, &mut out, "min_score")?;
+            copy_optional_bool(params, &mut out, "explain")?;
+            copy_optional_u64(params, &mut out, "limit")?;
+            copy_optional_u64(params, &mut out, "offset")?;
+        }
+        "search_columns" => {
+            copy_required_string(params, &mut out, "query")?;
+            copy_optional_string_array(params, &mut out, "resource_types")?;
+            copy_optional_string_array(params, &mut out, "roles")?;
+            copy_optional_string_array(params, &mut out, "semantic_types")?;
+            copy_optional_f64(params, &mut out, "min_score")?;
+            copy_optional_u64(params, &mut out, "limit")?;
+            copy_optional_u64(params, &mut out, "offset")?;
+        }
+        "get_entity" => {
+            copy_required_string(params, &mut out, "id_or_name")?;
+            copy_optional_string(params, &mut out, "resource_type")?;
+            copy_optional_string(params, &mut out, "detail")?;
+        }
+        "get_context" => {
+            copy_required_string(params, &mut out, "id_or_name")?;
+            copy_optional_string(params, &mut out, "resource_type")?;
+            copy_optional_bool(params, &mut out, "include_columns")?;
+            copy_optional_bool(params, &mut out, "include_upstream")?;
+            copy_optional_bool(params, &mut out, "include_downstream")?;
+            copy_optional_bool(params, &mut out, "include_tests")?;
+            copy_optional_bool(params, &mut out, "include_docs")?;
+            copy_optional_bool(params, &mut out, "include_sql")?;
+            copy_optional_string(params, &mut out, "context_mode")?;
+            copy_optional_u64(params, &mut out, "lineage_depth")?;
+            copy_optional_u64(params, &mut out, "upstream_limit")?;
+            copy_optional_u64(params, &mut out, "downstream_limit")?;
+        }
+        "get_lineage" => {
+            copy_required_string(params, &mut out, "id_or_name")?;
+            copy_required_string(params, &mut out, "direction")?;
+            copy_optional_u64(params, &mut out, "depth")?;
+            copy_optional_string_array(params, &mut out, "resource_types")?;
+            copy_optional_string(params, &mut out, "detail")?;
+        }
+        _ => return None,
+    }
+    Some(JsonValue::Object(out))
+}
+
+fn copy_required_string(
+    input: &JsonMap<String, JsonValue>,
+    output: &mut JsonMap<String, JsonValue>,
+    key: &'static str,
+) -> Option<()> {
+    let value = safe_replay_string(input.get(key)?)?;
+    output.insert(key.to_string(), JsonValue::String(value));
+    Some(())
+}
+
+fn copy_optional_string(
+    input: &JsonMap<String, JsonValue>,
+    output: &mut JsonMap<String, JsonValue>,
+    key: &'static str,
+) -> Option<()> {
+    let Some(value) = input.get(key) else {
+        return Some(());
+    };
+    let value = safe_replay_string(value)?;
+    output.insert(key.to_string(), JsonValue::String(value));
+    Some(())
+}
+
+fn copy_optional_string_array(
+    input: &JsonMap<String, JsonValue>,
+    output: &mut JsonMap<String, JsonValue>,
+    key: &'static str,
+) -> Option<()> {
+    let Some(value) = input.get(key) else {
+        return Some(());
+    };
+    let items = value.as_array()?;
+    let mut out = Vec::with_capacity(items.len());
+    for item in items {
+        out.push(JsonValue::String(safe_replay_string(item)?));
+    }
+    output.insert(key.to_string(), JsonValue::Array(out));
+    Some(())
+}
+
+fn copy_optional_bool(
+    input: &JsonMap<String, JsonValue>,
+    output: &mut JsonMap<String, JsonValue>,
+    key: &'static str,
+) -> Option<()> {
+    if let Some(value) = input.get(key) {
+        output.insert(key.to_string(), JsonValue::Bool(value.as_bool()?));
+    }
+    Some(())
+}
+
+fn copy_optional_u64(
+    input: &JsonMap<String, JsonValue>,
+    output: &mut JsonMap<String, JsonValue>,
+    key: &'static str,
+) -> Option<()> {
+    if let Some(value) = input.get(key) {
+        output.insert(key.to_string(), JsonValue::from(value.as_u64()?));
+    }
+    Some(())
+}
+
+fn copy_optional_f64(
+    input: &JsonMap<String, JsonValue>,
+    output: &mut JsonMap<String, JsonValue>,
+    key: &'static str,
+) -> Option<()> {
+    if let Some(value) = input.get(key) {
+        output.insert(key.to_string(), JsonValue::from(value.as_f64()?));
+    }
+    Some(())
+}
+
+fn safe_replay_string(value: &JsonValue) -> Option<String> {
+    let value = value.as_str()?.trim();
+    if value.is_empty()
+        || value == "[REDACTED]"
+        || value.contains("://")
+        || value.to_ascii_lowercase().contains("bearer ")
+    {
+        return None;
+    }
+    Some(value.to_string())
+}
+
+fn params_summary_has_sensitive_signal(params: &JsonMap<String, JsonValue>) -> bool {
+    params.iter().any(|(key, value)| {
+        sensitive_replay_fragment(key) || value_contains_sensitive_signal(value)
+    })
+}
+
+fn value_contains_sensitive_signal(value: &JsonValue) -> bool {
+    match value {
+        JsonValue::String(value) => {
+            let lowered = value.to_ascii_lowercase();
+            sensitive_replay_fragment(value)
+                || lowered == "[redacted]"
+                || lowered.contains("bearer ")
+                || lowered.contains("-----begin ")
+                || (lowered.contains("://")
+                    && ["token", "secret", "password", "api_key", "apikey"]
+                        .iter()
+                        .any(|needle| lowered.contains(needle)))
+        }
+        JsonValue::Array(items) => items.iter().any(value_contains_sensitive_signal),
+        JsonValue::Object(map) => map.iter().any(|(key, value)| {
+            sensitive_replay_fragment(key) || value_contains_sensitive_signal(value)
+        }),
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) => false,
+    }
+}
+
+fn sensitive_replay_fragment(value: &str) -> bool {
+    let lowered = value.to_ascii_lowercase();
+    [
+        "authorization",
+        "credential",
+        "password",
+        "passwd",
+        "private_key",
+        "secret",
+        "session",
+        "token",
+        "access_key",
+        "api_key",
+        "apikey",
+        "proof_key",
+        "raw_output",
+    ]
+    .iter()
+    .any(|fragment| lowered.contains(fragment))
+}
+
+fn trace_shape_from_row(row: &JsonValue) -> TraceReplayShape {
+    TraceReplayShape {
+        success: row.get("success").and_then(JsonValue::as_bool),
+        count: row.get("result_count").and_then(JsonValue::as_u64),
+        total_available: row.get("total_available").and_then(JsonValue::as_u64),
+        response_truncated: row
+            .get("response_truncated")
+            .and_then(JsonValue::as_bool)
+            .unwrap_or(false),
+        error_code: row
+            .get("error_code")
+            .and_then(JsonValue::as_str)
+            .map(ToString::to_string),
+        selected_unique_ids: string_array_field(row, "selected_unique_ids"),
+        top_unique_ids: string_array_field(row, "top_unique_ids"),
+    }
+}
+
+fn trace_shape_from_response(response: &JsonValue) -> TraceReplayShape {
+    TraceReplayShape {
+        success: response.get("success").and_then(JsonValue::as_bool),
+        count: response.get("count").and_then(JsonValue::as_u64),
+        total_available: response.get("total_available").and_then(JsonValue::as_u64),
+        response_truncated: extract_response_truncated(response),
+        error_code: response_error_code(response),
+        selected_unique_ids: extract_unique_ids(response),
+        top_unique_ids: extract_top_unique_ids(response),
+    }
+}
+
+fn response_error_code(response: &JsonValue) -> Option<String> {
+    response
+        .get("error_code")
+        .and_then(JsonValue::as_str)
+        .or_else(|| {
+            response
+                .get("error")
+                .and_then(|error| error.get("error_code"))
+                .and_then(JsonValue::as_str)
+        })
+        .map(ToString::to_string)
+}
+
+fn compare_trace_shapes(
+    original: &TraceReplayShape,
+    replayed: &TraceReplayShape,
+) -> Vec<TraceReplayChange> {
+    let mut changes = Vec::new();
+    push_option_change(
+        &mut changes,
+        "success",
+        original.success,
+        replayed.success,
+        JsonValue::Bool,
+    );
+    push_option_change(
+        &mut changes,
+        "count",
+        original.count,
+        replayed.count,
+        JsonValue::from,
+    );
+    push_option_change(
+        &mut changes,
+        "total_available",
+        original.total_available,
+        replayed.total_available,
+        JsonValue::from,
+    );
+    if original.response_truncated != replayed.response_truncated {
+        changes.push(TraceReplayChange {
+            field: "response_truncated",
+            before: JsonValue::Bool(original.response_truncated),
+            after: JsonValue::Bool(replayed.response_truncated),
+        });
+    }
+    if original.error_code != replayed.error_code
+        && (original.error_code.is_some() || replayed.error_code.is_some())
+    {
+        changes.push(TraceReplayChange {
+            field: "error_code",
+            before: string_option_json(original.error_code.as_deref()),
+            after: string_option_json(replayed.error_code.as_deref()),
+        });
+    }
+    push_vec_change(
+        &mut changes,
+        "selected_unique_ids",
+        &original.selected_unique_ids,
+        &replayed.selected_unique_ids,
+    );
+    push_vec_change(
+        &mut changes,
+        "top_unique_ids",
+        &original.top_unique_ids,
+        &replayed.top_unique_ids,
+    );
+    changes
+}
+
+fn push_option_change<T: Eq + Copy>(
+    changes: &mut Vec<TraceReplayChange>,
+    field: &'static str,
+    before: Option<T>,
+    after: Option<T>,
+    to_json: impl Fn(T) -> JsonValue,
+) {
+    if let (Some(before), Some(after)) = (before, after)
+        && before != after
+    {
+        changes.push(TraceReplayChange {
+            field,
+            before: to_json(before),
+            after: to_json(after),
+        });
+    }
+}
+
+fn push_vec_change(
+    changes: &mut Vec<TraceReplayChange>,
+    field: &'static str,
+    before: &[String],
+    after: &[String],
+) {
+    if !before.is_empty() && !after.is_empty() && before != after {
+        changes.push(TraceReplayChange {
+            field,
+            before: string_vec_json(before),
+            after: string_vec_json(after),
+        });
+    }
+}
+
+fn string_vec_json(values: &[String]) -> JsonValue {
+    JsonValue::Array(values.iter().cloned().map(JsonValue::String).collect())
+}
+
+fn string_option_json(value: Option<&str>) -> JsonValue {
+    value.map_or(JsonValue::Null, |value| {
+        JsonValue::String(value.to_string())
+    })
+}
+
+fn trace_row_tool(row: &JsonValue) -> String {
+    row.get("tool")
+        .and_then(JsonValue::as_str)
+        .or_else(|| row.get("tool_name").and_then(JsonValue::as_str))
+        .filter(|tool| !tool.trim().is_empty())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn trace_row_index(row: &JsonValue, fallback: usize) -> u64 {
+    row.get("tool_call_index")
+        .and_then(JsonValue::as_u64)
+        .unwrap_or_else(|| u64::try_from(fallback).unwrap_or(u64::MAX))
+}
+
+fn string_array_field(row: &JsonValue, key: &str) -> Vec<String> {
+    row.get(key)
+        .and_then(JsonValue::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(JsonValue::as_str)
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn elapsed_ms_to_u64(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)
 }
 
 #[cfg(test)]
@@ -633,6 +1305,38 @@ fn print_redaction_human(report: &ToolTraceRedactionReport) {
     println!("  fields_masked: {}", report.fields_masked);
 }
 
+fn print_replay_human(report: &TraceReplayData) {
+    println!("trace replay complete");
+    println!("  path: {}", report.path);
+    println!("  manifest_hash: {}", report.manifest.manifest_hash);
+    println!("  manifest_version: {}", report.manifest.manifest_version);
+    println!("  rows: {}", report.row_count);
+    println!("  parse_warnings: {}", report.parse_warnings.len());
+    println!("  replayed: {}", report.counts.replayed);
+    println!("  changed: {}", report.counts.changed);
+    println!("  skipped: {}", report.counts.skipped);
+    println!("  failed: {}", report.counts.failed);
+    println!("  unsupported: {}", report.counts.unsupported);
+
+    let interesting = report
+        .results
+        .iter()
+        .filter(|row| row.status != "replayed")
+        .take(10)
+        .collect::<Vec<_>>();
+    if interesting.is_empty() {
+        return;
+    }
+    println!("  findings:");
+    for row in interesting {
+        let reason = row.reason.as_deref().unwrap_or("");
+        println!(
+            "    #{} {} {} {}",
+            row.tool_call_index, row.tool, row.status, reason
+        );
+    }
+}
+
 fn escape_inline(value: &str) -> String {
     value.replace('`', "'")
 }
@@ -646,12 +1350,14 @@ mod tests {
     use tempfile::{NamedTempFile, TempDir};
 
     use super::{
-        MCP_ENABLE_TRACE_WRITES_ENV, build_trace_inspect_tool_response,
-        build_trace_redact_tool_response, read_trace_for_cli, render_markdown_summary,
-        run_redact_command, run_summarize_command,
+        MCP_ENABLE_TRACE_WRITES_ENV, TraceReplayShape, build_replay_params,
+        build_trace_inspect_tool_response, build_trace_redact_tool_response,
+        build_trace_replay_tool_response, compare_trace_shapes, read_trace_for_cli,
+        render_markdown_summary, run_redact_command, run_summarize_command,
     };
     use crate::cli::args::{TraceRedactArgs, TraceSummarizeArgs};
-    use crate::params::{TraceInspectParams, TraceRedactParams};
+    use crate::params::{TraceInspectParams, TraceRedactParams, TraceReplayParams};
+    use crate::tests::common::get_searcher_with_fixture;
     use crate::utils::tool_trace::{read_tool_trace_file, summarize_tool_trace};
 
     #[test]
@@ -773,5 +1479,139 @@ mod tests {
             Some(value) => unsafe { std::env::set_var(MCP_ENABLE_TRACE_WRITES_ENV, value) },
             None => unsafe { std::env::remove_var(MCP_ENABLE_TRACE_WRITES_ENV) },
         }
+    }
+
+    #[test]
+    fn trace_replay_params_preserve_safe_supported_tool_options() {
+        let search_columns = serde_json::json!({
+            "query": "customer",
+            "resource_types": ["model"],
+            "roles": ["dimension"],
+            "semantic_types": ["entity_id"],
+            "min_score": 0.5,
+            "limit": 3,
+            "offset": 1
+        });
+        let rebuilt = build_replay_params(
+            "search_columns",
+            search_columns.as_object().expect("object params"),
+        )
+        .expect("search_columns params");
+        assert_eq!(rebuilt["roles"], serde_json::json!(["dimension"]));
+        assert_eq!(rebuilt["semantic_types"], serde_json::json!(["entity_id"]));
+        assert_eq!(rebuilt["min_score"], serde_json::json!(0.5));
+
+        let context = serde_json::json!({
+            "id_or_name": "model.nova_test.fct__orders",
+            "resource_type": "model",
+            "include_columns": false,
+            "include_upstream": false,
+            "include_downstream": true,
+            "include_tests": false,
+            "include_docs": true,
+            "context_mode": "engineer",
+            "lineage_depth": 2,
+            "upstream_limit": 4,
+            "downstream_limit": 5
+        });
+        let rebuilt =
+            build_replay_params("get_context", context.as_object().expect("object params"))
+                .expect("get_context params");
+        assert_eq!(rebuilt["include_columns"], serde_json::json!(false));
+        assert_eq!(rebuilt["include_upstream"], serde_json::json!(false));
+        assert_eq!(rebuilt["context_mode"], serde_json::json!("engineer"));
+        assert_eq!(rebuilt["lineage_depth"], serde_json::json!(2));
+
+        let lineage = serde_json::json!({
+            "id_or_name": "model.nova_test.fct__orders",
+            "direction": "upstream",
+            "depth": 2
+        });
+        let rebuilt =
+            build_replay_params("get_lineage", lineage.as_object().expect("object params"))
+                .expect("get_lineage params");
+        assert_eq!(rebuilt["depth"], serde_json::json!(2));
+    }
+
+    #[test]
+    fn trace_replay_shape_changes_include_error_code() {
+        let original = TraceReplayShape {
+            success: Some(false),
+            error_code: Some("NOT_FOUND".to_string()),
+            ..TraceReplayShape::default()
+        };
+        let replayed = TraceReplayShape {
+            success: Some(true),
+            ..TraceReplayShape::default()
+        };
+
+        let fields = compare_trace_shapes(&original, &replayed)
+            .into_iter()
+            .map(|change| change.field)
+            .collect::<Vec<_>>();
+
+        assert!(fields.contains(&"success"));
+        assert!(fields.contains(&"error_code"));
+    }
+
+    #[tokio::test]
+    async fn trace_replay_tool_response_reports_replay_outcomes() {
+        let searcher = get_searcher_with_fixture("nova_manifest.json");
+        let root = std::env::current_dir()
+            .expect("cwd")
+            .canonicalize()
+            .expect("canonical cwd");
+        let dir = TempDir::new_in(&root).expect("dir");
+        let trace = dir.path().join("trace.jsonl");
+        std::fs::write(
+            &trace,
+            [
+                r#"{"tool":"get_entity","success":true,"result_count":1,"response_truncated":false,"selected_unique_ids":["model.nova_test.fct__orders"],"top_unique_ids":["model.nova_test.fct__orders"],"params_summary":{"id_or_name":"model.nova_test.fct__orders","resource_type":"model"}}"#,
+                r#"{"tool":"get_entity","success":true,"result_count":1,"response_truncated":false,"selected_unique_ids":["model.nova_test.dim__customers"],"top_unique_ids":["model.nova_test.dim__customers"],"params_summary":{"id_or_name":"model.nova_test.fct__orders","resource_type":"model"}}"#,
+                r#"{"tool":"execute_sql","success":true,"response_truncated":false,"params_summary":{"query":"select 1"}}"#,
+                r#"{"tool":"unknown_tool","success":true,"response_truncated":false,"params_summary":{"query":"orders"}}"#,
+                r#"{"tool":"search","success":true,"response_truncated":false,"params_summary":{"query":"orders","token":"secret"}}"#,
+                r#"{"tool":"get_entity","success":true,"response_truncated":false,"params_summary":{"id_or_name":"model.nova_test.missing","resource_type":"model"}}"#,
+            ]
+            .join("\n"),
+        )
+        .expect("write trace");
+
+        let response = build_trace_replay_tool_response(
+            &searcher,
+            &TraceReplayParams {
+                path: trace.display().to_string(),
+            },
+        )
+        .await
+        .expect("replay response");
+
+        assert_eq!(response["success"], serde_json::json!(true));
+        assert_eq!(response["count"], serde_json::json!(6));
+        assert_eq!(response["data"]["counts"]["replayed"], serde_json::json!(1));
+        assert_eq!(response["data"]["counts"]["changed"], serde_json::json!(1));
+        assert_eq!(response["data"]["counts"]["skipped"], serde_json::json!(2));
+        assert_eq!(
+            response["data"]["counts"]["unsupported"],
+            serde_json::json!(1)
+        );
+        assert_eq!(response["data"]["counts"]["failed"], serde_json::json!(1));
+        assert_eq!(
+            response["data"]["results"][1]["changes"][0]["field"],
+            serde_json::json!("selected_unique_ids")
+        );
+        assert!(
+            response["data"]["results"][2]["reason"]
+                .as_str()
+                .expect("skip reason")
+                .contains("execute_sql")
+        );
+        assert!(
+            response["data"]["results"][4]["reason"]
+                .as_str()
+                .expect("unsafe reason")
+                .contains("sensitive")
+        );
+        assert!(response["data"]["safety_policy"].is_object());
     }
 }

--- a/src/params.rs
+++ b/src/params.rs
@@ -874,6 +874,13 @@ pub struct TraceRedactParams {
     pub out: String,
 }
 
+/// Parameters for the replay_tool_trace tool.
+#[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+pub struct TraceReplayParams {
+    /// JSONL tool trace path under the server working directory.
+    pub path: String,
+}
+
 /// Parameters for the show_config tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
 pub struct ConfigShowParams {

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -32,7 +32,7 @@ use crate::cli::storage_cmd::{
 };
 use crate::cli::trace_cmd::{
     build_trace_inspect_tool_response, build_trace_redact_tool_response,
-    build_trace_summarize_tool_response,
+    build_trace_replay_tool_response, build_trace_summarize_tool_response,
 };
 use crate::config::DbtNovaConfig;
 use crate::error::DbtNovaError;
@@ -48,8 +48,8 @@ use crate::params::{
     ParentGroupMode, ReloadManifestParams, RunAgentEvalParams, RunEvalParams, RunRecipeParams,
     SearchColumnsParams, SearchIndicatorParams, SearchParams, SearchRecipesParams,
     StorageCleanupParams, StorageInspectParams, StoragePruneParams, TraceInspectParams,
-    TraceRedactParams, TraceSummarizeParams, ValidateDagParams, ValidateEvalSuiteParams,
-    ValidateNovaMetaParams, WarmManifestParams,
+    TraceRedactParams, TraceReplayParams, TraceSummarizeParams, ValidateDagParams,
+    ValidateEvalSuiteParams, ValidateNovaMetaParams, WarmManifestParams,
 };
 use crate::responses::SuccessResponse;
 use crate::server::health::build_manifest_health_payload;
@@ -1791,6 +1791,19 @@ impl DbtNovaServer {
     async fn redact_tool_trace(&self, params: Parameters<TraceRedactParams>) -> String {
         self.handle_async("redact_tool_trace", None, |_searcher| async move {
             build_trace_redact_tool_response(&params.0)
+        })
+        .await
+    }
+
+    /// Replay deterministic local Nova tool calls from a trace.
+    #[tool(
+        name = "replay_tool_trace",
+        description = "Replay supported deterministic Nova tool calls from a local trace JSONL file against the currently loaded MCP manifest. Unsupported, unsafe, under-specified, and execute_sql rows are skipped with explicit reasons."
+    )]
+    #[instrument(level = "info", skip(self, params))]
+    async fn replay_tool_trace(&self, params: Parameters<TraceReplayParams>) -> String {
+        self.handle_async("replay_tool_trace", None, |searcher| async move {
+            build_trace_replay_tool_response(&searcher, &params.0).await
         })
         .await
     }

--- a/src/tools/catalog.rs
+++ b/src/tools/catalog.rs
@@ -1,5 +1,5 @@
 /// Canonical MCP tool names exposed by dbt-nova.
-pub const MCP_TOOL_NAMES: [&str; 51] = [
+pub const MCP_TOOL_NAMES: [&str; 52] = [
     "search",
     "search_indicator",
     "indicator_inventory",
@@ -26,6 +26,7 @@ pub const MCP_TOOL_NAMES: [&str; 51] = [
     "inspect_tool_trace",
     "summarize_tool_trace",
     "redact_tool_trace",
+    "replay_tool_trace",
     "show_metadata",
     "health",
     "reload_manifest",
@@ -89,7 +90,7 @@ pub struct CliMcpParityEntry {
 /// Keep this matrix in sync with `docs/getting-started/cli.md` and
 /// `docs/api/mcp-cli-parity.md`. Product capabilities should trend from `Gap`
 /// to `Equivalent`; process lifecycle commands may remain `LifecycleException`.
-pub const CLI_MCP_PARITY_MATRIX: [CliMcpParityEntry; 23] = [
+pub const CLI_MCP_PARITY_MATRIX: [CliMcpParityEntry; 24] = [
     CliMcpParityEntry {
         cli_command: "server start",
         mcp_tool: None,
@@ -243,6 +244,13 @@ pub const CLI_MCP_PARITY_MATRIX: [CliMcpParityEntry; 23] = [
         status: CliMcpParityStatus::SafetyGated,
         issue: None,
         notes: "MCP safe-sharing redaction writes require DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1",
+    },
+    CliMcpParityEntry {
+        cli_command: "trace replay",
+        mcp_tool: Some("replay_tool_trace"),
+        status: CliMcpParityStatus::Equivalent,
+        issue: None,
+        notes: "MCP replays supported deterministic trace rows against the currently loaded manifest while CLI replay loads an explicit manifest source",
     },
     CliMcpParityEntry {
         cli_command: "health check",

--- a/src/utils/tool_trace.rs
+++ b/src/utils/tool_trace.rs
@@ -22,19 +22,36 @@ const MAX_UNIQUE_ID_CHARS: usize = 512;
 const REDACTED_VALUE: &str = "[REDACTED]";
 const TRACE_SUMMARY_SCHEMA_VERSION: &str = "tool_trace_summary.v1";
 const TRACE_REDACTION_SCHEMA_VERSION: &str = "tool_trace_redaction.v1";
-const SAFE_PARAM_SUMMARY_KEYS: [&str; 19] = [
+const SAFE_PARAM_SUMMARY_KEYS: [&str; 36] = [
     "query",
     "persona",
     "id_or_name",
     "resource_type",
     "resource_types",
+    "roles",
+    "semantic_types",
     "recipe_id",
     "direction",
+    "depth",
     "detail",
     "group_mode",
     "indicator_types",
     "include_support_signals",
     "max_parent_groups",
+    "min_score",
+    "fuzzy",
+    "include_highlights",
+    "include_sql",
+    "explain",
+    "include_columns",
+    "include_upstream",
+    "include_downstream",
+    "include_tests",
+    "include_docs",
+    "context_mode",
+    "lineage_depth",
+    "upstream_limit",
+    "downstream_limit",
     "preflight_only",
     "row_limit",
     "byte_limit",
@@ -987,7 +1004,7 @@ fn serialized_len(value: &Value) -> usize {
     serde_json::to_string(value).map_or(0, |serialized| serialized.len())
 }
 
-fn extract_response_truncated(response: &Value) -> bool {
+pub(crate) fn extract_response_truncated(response: &Value) -> bool {
     match response {
         Value::Object(map) => {
             map.get("truncated")
@@ -1016,26 +1033,7 @@ fn summarize_params(params: &Value) -> Value {
         .map(|key| Value::String(truncate_string(key, MAX_SUMMARY_STRING_CHARS)))
         .collect();
     let mut summary = serde_json::Map::from_iter([(String::from("keys"), Value::Array(keys))]);
-    for key in [
-        "query",
-        "persona",
-        "id_or_name",
-        "resource_type",
-        "resource_types",
-        "recipe_id",
-        "direction",
-        "detail",
-        "group_mode",
-        "indicator_types",
-        "include_support_signals",
-        "max_parent_groups",
-        "preflight_only",
-        "row_limit",
-        "byte_limit",
-        "max_poll_seconds",
-        "limit",
-        "offset",
-    ] {
+    for key in SAFE_PARAM_SUMMARY_KEYS {
         if let Some(value) = map.get(key).and_then(summarize_safe_value) {
             summary.insert(key.to_string(), value);
         }
@@ -1100,13 +1098,13 @@ fn extract_error_code(response: &Value) -> Option<String> {
         .map(ToString::to_string)
 }
 
-fn extract_unique_ids(response: &Value) -> Vec<String> {
+pub(crate) fn extract_unique_ids(response: &Value) -> Vec<String> {
     let mut out = BTreeSet::new();
     collect_unique_ids(response, &mut out);
     out.into_iter().collect()
 }
 
-fn extract_top_unique_ids(response: &Value) -> Vec<String> {
+pub(crate) fn extract_top_unique_ids(response: &Value) -> Vec<String> {
     let mut out = Vec::new();
     let mut seen = BTreeSet::new();
     if let Some(rows) = response.get("data").and_then(Value::as_array) {
@@ -1240,9 +1238,15 @@ mod tests {
         let summary = summarize_params(&json!({
             "query": "gmv",
             "parameters": {"token": "secret"},
+            "roles": ["dimension"],
+            "include_upstream": false,
+            "lineage_depth": 2,
             "limit": 5
         }));
         assert_eq!(summary["query"], "gmv");
+        assert_eq!(summary["roles"], json!(["dimension"]));
+        assert_eq!(summary["include_upstream"], false);
+        assert_eq!(summary["lineage_depth"], 2);
         assert_eq!(summary["limit"], 5);
         assert!(summary.get("parameters").is_none());
     }


### PR DESCRIPTION
## Summary

- add `dbt-nova trace replay` for deterministic replay of supported Nova tool-call trace rows against a loaded manifest
- expose MCP/CLI parity through `replay_tool_trace`, with local path safety and explicit skip reasons for unsupported, unsafe, under-specified, and `execute_sql` rows
- report compact response-shape summaries and changed evidence fields without full response diffs; update trace docs, API docs, parity matrix, architecture map, and changelog

Linear: JOE-114

## Validation

- `cargo test --locked --all-features trace_replay`
- `cargo test --locked --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- `uv run --with-requirements docs/requirements.txt mkdocs build --strict`
- `bash scripts/check_config_reference.sh`

## Manual smoke

- `cargo run --locked -- trace replay --path .nova/trace-replay-smoke/tool-calls.jsonl --manifest-path tests/fixtures/nova_manifest.json --storage-instance-id trace-replay-smoke --cleanup-storage-on-start --json` -> `replayed=1 skipped=1 unsupported=1 failed=0`
- `cargo run --locked -- tool call replay_tool_trace --params-json {"path":".nova/trace-replay-smoke/tool-calls.jsonl"} --manifest-path tests/fixtures/nova_manifest.json --storage-instance-id trace-replay-smoke-tool --cleanup-storage-on-start --json` -> `replayed=1 skipped=1 unsupported=1 failed=0`

## Deep review notes

- replay rebuilds calls only from `params_summary` safe primitives/string arrays and rejects sensitive keys, redacted values, bearer fragments, and URI-like copied strings
- `execute_sql` is never replayed; unsupported tools are separated from skipped rows for clearer triage
- MCP replay reads only paths under the server working directory and reuses the already loaded manifest; CLI replay loads an explicit manifest source
