### PR TITLE
Add eval card output for eval suites

### DIFF
--- a/.github/skills/eval-author/SKILL.md
+++ b/.github/skills/eval-author/SKILL.md
@@ -53,7 +53,7 @@ Eval execution is CLI-only. MCP is for discovering ground truth and debugging ex
 8. Set a gate that matches the suite purpose.
 9. Run the full suite with `--telemetry` before checking readiness gates.
 10. Check readiness with `dbt-nova eval gate <suite_name> --json` for high-stakes, launch-readiness, or recurring production suites.
-11. Read `results.json` for machines, `report.md` for humans, and tool traces for agent behavior.
+11. Read `card.md` for PR summaries, `results.json` for machines, `report.md` for assertion details, and tool traces for agent behavior.
 
 ## Design rules
 
@@ -73,6 +73,7 @@ Eval execution is CLI-only. MCP is for discovering ground truth and debugging ex
 When handing off an eval suite or eval fix, include:
 - suite purpose and target persona
 - manifest source assumption
+- declared manifest scope and known gaps
 - bridge cases and what each proves
 - agent cases and what each proves
 - gate threshold and intended run cadence

--- a/.github/skills/eval-author/assets/eval-suite-template.yml
+++ b/.github/skills/eval-author/assets/eval-suite-template.yml
@@ -1,5 +1,9 @@
 version: 1
 name: nova-analyst-smoke
+purpose: Prove that analyst discovery can find the canonical governed metric, model, and context for the target workflow.
+manifest_scope: target/manifest.json for the analytics project
+known_gaps:
+  - Replace this with any workflow, domain, freshness, or provider behavior not covered by the suite.
 defaults:
   persona: analyst
   top_k: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `dbt-nova eval gate <NAME> --json` reads the latest full-suite telemetry and
   reports allowed/blocked status, pass rate, and failed case/assertion ids,
   blocking stale suite-file telemetry before allowing configured gates.
+- Eval bridge and agent runs now emit an `eval_card.v1` summary in
+  `results.json`, write a PR-ready `card.md`, and prepend the same card to
+  `report.md`, including suite purpose, scope, case counts, pass rate, gate
+  evidence, telemetry status, provider metadata, and known gaps.
 - Added `dbt-nova trace inspect`, `trace summarize`, and `trace redact`, plus
   MCP/CLI `tool call` parity through `inspect_tool_trace`,
   `summarize_tool_trace`, and `redact_tool_trace`, for inspecting sanitized

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -827,6 +827,11 @@ This local execution capability is disabled unless
 `DBT_NOVA_MCP_ENABLE_EVAL_RUN=1` is set. Unlike the CLI, MCP `run_eval` uses the
 manifest already loaded by the server.
 
+The response `data` is the same eval report contract written to CLI
+`results.json` and includes `eval_card` (`eval_card.v1`) with suite purpose,
+scope, case counts, pass rate, gate evidence, telemetry status, and known gaps.
+CLI runs also write `card.md` and prepend the same card to `report.md`.
+
 ```json
 {"name":"run_eval","arguments":{"suite":"evals/analyst-smoke.yml","telemetry":true,"fail_under":1.0}}
 ```
@@ -865,6 +870,9 @@ Optional:
 This provider execution capability is disabled unless
 `DBT_NOVA_MCP_ENABLE_AGENT_EVAL=1` is set. Custom provider commands and
 arguments also require `DBT_NOVA_MCP_ENABLE_CUSTOM_AGENT_PROVIDER=1`.
+
+The response `data.eval_card` includes provider metadata when available,
+including provider preset, command preset, and provider model.
 
 ```json
 {"name":"run_agent_eval","arguments":{"suite":"evals/analyst-smoke.yml","provider":"opencode","case_ids":["metric_lookup_flow"]}}

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -30,6 +30,10 @@ The suite format is YAML or JSON. A minimal bridge suite looks like this:
 ```yaml
 version: 1
 name: analyst-smoke
+purpose: Prove that analyst discovery can find the canonical orders model and context.
+manifest_scope: target/manifest.json for the analytics project
+known_gaps:
+  - Does not execute warehouse SQL.
 defaults:
   persona: analyst
   top_k: 5
@@ -105,8 +109,18 @@ Outputs are written to `.nova/eval-runs/<timestamp>-<suite>-bridge/` by default:
 
 - `results.json` for machine-readable CI output.
 - `results.tsv` for spreadsheet review.
+- `card.md` for a compact PR-ready eval card.
 - `report.md` for human review.
 - `suite.yml` as the exact suite copy used for the run.
+
+`results.json` includes an `eval_card` object with schema
+`eval_card.v1`. The card summarizes the suite name/version, optional suite
+`purpose`, default persona, declared `manifest_scope`, bridge and agent case
+counts, latest run status, pass rate, configured gate evidence when telemetry is
+available, telemetry timestamp or explicit missing-telemetry status, provider
+metadata for agent runs, and declared `known_gaps`. `report.md` starts with the
+same card before listing assertion-level details, so `card.md` can be pasted
+directly into PR descriptions.
 
 Bridge assertions currently support:
 

--- a/evals/agent-tokenomics-bridge.yml
+++ b/evals/agent-tokenomics-bridge.yml
@@ -1,5 +1,10 @@
 version: 1
 name: agent-tokenomics-bridge
+purpose: Prove that compact Nova tool responses preserve enough ecommerce tokenomics evidence for deterministic bridge evals.
+manifest_scope: tests/fixtures/tokenomics_manifest.json synthetic ecommerce tokenomics manifest
+known_gaps:
+  - Does not run a provider-backed agent.
+  - Does not execute live warehouse SQL.
 gate:
   threshold: 1.0
 defaults:

--- a/evals/agent-tokenomics-opencode.yml
+++ b/evals/agent-tokenomics-opencode.yml
@@ -1,5 +1,10 @@
 version: 1
 name: agent-tokenomics-opencode
+purpose: Prove that a provider-backed analyst agent can discover ecommerce tokenomics metrics through Nova and use DuckDB execution evidence correctly.
+manifest_scope: tests/fixtures/tokenomics_manifest.json with DuckDB fixture data
+known_gaps:
+  - Requires a configured OpenCode-compatible provider.
+  - Covers a narrow synthetic ecommerce question set.
 defaults:
   persona: analyst
   top_k: 5

--- a/evals/starter.yml
+++ b/evals/starter.yml
@@ -1,5 +1,10 @@
 version: 1
 name: starter
+purpose: Prove that the packaged synthetic manifest supports core Nova discovery, context, lineage, recipe, metadata-score, and agent tool-use flows.
+manifest_scope: tests/fixtures/starter_eval_manifest.json synthetic commerce manifest
+known_gaps:
+  - Does not execute warehouse SQL.
+  - Uses synthetic metadata and should not be interpreted as production domain coverage.
 defaults:
   persona: analyst
   top_k: 5

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -40,6 +40,12 @@ struct EvalSuite {
     #[serde(default)]
     name: Option<String>,
     #[serde(default)]
+    purpose: Option<String>,
+    #[serde(default)]
+    manifest_scope: Option<String>,
+    #[serde(default)]
+    known_gaps: Vec<String>,
+    #[serde(default)]
     gate: Option<EvalGateConfig>,
     #[serde(default)]
     defaults: EvalDefaults,
@@ -243,6 +249,7 @@ struct EvalReport {
     version: u32,
     mode: &'static str,
     output_dir: String,
+    eval_card: EvalCard,
     assertion_count: usize,
     pass_count: usize,
     fail_count: usize,
@@ -251,6 +258,80 @@ struct EvalReport {
     fail_under: f64,
     gate_status: &'static str,
     cases: Vec<EvalCaseReport>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct EvalCard {
+    schema_version: &'static str,
+    suite_name: String,
+    version: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    suite_path: Option<String>,
+    purpose: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    persona: Option<String>,
+    manifest_scope: EvalCardManifestScope,
+    mode: &'static str,
+    bridge_case_count: usize,
+    agent_case_count: usize,
+    run_case_count: usize,
+    output_dir: String,
+    assertion_count: usize,
+    pass_count: usize,
+    fail_count: usize,
+    error_count: usize,
+    pass_rate: f64,
+    fail_under: f64,
+    run_status: &'static str,
+    gate: EvalCardGate,
+    telemetry: EvalCardTelemetry,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provider: Option<EvalCardProvider>,
+    known_gaps: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct EvalCardManifestScope {
+    declared: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    manifest_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    manifest_source: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct EvalCardGate {
+    status: String,
+    source: &'static str,
+    configured: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    threshold: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pass_rate: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    total_evals: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    failed_evals: Option<usize>,
+    message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct EvalCardTelemetry {
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timestamp: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    run_id: Option<String>,
+    row_count: usize,
+    message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct EvalCardProvider {
+    provider: String,
+    command_preset: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -359,6 +440,21 @@ struct EvalHistoryPayload {
     row_count: usize,
     rows: Vec<JsonValue>,
     safety_policy: EvalMcpSafetyPolicy,
+}
+
+#[derive(Debug, Clone, Default)]
+struct EvalCardRunContext {
+    suite_path: Option<String>,
+    manifest_hash: Option<String>,
+    manifest_source: Option<String>,
+    telemetry_requested: bool,
+    provider: Option<EvalCardProvider>,
+}
+
+#[derive(Debug, Clone)]
+struct EvalCardTelemetryEvidence {
+    telemetry: EvalCardTelemetry,
+    gate: EvalCardGate,
 }
 
 const MCP_ENABLE_EVAL_RUN_ENV: &str = "DBT_NOVA_MCP_ENABLE_EVAL_RUN";
@@ -739,14 +835,13 @@ async fn execute_bridge_eval(
     for case in selected_cases {
         cases.push(evaluate_bridge_case(case, &suite, search).await);
     }
-    let report = build_report(
+    let mut report = build_report(
         &suite,
         "bridge",
         output_dir.display().to_string(),
         fail_under.unwrap_or(DEFAULT_FAIL_UNDER),
         cases,
     );
-    write_report_artifacts(&output_dir, &report, suite_path).map_err(|error| error.error)?;
     if telemetry {
         write_eval_telemetry(
             &report,
@@ -762,6 +857,17 @@ async fn execute_bridge_eval(
         )
         .map_err(|error| error.error)?;
     }
+    refresh_eval_card(
+        &mut report,
+        &suite,
+        &EvalCardRunContext {
+            suite_path: Some(suite_path.to_string()),
+            manifest_hash: manifest_hash.map(str::to_string),
+            telemetry_requested: telemetry,
+            ..EvalCardRunContext::default()
+        },
+    );
+    write_report_artifacts(&output_dir, &report, suite_path).map_err(|error| error.error)?;
     Ok(report)
 }
 
@@ -785,14 +891,13 @@ async fn execute_agent_eval_from_args(args: &EvalAgentRunArgs) -> crate::error::
     for case in selected_cases {
         cases.push(run_agent_case(case, args, &output_dir).await);
     }
-    let report = build_report(
+    let mut report = build_report(
         &suite,
         "agent",
         output_dir.display().to_string(),
         args.fail_under.unwrap_or(DEFAULT_FAIL_UNDER),
         cases,
     );
-    write_report_artifacts(&output_dir, &report, &args.suite).map_err(|error| error.error)?;
     let elapsed = started.elapsed();
     if args.telemetry {
         write_eval_telemetry(
@@ -812,6 +917,22 @@ async fn execute_agent_eval_from_args(args: &EvalAgentRunArgs) -> crate::error::
         )
         .map_err(|error| error.error)?;
     }
+    refresh_eval_card(
+        &mut report,
+        &suite,
+        &EvalCardRunContext {
+            suite_path: Some(args.suite.clone()),
+            manifest_source: agent_manifest_source(args),
+            telemetry_requested: args.telemetry,
+            provider: Some(EvalCardProvider {
+                provider: args.provider.clone(),
+                command_preset: agent_provider_command_preset(args).to_string(),
+                model: args.provider_model.clone(),
+            }),
+            ..EvalCardRunContext::default()
+        },
+    );
+    write_report_artifacts(&output_dir, &report, &args.suite).map_err(|error| error.error)?;
     Ok(report)
 }
 
@@ -2222,11 +2343,33 @@ fn build_report(
     } else {
         "fail"
     };
+    let suite_name = suite.name.clone().unwrap_or_else(|| "unnamed".to_string());
+    let summary = EvalReportCardSummary {
+        suite_name: suite_name.clone(),
+        version: suite.version,
+        mode,
+        output_dir: output_dir.clone(),
+        assertion_count,
+        pass_count,
+        fail_count,
+        error_count,
+        pass_rate,
+        fail_under,
+        gate_status,
+        run_case_count: cases.len(),
+    };
+    let eval_card = build_eval_card(
+        suite,
+        &summary,
+        &EvalCardRunContext::default(),
+        eval_card_telemetry_evidence(&summary.suite_name, false),
+    );
     EvalReport {
-        suite_name: suite.name.clone().unwrap_or_else(|| "unnamed".to_string()),
+        suite_name,
         version: suite.version,
         mode,
         output_dir,
+        eval_card,
         assertion_count,
         pass_count,
         fail_count,
@@ -2236,6 +2379,239 @@ fn build_report(
         gate_status,
         cases,
     }
+}
+
+#[derive(Debug)]
+struct EvalReportCardSummary {
+    suite_name: String,
+    version: u32,
+    mode: &'static str,
+    output_dir: String,
+    assertion_count: usize,
+    pass_count: usize,
+    fail_count: usize,
+    error_count: usize,
+    pass_rate: f64,
+    fail_under: f64,
+    gate_status: &'static str,
+    run_case_count: usize,
+}
+
+fn refresh_eval_card(report: &mut EvalReport, suite: &EvalSuite, context: &EvalCardRunContext) {
+    let summary = EvalReportCardSummary::from_report(report);
+    report.eval_card = build_eval_card(
+        suite,
+        &summary,
+        context,
+        eval_card_telemetry_evidence(&report.suite_name, context.telemetry_requested),
+    );
+}
+
+fn build_eval_card(
+    suite: &EvalSuite,
+    summary: &EvalReportCardSummary,
+    context: &EvalCardRunContext,
+    evidence: EvalCardTelemetryEvidence,
+) -> EvalCard {
+    EvalCard {
+        schema_version: "eval_card.v1",
+        suite_name: summary.suite_name.clone(),
+        version: summary.version,
+        suite_path: context.suite_path.clone(),
+        purpose: suite
+            .purpose
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map_or_else(|| default_eval_card_purpose(summary.mode), str::to_string),
+        persona: suite
+            .defaults
+            .persona
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+        manifest_scope: EvalCardManifestScope {
+            declared: suite
+                .manifest_scope
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .unwrap_or("not declared")
+                .to_string(),
+            manifest_hash: context.manifest_hash.clone(),
+            manifest_source: context.manifest_source.clone(),
+        },
+        mode: summary.mode,
+        bridge_case_count: suite.cases.len(),
+        agent_case_count: suite.agent_cases.len(),
+        run_case_count: summary.run_case_count,
+        output_dir: summary.output_dir.clone(),
+        assertion_count: summary.assertion_count,
+        pass_count: summary.pass_count,
+        fail_count: summary.fail_count,
+        error_count: summary.error_count,
+        pass_rate: summary.pass_rate,
+        fail_under: summary.fail_under,
+        run_status: summary.gate_status,
+        gate: evidence.gate,
+        telemetry: evidence.telemetry,
+        provider: context.provider.clone(),
+        known_gaps: suite
+            .known_gaps
+            .iter()
+            .map(|gap| gap.trim())
+            .filter(|gap| !gap.is_empty())
+            .map(str::to_string)
+            .collect(),
+    }
+}
+
+fn eval_card_telemetry_evidence(
+    suite_name: &str,
+    telemetry_requested: bool,
+) -> EvalCardTelemetryEvidence {
+    match read_telemetry_rows_for_suite(suite_name) {
+        Ok(rows) if rows.is_empty() => missing_eval_card_telemetry(telemetry_requested),
+        Ok(rows) => {
+            let latest = latest_telemetry_rows(&rows);
+            let first = latest.first().copied();
+            let timestamp = first
+                .and_then(|row| row.get("timestamp"))
+                .and_then(JsonValue::as_str)
+                .map(str::to_string);
+            let run_id = first
+                .and_then(|row| row.get("run_id"))
+                .and_then(JsonValue::as_str)
+                .map(str::to_string);
+            let telemetry = EvalCardTelemetry {
+                status: "latest".to_string(),
+                timestamp,
+                run_id,
+                row_count: latest.len(),
+                message: format!(
+                    "latest telemetry includes {} assertion row(s) for suite '{suite_name}'",
+                    latest.len()
+                ),
+            };
+            let gate = build_eval_gate_report(suite_name, &rows).map_or_else(
+                |error| EvalCardGate {
+                    status: "unavailable".to_string(),
+                    source: "telemetry",
+                    configured: false,
+                    threshold: None,
+                    pass_rate: None,
+                    total_evals: Some(latest.len()),
+                    failed_evals: None,
+                    message: format!("eval gate could not be derived from telemetry: {error}"),
+                },
+                |report| EvalCardGate::from_report(&report),
+            );
+            EvalCardTelemetryEvidence { telemetry, gate }
+        }
+        Err(error) => EvalCardTelemetryEvidence {
+            telemetry: EvalCardTelemetry {
+                status: "unavailable".to_string(),
+                timestamp: None,
+                run_id: None,
+                row_count: 0,
+                message: format!("eval telemetry could not be read: {error}"),
+            },
+            gate: EvalCardGate {
+                status: "unavailable".to_string(),
+                source: "telemetry",
+                configured: false,
+                threshold: None,
+                pass_rate: None,
+                total_evals: None,
+                failed_evals: None,
+                message: format!(
+                    "eval gate could not be derived because telemetry is unreadable: {error}"
+                ),
+            },
+        },
+    }
+}
+
+fn missing_eval_card_telemetry(telemetry_requested: bool) -> EvalCardTelemetryEvidence {
+    let message = if telemetry_requested {
+        "telemetry was requested, but no telemetry rows were found for this suite"
+    } else {
+        "no telemetry found for this suite; run with --telemetry to populate latest gate evidence"
+    };
+    EvalCardTelemetryEvidence {
+        telemetry: EvalCardTelemetry {
+            status: "missing".to_string(),
+            timestamp: None,
+            run_id: None,
+            row_count: 0,
+            message: message.to_string(),
+        },
+        gate: EvalCardGate {
+            status: "missing_telemetry".to_string(),
+            source: "telemetry",
+            configured: false,
+            threshold: None,
+            pass_rate: None,
+            total_evals: Some(0),
+            failed_evals: None,
+            message: "gate status unavailable until telemetry exists for the suite".to_string(),
+        },
+    }
+}
+
+fn default_eval_card_purpose(mode: &str) -> String {
+    match mode {
+        "agent" => "Summarizes provider-backed agent tool-use evidence for this eval suite.",
+        _ => "Summarizes deterministic Nova bridge eval evidence for this eval suite.",
+    }
+    .to_string()
+}
+
+impl EvalReportCardSummary {
+    fn from_report(report: &EvalReport) -> Self {
+        Self {
+            suite_name: report.suite_name.clone(),
+            version: report.version,
+            mode: report.mode,
+            output_dir: report.output_dir.clone(),
+            assertion_count: report.assertion_count,
+            pass_count: report.pass_count,
+            fail_count: report.fail_count,
+            error_count: report.error_count,
+            pass_rate: report.pass_rate,
+            fail_under: report.fail_under,
+            gate_status: report.gate_status,
+            run_case_count: report.cases.len(),
+        }
+    }
+}
+
+impl EvalCardGate {
+    fn from_report(report: &EvalGateReport) -> Self {
+        let status = if report.gate_configured {
+            if report.allowed { "pass" } else { "fail" }
+        } else {
+            "not_configured"
+        };
+        Self {
+            status: status.to_string(),
+            source: "telemetry",
+            configured: report.gate_configured,
+            threshold: report.threshold,
+            pass_rate: Some(report.pass_rate),
+            total_evals: Some(report.total_evals),
+            failed_evals: Some(report.failed_evals),
+            message: report.message.clone(),
+        }
+    }
+}
+
+fn agent_manifest_source(args: &EvalAgentRunArgs) -> Option<String> {
+    args.manifest_path
+        .as_deref()
+        .or(args.manifest_uri.as_deref())
+        .map(crate::utils::sanitize_uri)
 }
 
 fn write_report_artifacts(
@@ -2250,6 +2626,11 @@ fn write_report_artifacts(
         .map_err(|error| server_error(error.to_string()))?;
     fs::write(output_dir.join("results.tsv"), render_tsv(report))
         .map_err(|error| server_error(error.to_string()))?;
+    fs::write(
+        output_dir.join("card.md"),
+        render_eval_card_markdown(&report.eval_card),
+    )
+    .map_err(|error| server_error(error.to_string()))?;
     fs::write(output_dir.join("report.md"), render_markdown(report))
         .map_err(|error| server_error(error.to_string()))?;
     if let Err(error) = fs::copy(suite_path, output_dir.join("suite.yml")) {
@@ -2957,18 +3338,10 @@ fn render_tsv(report: &EvalReport) -> String {
 }
 
 fn render_markdown(report: &EvalReport) -> String {
-    let mut out = format!(
-        "# Nova Eval Report\n\n- Suite: `{}`\n- Mode: `{}`\n- Gate: `{}`\n- Pass rate: `{:.1}%`\n- Assertions: {} pass, {} fail, {} error\n\n",
-        report.suite_name,
-        report.mode,
-        report.gate_status,
-        report.pass_rate * 100.0,
-        report.pass_count,
-        report.fail_count,
-        report.error_count
-    );
+    let mut out = render_eval_card_markdown(&report.eval_card);
+    out.push_str("\n## Assertion Details\n\n");
     for case in &report.cases {
-        let _ = writeln!(out, "## {}\n", case.id);
+        let _ = writeln!(out, "### {}\n", case.id);
         for assertion in &case.assertions {
             let _ = writeln!(
                 out,
@@ -2977,6 +3350,75 @@ fn render_markdown(report: &EvalReport) -> String {
             );
         }
         out.push('\n');
+    }
+    out
+}
+
+fn render_eval_card_markdown(card: &EvalCard) -> String {
+    let mut out = format!(
+        "# Nova Eval Card\n\n- Suite: `{}`\n- Version: `{}`\n- Mode: `{}`\n- Purpose: {}\n- Run status: `{}`\n- Pass rate: `{:.1}%` ({} pass, {} fail, {} error / {} assertions)\n- Gate status: `{}`\n- Telemetry: `{}`\n- Output: `{}`\n",
+        card.suite_name,
+        card.version,
+        card.mode,
+        card.purpose,
+        card.run_status,
+        card.pass_rate * 100.0,
+        card.pass_count,
+        card.fail_count,
+        card.error_count,
+        card.assertion_count,
+        card.gate.status,
+        card.telemetry.status,
+        card.output_dir
+    );
+    if let Some(persona) = card.persona.as_ref() {
+        let _ = writeln!(out, "- Persona: `{persona}`");
+    }
+    if let Some(path) = card.suite_path.as_ref() {
+        let _ = writeln!(out, "- Suite path: `{path}`");
+    }
+    let _ = writeln!(
+        out,
+        "- Cases: {} bridge, {} agent, {} run",
+        card.bridge_case_count, card.agent_case_count, card.run_case_count
+    );
+    let _ = writeln!(out, "- Manifest scope: {}", card.manifest_scope.declared);
+    if let Some(source) = card.manifest_scope.manifest_source.as_ref() {
+        let _ = writeln!(out, "- Manifest source: `{source}`");
+    }
+    if let Some(hash) = card.manifest_scope.manifest_hash.as_ref() {
+        let _ = writeln!(out, "- Manifest hash: `{hash}`");
+    }
+    if let Some(threshold) = card.gate.threshold {
+        let _ = writeln!(out, "- Gate threshold: `{threshold:.3}`");
+    }
+    let _ = writeln!(out, "- Gate message: {}", card.gate.message);
+    if let Some(timestamp) = card.telemetry.timestamp.as_ref() {
+        let _ = writeln!(out, "- Telemetry timestamp: `{timestamp}`");
+    }
+    if let Some(run_id) = card.telemetry.run_id.as_ref() {
+        let _ = writeln!(out, "- Telemetry run: `{run_id}`");
+    }
+    let _ = writeln!(out, "- Telemetry rows: {}", card.telemetry.row_count);
+    let _ = writeln!(out, "- Telemetry message: {}", card.telemetry.message);
+    if let Some(provider) = card.provider.as_ref() {
+        let _ = writeln!(out, "- Provider: `{}`", provider.provider);
+        let _ = writeln!(
+            out,
+            "- Provider command preset: `{}`",
+            provider.command_preset
+        );
+        if let Some(model) = provider.model.as_ref() {
+            let _ = writeln!(out, "- Provider model: `{model}`");
+        }
+    }
+    out.push_str("- Known gaps:\n");
+    if card.known_gaps.is_empty() {
+        out.push_str("  - None declared.\n");
+    } else {
+        for gap in &card.known_gaps {
+            let _ = writeln!(out, "  - {gap}");
+        }
     }
     out
 }

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -5,18 +5,19 @@ use serde_json::json;
 use tempfile::{NamedTempFile, TempDir};
 
 use super::{
-    AgentCalledWith, AgentEntityRank, AgentExpected, AgentOrder, AssertionResult, EvalCaseReport,
-    EvalDefaults, EvalRunArgs, EvalSuite, EvalValidateArgs, FinalAnswerExpected,
-    apply_telemetry_retention, build_agent_eval_tool_response, build_eval_gate_report,
-    build_eval_gate_tool_response, build_eval_history_tool_response, build_eval_init_tool_response,
-    build_eval_validate_tool_response, contains_rank_assertion, context_contains_assertion,
-    context_field_equals_assertion, eval_case_telemetry_from_trace, format_utc_timestamp_millis,
-    json_has_field_path, metadata_score_max_assertion, metadata_score_min_assertion,
-    read_tool_trace, recipe_rank_assertion, resolve_mcp_writable_path, run_eval_command,
-    run_validate_command, safe_path_segment, score_agent_expectations, selected_agent_cases,
-    selected_bridge_cases, suite_file_hash, telemetry_path_for_suite, telemetry_row_matches_since,
-    tool_response_budget_assertion, tool_success_assertion, validate_since_date, validate_suite,
-    validate_telemetry_suite_name,
+    AgentCalledWith, AgentEntityRank, AgentExpected, AgentOrder, AssertionResult, EvalCardProvider,
+    EvalCardRunContext, EvalCaseReport, EvalDefaults, EvalRunArgs, EvalSuite, EvalValidateArgs,
+    FinalAnswerExpected, apply_telemetry_retention, build_agent_eval_tool_response,
+    build_eval_gate_report, build_eval_gate_tool_response, build_eval_history_tool_response,
+    build_eval_init_tool_response, build_eval_validate_tool_response, build_report,
+    contains_rank_assertion, context_contains_assertion, context_field_equals_assertion,
+    eval_case_telemetry_from_trace, format_utc_timestamp_millis, json_has_field_path,
+    metadata_score_max_assertion, metadata_score_min_assertion, read_tool_trace,
+    recipe_rank_assertion, refresh_eval_card, render_eval_card_markdown, resolve_mcp_writable_path,
+    run_eval_command, run_validate_command, safe_path_segment, score_agent_expectations,
+    selected_agent_cases, selected_bridge_cases, suite_file_hash, telemetry_path_for_suite,
+    telemetry_row_matches_since, tool_response_budget_assertion, tool_success_assertion,
+    validate_since_date, validate_suite, validate_telemetry_suite_name,
 };
 use crate::params::{
     GetEvalGateParams, GetEvalHistoryParams, InitEvalSuiteParams, RunAgentEvalParams,
@@ -294,6 +295,244 @@ fn case_report_counts_statuses() {
 }
 
 #[test]
+fn eval_card_summarizes_bridge_report_with_missing_telemetry() {
+    let suite = eval_card_suite("card-bridge", Some(0.9), false);
+    let report = build_report(
+        &suite,
+        "bridge",
+        "out/eval-card".to_string(),
+        0.9,
+        vec![EvalCaseReport::new(
+            "bridge_case".to_string(),
+            Some("Find canonical orders".to_string()),
+            vec![AssertionResult::pass(
+                "search_rank",
+                "ranked first",
+                json!({}),
+            )],
+            None,
+        )],
+    );
+
+    assert_eq!(report.eval_card.schema_version, "eval_card.v1");
+    assert_eq!(report.eval_card.suite_name, "card-bridge");
+    assert_eq!(report.eval_card.mode, "bridge");
+    assert_eq!(report.eval_card.bridge_case_count, 1);
+    assert_eq!(report.eval_card.agent_case_count, 0);
+    assert_eq!(report.eval_card.run_status, "pass");
+    assert!((report.eval_card.pass_rate - 1.0).abs() < f64::EPSILON);
+    assert_eq!(report.eval_card.telemetry.status, "missing");
+    assert_eq!(report.eval_card.gate.status, "missing_telemetry");
+    assert_eq!(
+        report.eval_card.manifest_scope.declared,
+        "synthetic starter manifest"
+    );
+    assert_eq!(
+        report.eval_card.known_gaps,
+        vec!["does not cover live warehouse freshness".to_string()]
+    );
+}
+
+#[test]
+fn eval_card_includes_agent_provider_metadata() {
+    let suite = eval_card_suite("card-agent", None, true);
+    let mut report = build_report(
+        &suite,
+        "agent",
+        "out/agent-card".to_string(),
+        1.0,
+        vec![EvalCaseReport::new(
+            "agent_case".to_string(),
+            Some("Use Nova to answer the task".to_string()),
+            vec![AssertionResult::pass(
+                "must_call:search_indicator",
+                "required tool was called",
+                json!({}),
+            )],
+            None,
+        )],
+    );
+    refresh_eval_card(
+        &mut report,
+        &suite,
+        &EvalCardRunContext {
+            manifest_source: Some("tests/fixtures/starter_eval_manifest.json".to_string()),
+            provider: Some(EvalCardProvider {
+                provider: "opencode".to_string(),
+                command_preset: "opencode".to_string(),
+                model: Some("opencode/deepseek-v4-flash-free".to_string()),
+            }),
+            ..EvalCardRunContext::default()
+        },
+    );
+
+    let provider = report
+        .eval_card
+        .provider
+        .as_ref()
+        .expect("provider metadata");
+    assert_eq!(provider.provider, "opencode");
+    assert_eq!(provider.command_preset, "opencode");
+    assert_eq!(
+        provider.model.as_deref(),
+        Some("opencode/deepseek-v4-flash-free")
+    );
+    assert_eq!(
+        report.eval_card.manifest_scope.manifest_source.as_deref(),
+        Some("tests/fixtures/starter_eval_manifest.json")
+    );
+}
+
+#[test]
+fn eval_card_uses_latest_telemetry_gate_when_available() {
+    let suite_name = "card-gated";
+    let suite = gate_suite_file(Some(1.0));
+    let suite_hash = suite_file_hash(&suite.path().display().to_string()).expect("suite hash");
+    let telemetry_path = telemetry_path_for_suite(suite_name);
+    if let Some(parent) = telemetry_path.parent() {
+        std::fs::create_dir_all(parent).expect("telemetry dir");
+    }
+    let rows = [
+        telemetry_row_with_suite_hash(
+            suite_name,
+            &suite.path().display().to_string(),
+            &suite_hash,
+            "latest",
+            2,
+            "case_a",
+            "assertion_a",
+            "pass",
+        ),
+        telemetry_row_with_suite_hash(
+            suite_name,
+            &suite.path().display().to_string(),
+            &suite_hash,
+            "latest",
+            2,
+            "case_b",
+            "assertion_b",
+            "fail",
+        ),
+    ];
+    let mut body = rows
+        .iter()
+        .map(serde_json::to_string)
+        .collect::<Result<Vec<_>, _>>()
+        .expect("serialize telemetry")
+        .join("\n");
+    body.push('\n');
+    std::fs::write(&telemetry_path, body).expect("write telemetry");
+
+    let suite = eval_card_suite(suite_name, Some(1.0), false);
+    let mut report = build_report(
+        &suite,
+        "bridge",
+        "out/card-gated".to_string(),
+        1.0,
+        vec![EvalCaseReport::new(
+            "case_a".to_string(),
+            None,
+            vec![AssertionResult::pass("assertion_a", "ok", json!({}))],
+            None,
+        )],
+    );
+    refresh_eval_card(
+        &mut report,
+        &suite,
+        &EvalCardRunContext {
+            telemetry_requested: true,
+            ..EvalCardRunContext::default()
+        },
+    );
+
+    assert_eq!(report.eval_card.telemetry.status, "latest");
+    assert_eq!(report.eval_card.telemetry.row_count, 2);
+    assert_eq!(report.eval_card.gate.status, "fail");
+    assert!(report.eval_card.gate.configured);
+    assert_eq!(report.eval_card.gate.threshold, Some(1.0));
+    assert_eq!(report.eval_card.gate.total_evals, Some(2));
+    assert_eq!(report.eval_card.gate.failed_evals, Some(1));
+
+    std::fs::remove_file(telemetry_path).expect("remove telemetry");
+}
+
+#[test]
+fn eval_card_represents_no_gate_with_latest_telemetry() {
+    let suite = gate_suite_file(None);
+    let suite_name = "card-no-gate";
+    let suite_hash = suite_file_hash(&suite.path().display().to_string()).expect("suite hash");
+    let telemetry_path = telemetry_path_for_suite(suite_name);
+    if let Some(parent) = telemetry_path.parent() {
+        std::fs::create_dir_all(parent).expect("telemetry dir");
+    }
+    let row = telemetry_row_with_suite_hash(
+        suite_name,
+        &suite.path().display().to_string(),
+        &suite_hash,
+        "latest",
+        1,
+        "case_a",
+        "assertion_a",
+        "pass",
+    );
+    std::fs::write(
+        &telemetry_path,
+        format!("{}\n", serde_json::to_string(&row).expect("row JSON")),
+    )
+    .expect("write telemetry");
+
+    let suite = eval_card_suite(suite_name, None, false);
+    let report = build_report(
+        &suite,
+        "bridge",
+        "out/card-no-gate".to_string(),
+        1.0,
+        vec![EvalCaseReport::new(
+            "case_a".to_string(),
+            None,
+            vec![AssertionResult::pass("assertion_a", "ok", json!({}))],
+            None,
+        )],
+    );
+
+    assert_eq!(report.eval_card.telemetry.status, "latest");
+    assert_eq!(report.eval_card.gate.status, "not_configured");
+    assert!(!report.eval_card.gate.configured);
+    assert!(report.eval_card.gate.message.contains("allowed by default"));
+
+    std::fs::remove_file(telemetry_path).expect("remove telemetry");
+}
+
+#[test]
+fn eval_card_markdown_is_pr_ready() {
+    let suite = eval_card_suite("card-markdown", None, false);
+    let report = build_report(
+        &suite,
+        "bridge",
+        "out/card-markdown".to_string(),
+        1.0,
+        vec![EvalCaseReport::new(
+            "case".to_string(),
+            None,
+            vec![AssertionResult::pass(
+                "tool_success:search",
+                "ok",
+                json!({}),
+            )],
+            None,
+        )],
+    );
+
+    let markdown = render_eval_card_markdown(&report.eval_card);
+
+    assert!(markdown.starts_with("# Nova Eval Card"));
+    assert!(markdown.contains("Pass rate: `100.0%`"));
+    assert!(markdown.contains("Gate status: `missing_telemetry`"));
+    assert!(markdown.contains("Known gaps:"));
+    assert!(markdown.contains("does not cover live warehouse freshness"));
+}
+
+#[test]
 fn read_tool_trace_reports_parse_errors() {
     let file = NamedTempFile::new().expect("temp file");
     std::fs::write(
@@ -418,6 +657,9 @@ fn telemetry_requires_named_suite() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        purpose: None,
+        manifest_scope: None,
+        known_gaps: Vec::new(),
         gate: None,
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
@@ -778,6 +1020,9 @@ fn validate_suite_rejects_invalid_gate_threshold() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        purpose: None,
+        manifest_scope: None,
+        known_gaps: Vec::new(),
         gate: Some(super::EvalGateConfig { threshold: 1.1 }),
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
@@ -792,6 +1037,9 @@ fn validate_suite_rejects_duplicate_agent_case_ids() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        purpose: None,
+        manifest_scope: None,
+        known_gaps: Vec::new(),
         gate: None,
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
@@ -817,6 +1065,9 @@ fn validate_suite_rejects_duplicate_artifact_segments() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        purpose: None,
+        manifest_scope: None,
+        known_gaps: Vec::new(),
         gate: None,
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
@@ -842,6 +1093,9 @@ fn validate_suite_rejects_case_insensitive_artifact_segment_collisions() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        purpose: None,
+        manifest_scope: None,
+        known_gaps: Vec::new(),
         gate: None,
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
@@ -867,6 +1121,9 @@ fn validate_suite_rejects_vacuous_search_columns_rank_assertion() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        purpose: None,
+        manifest_scope: None,
+        known_gaps: Vec::new(),
         gate: None,
         defaults: EvalDefaults::default(),
         cases: vec![super::EvalCase {
@@ -891,6 +1148,9 @@ fn validate_suite_rejects_unmatchable_called_with_param_values() {
     let suite = EvalSuite {
         version: 1,
         name: None,
+        purpose: None,
+        manifest_scope: None,
+        known_gaps: Vec::new(),
         gate: None,
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
@@ -1238,8 +1498,16 @@ cases:
     );
     assert!(output_dir.join("results.json").exists());
     assert!(output_dir.join("results.tsv").exists());
+    assert!(output_dir.join("card.md").exists());
     assert!(output_dir.join("report.md").exists());
     assert!(output_dir.join("suite.yml").exists());
+    let results = std::fs::read_to_string(output_dir.join("results.json")).expect("results json");
+    let results: serde_json::Value = serde_json::from_str(&results).expect("parse results");
+    assert_eq!(
+        results["eval_card"]["schema_version"],
+        json!("eval_card.v1")
+    );
+    assert_eq!(results["eval_card"]["mode"], json!("bridge"));
 }
 
 #[test]
@@ -1255,6 +1523,43 @@ fn fixture_manifest_path(name: &str) -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures")
         .join(name)
+}
+
+fn eval_card_suite(name: &str, threshold: Option<f64>, include_agent_case: bool) -> EvalSuite {
+    EvalSuite {
+        version: 1,
+        name: Some(name.to_string()),
+        purpose: Some("Proves that Nova can answer the core eval question.".to_string()),
+        manifest_scope: Some("synthetic starter manifest".to_string()),
+        known_gaps: vec!["does not cover live warehouse freshness".to_string()],
+        gate: threshold.map(|threshold| super::EvalGateConfig { threshold }),
+        defaults: EvalDefaults {
+            persona: Some("analyst".to_string()),
+            top_k: 5,
+        },
+        cases: if include_agent_case {
+            Vec::new()
+        } else {
+            vec![super::EvalCase {
+                id: "bridge_case".to_string(),
+                question: Some("Find canonical orders".to_string()),
+                persona: None,
+                assertions: vec![super::EvalAssertion::ToolSuccess {
+                    tool: "search".to_string(),
+                    params: json!({}),
+                }],
+            }]
+        },
+        agent_cases: if include_agent_case {
+            vec![super::AgentCase {
+                id: "agent_case".to_string(),
+                task: "Use Nova to answer the task".to_string(),
+                expected: AgentExpected::default(),
+            }]
+        } else {
+            Vec::new()
+        },
+    }
 }
 
 fn gate_suite_file(threshold: Option<f64>) -> NamedTempFile {
@@ -1431,6 +1736,35 @@ fn telemetry_row_with_run_id_and_counts(
         && let Some(object) = row.as_object_mut()
     {
         object.insert("suite_hash".to_string(), json!(hash));
+    }
+    row
+}
+
+#[allow(clippy::too_many_arguments)]
+fn telemetry_row_with_suite_hash(
+    suite_name: &str,
+    suite_path: &str,
+    suite_hash: &str,
+    output_dir: &str,
+    timestamp_ms: u64,
+    case_id: &str,
+    assertion_name: &str,
+    status: &str,
+) -> serde_json::Value {
+    let mut row = telemetry_row_with_assertion_count(
+        suite_name,
+        suite_path,
+        output_dir,
+        timestamp_ms,
+        case_id,
+        assertion_name,
+        status,
+        2,
+    );
+    if let Some(object) = row.as_object_mut() {
+        object.insert("suite_hash".to_string(), json!(suite_hash));
+        object.insert("suite_case_count".to_string(), json!(2));
+        object.insert("run_case_count".to_string(), json!(2));
     }
     row
 }


### PR DESCRIPTION
## Summary
- Add `eval_card.v1` to bridge and provider-backed agent eval reports.
- Write `card.md` and prepend the same PR-ready card to `report.md`.
- Document card fields and update packaged eval suites plus eval-author guidance with purpose, manifest scope, and known gaps.

## Linear
- JOE-115

## Validation
- `git diff --check`
- `cargo fmt --check`
- `cargo test --locked --all-features eval_cmd`
- `uv run --with-requirements docs/requirements.txt mkdocs build --strict`
- Manual smoke: `cargo run --locked --no-default-features -- eval run --suite evals/starter.yml --manifest-path tests/fixtures/starter_eval_manifest.json --output-dir /tmp/dbt-nova-joe-115-starter --telemetry --fail-under 1.0 --json`

## Review Notes
- Local deep sweep checked CLI/MCP report parity, stale or missing telemetry behavior, provider metadata, artifact ordering, Markdown rendering, and docs/examples alignment.