### PR TITLE
Add eval date anchoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `results.json`, write a PR-ready `card.md`, and prepend the same card to
   `report.md`, including suite purpose, scope, case counts, pass rate, gate
   evidence, telemetry status, provider metadata, and known gaps.
+- Eval suites can now declare `snapshot_date`, `date_range_start`,
+  `date_range_end`, and `date_field` anchors at suite or case level; Nova
+  validates anchor dates, injects effective anchors into agent prompts, and
+  includes them in reports and eval telemetry.
 - Documented bridge and provider-backed eval CI templates with GitHub Actions
   examples for manifest generation, telemetry retention, eval gates, artifact
   upload, private OpenCode provider runs, and redacted trace handling.

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -58,6 +58,62 @@ Validate suite shape before running against a manifest or provider:
 dbt-nova eval validate --suite evals/analyst-smoke.yml
 ```
 
+## Date Anchors
+
+Use date anchors when a case contains relative time language such as "last
+month", "this week", or "current quarter". Anchors are suite/case metadata:
+they validate the intended dates, appear in artifacts and telemetry, and are
+injected into agent eval prompts. They do not rewrite SQL, guess date columns,
+or create warehouse snapshots.
+
+Put common anchors at the suite level, then override any field on individual
+bridge or agent cases:
+
+```yaml
+version: 1
+name: analyst-date-smoke
+snapshot_date: "2026-03-31"
+date_field: order_date
+cases:
+  - id: march_revenue_context
+    question: Find the model for revenue last month.
+    date_range_start: "2026-03-01"
+    date_range_end: "2026-03-31"
+    assertions:
+      - type: search_indicator_rank
+        query: gross revenue last month
+        expected: gross_revenue
+        max_rank: 3
+agent_cases:
+  - id: march_revenue_agent
+    task: Compare gross revenue last month with the prior month.
+    date_range_start: "2026-03-01"
+    date_range_end: "2026-03-31"
+    expected:
+      must_call:
+        - search_indicator
+```
+
+Supported fields are:
+
+- `snapshot_date`: the absolute "as of" date for interpreting relative terms.
+- `date_range_start` and `date_range_end`: an inclusive date range; set both
+  fields together.
+- `date_field`: the expected business/date column name when the case needs one.
+
+Dates must be valid `YYYY-MM-DD` calendar dates. `date_field` is optional, but
+when set it must accompany either `snapshot_date` or a full date range after
+suite/case inheritance is applied. Case fields override suite fields one by
+one, so a case can inherit `snapshot_date`, `date_range_end`, or `date_field`
+while setting only the fields that differ. If the effective case anchor has an
+incomplete range, validation fails.
+
+Date anchoring answers "what dates should this case mean?" Query-structure
+grading answers a different question: "did the generated SQL use the expected
+tables, joins, filters, projections, and grouping even if returned values
+drift?" Date anchors provide deterministic prompt/report context; they are not
+a SQL-structure grader.
+
 ## Run The Packaged Starter Suite
 
 dbt-nova ships `evals/starter.yml` plus a synthetic manifest fixture at
@@ -117,9 +173,10 @@ Outputs are written to `.nova/eval-runs/<timestamp>-<suite>-bridge/` by default:
 `eval_card.v1`. The card summarizes the suite name/version, optional suite
 `purpose`, default persona, declared `manifest_scope`, bridge and agent case
 counts, latest run status, pass rate, configured gate evidence when telemetry is
-available, telemetry timestamp or explicit missing-telemetry status, provider
-metadata for agent runs, and declared `known_gaps`. `report.md` starts with the
-same card before listing assertion-level details, so `card.md` can be pasted
+available, telemetry timestamp or explicit missing-telemetry status, suite-level
+date anchor metadata when declared, provider metadata for agent runs, and
+declared `known_gaps`. `report.md` starts with the same card before listing
+assertion-level details and per-case date anchors, so `card.md` can be pasted
 directly into PR descriptions.
 
 Bridge assertions currently support:
@@ -346,8 +403,10 @@ name/path/hash, mode, case id, assertion name/type, status, run duration, output
 directory, git SHA when available, and manifest hash for bridge runs. Agent rows
 also include provider metadata and sanitized trace counters such as tool-call
 count, distinct tool count, response bytes, and token counts when a provider
-trace exposes them. Telemetry does not store raw SQL parameter maps, provider
-stdout/stderr, or credentials.
+trace exposes them. When a suite or case declares date anchors, each assertion
+row also includes the effective `snapshot_date`, `date_range_start`,
+`date_range_end`, `date_field`, and nested `date_anchor` object. Telemetry does
+not store raw SQL parameter maps, provider stdout/stderr, or credentials.
 
 Use `eval history` for a thin date filter over the JSONL file:
 

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -47,6 +47,8 @@ struct EvalSuite {
     known_gaps: Vec<String>,
     #[serde(default)]
     gate: Option<EvalGateConfig>,
+    #[serde(flatten)]
+    date_anchor: DateAnchor,
     #[serde(default)]
     defaults: EvalDefaults,
     #[serde(default)]
@@ -58,6 +60,75 @@ struct EvalSuite {
 #[derive(Debug, Clone, Copy, Deserialize)]
 struct EvalGateConfig {
     threshold: f64,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+struct DateAnchor {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    snapshot_date: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    date_range_start: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    date_range_end: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    date_field: Option<String>,
+}
+
+impl DateAnchor {
+    fn normalized(&self) -> Option<Self> {
+        let anchor = Self {
+            snapshot_date: normalized_string(self.snapshot_date.as_ref()),
+            date_range_start: normalized_string(self.date_range_start.as_ref()),
+            date_range_end: normalized_string(self.date_range_end.as_ref()),
+            date_field: normalized_string(self.date_field.as_ref()),
+        };
+        (!anchor.is_empty()).then_some(anchor)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.snapshot_date
+            .as_deref()
+            .is_none_or(|value| value.trim().is_empty())
+            && self
+                .date_range_start
+                .as_deref()
+                .is_none_or(|value| value.trim().is_empty())
+            && self
+                .date_range_end
+                .as_deref()
+                .is_none_or(|value| value.trim().is_empty())
+            && self
+                .date_field
+                .as_deref()
+                .is_none_or(|value| value.trim().is_empty())
+    }
+
+    fn prompt_lines(&self) -> Vec<String> {
+        self.markdown_lines()
+            .into_iter()
+            .map(|line| line.replace('`', ""))
+            .collect()
+    }
+
+    fn markdown_lines(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        if let Some(value) = self.snapshot_date.as_deref() {
+            lines.push(format!("snapshot_date: `{value}`"));
+        }
+        match (
+            self.date_range_start.as_deref(),
+            self.date_range_end.as_deref(),
+        ) {
+            (Some(start), Some(end)) => lines.push(format!("date_range: `{start}` to `{end}`")),
+            (Some(start), None) => lines.push(format!("date_range_start: `{start}`")),
+            (None, Some(end)) => lines.push(format!("date_range_end: `{end}`")),
+            (None, None) => {}
+        }
+        if let Some(value) = self.date_field.as_deref() {
+            lines.push(format!("date_field: `{value}`"));
+        }
+        lines
+    }
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -75,6 +146,8 @@ struct EvalCase {
     question: Option<String>,
     #[serde(default)]
     persona: Option<String>,
+    #[serde(flatten)]
+    date_anchor: DateAnchor,
     assertions: Vec<EvalAssertion>,
 }
 
@@ -180,6 +253,8 @@ enum EvalAssertion {
 struct AgentCase {
     id: String,
     task: String,
+    #[serde(flatten)]
+    date_anchor: DateAnchor,
     #[serde(default)]
     expected: AgentExpected,
 }
@@ -286,6 +361,8 @@ struct EvalCard {
     gate: EvalCardGate,
     telemetry: EvalCardTelemetry,
     #[serde(skip_serializing_if = "Option::is_none")]
+    date_anchor: Option<DateAnchor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     provider: Option<EvalCardProvider>,
     known_gaps: Vec<String>,
 }
@@ -343,6 +420,8 @@ struct EvalCaseReport {
     fail_count: usize,
     error_count: usize,
     assertions: Vec<AssertionResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    date_anchor: Option<DateAnchor>,
     #[serde(skip_serializing_if = "Option::is_none")]
     artifacts: Option<AgentArtifacts>,
     #[serde(skip)]
@@ -889,7 +968,7 @@ async fn execute_agent_eval_from_args(args: &EvalAgentRunArgs) -> crate::error::
 
     let mut cases = Vec::with_capacity(selected_cases.len());
     for case in selected_cases {
-        cases.push(run_agent_case(case, args, &output_dir).await);
+        cases.push(run_agent_case(case, &suite, args, &output_dir).await);
     }
     let mut report = build_report(
         &suite,
@@ -946,6 +1025,7 @@ async fn evaluate_bridge_case(
         assertions.push(evaluate_bridge_assertion(assertion, case, suite, search).await);
     }
     EvalCaseReport::new(case.id.clone(), case.question.clone(), assertions, None)
+        .with_date_anchor(effective_date_anchor(&suite.date_anchor, &case.date_anchor))
 }
 
 async fn evaluate_bridge_assertion(
@@ -1184,9 +1264,11 @@ async fn call_tool(
 
 async fn run_agent_case(
     case: &AgentCase,
+    suite: &EvalSuite,
     args: &EvalAgentRunArgs,
     output_dir: &Path,
 ) -> EvalCaseReport {
+    let date_anchor = effective_date_anchor(&suite.date_anchor, &case.date_anchor);
     let case_dir = output_dir.join(safe_path_segment(&case.id));
     if let Err(error) = fs::create_dir_all(&case_dir) {
         return EvalCaseReport::new(
@@ -1197,7 +1279,8 @@ async fn run_agent_case(
                 format!("failed to create case artifact directory: {error}"),
             )],
             None,
-        );
+        )
+        .with_date_anchor(date_anchor);
     }
     let trace_path = output_dir
         .join("tool-calls")
@@ -1211,9 +1294,10 @@ async fn run_agent_case(
                 format!("failed to reset tool trace file: {error}"),
             )],
             None,
-        );
+        )
+        .with_date_anchor(date_anchor);
     }
-    let prompt = agent_prompt(case);
+    let prompt = agent_prompt(case, date_anchor.as_ref());
     let invocation = match provider::provider_invocation(args, &prompt, &trace_path) {
         Ok(invocation) => invocation,
         Err(error) => {
@@ -1225,7 +1309,8 @@ async fn run_agent_case(
                     error.to_string(),
                 )],
                 None,
-            );
+            )
+            .with_date_anchor(date_anchor);
         }
     };
 
@@ -1306,6 +1391,7 @@ async fn run_agent_case(
             tool_trace: trace_path.display().to_string(),
         }),
     )
+    .with_date_anchor(date_anchor)
     .with_telemetry(telemetry)
 }
 
@@ -2456,6 +2542,7 @@ fn build_eval_card(
         run_status: summary.gate_status,
         gate: evidence.gate,
         telemetry: evidence.telemetry,
+        date_anchor: suite.date_anchor.normalized(),
         provider: context.provider.clone(),
         known_gaps: suite
             .known_gaps
@@ -3064,6 +3151,9 @@ fn write_eval_telemetry(
                     }
                 }
             }
+            if let Some(date_anchor) = case.date_anchor.as_ref() {
+                insert_date_anchor_telemetry(&mut row, date_anchor);
+            }
             let line = serde_json::to_string(&JsonValue::Object(row))
                 .map_err(|error| server_error(error.to_string()))?;
             file.write_all(line.as_bytes())
@@ -3108,6 +3198,22 @@ fn stable_telemetry_hash(value: &str) -> u64 {
         hash = hash.wrapping_mul(0x0000_0001_0000_01b3);
     }
     hash
+}
+
+fn insert_date_anchor_telemetry(row: &mut serde_json::Map<String, JsonValue>, anchor: &DateAnchor) {
+    if let Some(value) = anchor.snapshot_date.as_ref() {
+        row.insert("snapshot_date".to_string(), json!(value));
+    }
+    if let Some(value) = anchor.date_range_start.as_ref() {
+        row.insert("date_range_start".to_string(), json!(value));
+    }
+    if let Some(value) = anchor.date_range_end.as_ref() {
+        row.insert("date_range_end".to_string(), json!(value));
+    }
+    if let Some(value) = anchor.date_field.as_ref() {
+        row.insert("date_field".to_string(), json!(value));
+    }
+    row.insert("date_anchor".to_string(), json!(anchor));
 }
 
 fn telemetry_row_matches_since(row: &JsonValue, since_boundary: &str) -> bool {
@@ -3342,6 +3448,13 @@ fn render_markdown(report: &EvalReport) -> String {
     out.push_str("\n## Assertion Details\n\n");
     for case in &report.cases {
         let _ = writeln!(out, "### {}\n", case.id);
+        if let Some(date_anchor) = case.date_anchor.as_ref() {
+            out.push_str("Date anchor:\n");
+            for line in date_anchor.markdown_lines() {
+                let _ = writeln!(out, "- {line}");
+            }
+            out.push('\n');
+        }
         for assertion in &case.assertions {
             let _ = writeln!(
                 out,
@@ -3401,6 +3514,12 @@ fn render_eval_card_markdown(card: &EvalCard) -> String {
     }
     let _ = writeln!(out, "- Telemetry rows: {}", card.telemetry.row_count);
     let _ = writeln!(out, "- Telemetry message: {}", card.telemetry.message);
+    if let Some(date_anchor) = card.date_anchor.as_ref() {
+        out.push_str("- Suite date anchor:\n");
+        for line in date_anchor.markdown_lines() {
+            let _ = writeln!(out, "  - {line}");
+        }
+    }
     if let Some(provider) = card.provider.as_ref() {
         let _ = writeln!(out, "- Provider: `{}`", provider.provider);
         let _ = writeln!(
@@ -3496,9 +3615,15 @@ impl EvalCaseReport {
             fail_count,
             error_count,
             assertions,
+            date_anchor: None,
             artifacts,
             telemetry: None,
         }
+    }
+
+    fn with_date_anchor(mut self, date_anchor: Option<DateAnchor>) -> Self {
+        self.date_anchor = date_anchor;
+        self
     }
 
     fn with_telemetry(mut self, telemetry: EvalCaseTelemetry) -> Self {
@@ -3553,11 +3678,23 @@ impl AgentExpected {
 
 fn build_eval_validate_payload(path: &str) -> crate::error::Result<JsonValue> {
     let suite = load_suite(path)?;
+    let date_anchor_case_count = suite
+        .cases
+        .iter()
+        .filter(|case| effective_date_anchor(&suite.date_anchor, &case.date_anchor).is_some())
+        .count()
+        + suite
+            .agent_cases
+            .iter()
+            .filter(|case| effective_date_anchor(&suite.date_anchor, &case.date_anchor).is_some())
+            .count();
     Ok(json!({
         "valid": true,
         "path": path,
         "suite_name": suite.name.as_deref().unwrap_or("suite"),
         "version": suite.version,
+        "date_anchor": suite.date_anchor.normalized(),
+        "date_anchor_case_count": date_anchor_case_count,
         "bridge_case_count": suite.cases.len(),
         "agent_case_count": suite.agent_cases.len(),
     }))
@@ -3566,6 +3703,127 @@ fn build_eval_validate_payload(path: &str) -> crate::error::Result<JsonValue> {
 fn build_eval_gate_report_for_suite(suite_name: &str) -> crate::error::Result<EvalGateReport> {
     let rows = read_telemetry_rows_for_suite(suite_name)?;
     build_eval_gate_report(suite_name, &rows)
+}
+
+fn normalized_string(value: Option<&String>) -> Option<String> {
+    value
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn effective_date_anchor(suite: &DateAnchor, case: &DateAnchor) -> Option<DateAnchor> {
+    let anchor = DateAnchor {
+        snapshot_date: normalized_string(case.snapshot_date.as_ref())
+            .or_else(|| normalized_string(suite.snapshot_date.as_ref())),
+        date_range_start: normalized_string(case.date_range_start.as_ref())
+            .or_else(|| normalized_string(suite.date_range_start.as_ref())),
+        date_range_end: normalized_string(case.date_range_end.as_ref())
+            .or_else(|| normalized_string(suite.date_range_end.as_ref())),
+        date_field: normalized_string(case.date_field.as_ref())
+            .or_else(|| normalized_string(suite.date_field.as_ref())),
+    };
+    (!anchor.is_empty()).then_some(anchor)
+}
+
+fn validate_date_anchor(anchor: &DateAnchor, location: &str) -> crate::error::Result<()> {
+    validate_optional_date(anchor.snapshot_date.as_deref(), location, "snapshot_date")?;
+    validate_optional_date(
+        anchor.date_range_start.as_deref(),
+        location,
+        "date_range_start",
+    )?;
+    validate_optional_date(anchor.date_range_end.as_deref(), location, "date_range_end")?;
+    if let Some(field) = anchor.date_field.as_deref()
+        && field.trim().is_empty()
+    {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "{location} date_field must be non-empty when set"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_complete_date_anchor(anchor: &DateAnchor, location: &str) -> crate::error::Result<()> {
+    let snapshot_date =
+        validate_optional_date(anchor.snapshot_date.as_deref(), location, "snapshot_date")?;
+    let date_range_start = validate_optional_date(
+        anchor.date_range_start.as_deref(),
+        location,
+        "date_range_start",
+    )?;
+    let date_range_end =
+        validate_optional_date(anchor.date_range_end.as_deref(), location, "date_range_end")?;
+    if date_range_start.is_some() != date_range_end.is_some() {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "{location} must include both date_range_start and date_range_end when either date range field is set"
+        )));
+    }
+    if let (Some(start), Some(end)) = (date_range_start, date_range_end)
+        && start > end
+    {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "{location} date_range_start must be on or before date_range_end"
+        )));
+    }
+    if snapshot_date.is_none()
+        && date_range_start.is_none()
+        && anchor
+            .date_field
+            .as_deref()
+            .is_some_and(|field| !field.trim().is_empty())
+    {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "{location} date_field requires snapshot_date or date_range_start/date_range_end"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_optional_date(
+    value: Option<&str>,
+    location: &str,
+    field: &str,
+) -> crate::error::Result<Option<(i32, u32, u32)>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "{location} {field} must be a non-empty YYYY-MM-DD date"
+        )));
+    }
+    parse_iso_date(trimmed).map(Some).ok_or_else(|| {
+        DbtNovaError::InvalidParams(format!(
+            "{location} {field} must use YYYY-MM-DD with a valid calendar date"
+        ))
+    })
+}
+
+fn parse_iso_date(value: &str) -> Option<(i32, u32, u32)> {
+    let bytes = value.as_bytes();
+    if bytes.len() != 10 || bytes[4] != b'-' || bytes[7] != b'-' {
+        return None;
+    }
+    let year = i32::try_from(parse_date_part(&value[0..4])?).ok()?;
+    let month = parse_date_part(&value[5..7])?;
+    let day = parse_date_part(&value[8..10])?;
+    let max_day = days_in_month(year, month);
+    if max_day == 0 || day == 0 || day > max_day {
+        return None;
+    }
+    Some((year, month, day))
+}
+
+fn parse_date_part(value: &str) -> Option<u32> {
+    value
+        .as_bytes()
+        .iter()
+        .all(u8::is_ascii_digit)
+        .then(|| value.parse::<u32>().ok())
+        .flatten()
 }
 
 fn eval_history_rows(
@@ -3838,12 +4096,26 @@ fn validate_suite(suite: &EvalSuite) -> crate::error::Result<()> {
             "eval suite gate.threshold must be between 0.0 and 1.0".to_string(),
         ));
     }
+    validate_date_anchor(&suite.date_anchor, "eval suite")?;
+    if suite.cases.is_empty()
+        && suite.agent_cases.is_empty()
+        && let Some(date_anchor) = suite.date_anchor.normalized()
+    {
+        validate_complete_date_anchor(&date_anchor, "eval suite")?;
+    }
     validate_case_ids(suite.cases.iter().map(|case| case.id.as_str()), "cases")?;
     validate_case_ids(
         suite.agent_cases.iter().map(|case| case.id.as_str()),
         "agent_cases",
     )?;
     for case in &suite.cases {
+        validate_date_anchor(&case.date_anchor, &format!("eval case '{}'", case.id))?;
+        if let Some(date_anchor) = effective_date_anchor(&suite.date_anchor, &case.date_anchor) {
+            validate_complete_date_anchor(
+                &date_anchor,
+                &format!("effective date anchor for eval case '{}'", case.id),
+            )?;
+        }
         if case.assertions.is_empty() {
             return Err(DbtNovaError::InvalidParams(format!(
                 "eval case '{}' must include at least one assertion",
@@ -3855,6 +4127,13 @@ fn validate_suite(suite: &EvalSuite) -> crate::error::Result<()> {
         }
     }
     for case in &suite.agent_cases {
+        validate_date_anchor(&case.date_anchor, &format!("agent case '{}'", case.id))?;
+        if let Some(date_anchor) = effective_date_anchor(&suite.date_anchor, &case.date_anchor) {
+            validate_complete_date_anchor(
+                &date_anchor,
+                &format!("effective date anchor for agent case '{}'", case.id),
+            )?;
+        }
         if case.task.trim().is_empty() {
             return Err(DbtNovaError::InvalidParams(format!(
                 "agent case '{}' must include a non-empty task",
@@ -4154,10 +4433,18 @@ fn validate_selected_cases<'a>(
     )))
 }
 
-fn agent_prompt(case: &AgentCase) -> String {
+fn agent_prompt(case: &AgentCase, date_anchor: Option<&DateAnchor>) -> String {
+    let date_anchor_section = date_anchor.map_or_else(String::new, |anchor| {
+        let mut section = String::from("\nDate anchor:\n");
+        for line in anchor.prompt_lines() {
+            let _ = writeln!(section, "- {line}");
+        }
+        section.push_str("- Treat these dates as ground truth for relative time phrases in the task. Do not reinterpret them using today's date.\n");
+        section
+    });
     format!(
-        "You are running a dbt-nova analytics-agent eval.\n\nTask:\n{}\n\nRules:\n- Use Nova discovery and execution tools directly. Do not inspect repository files, source code, fixtures, or Rust params unless a Nova command fails and you cannot recover from the error message.\n- For KPI, metric, conversion, funnel, checkout, or business-concept questions, start with search_indicator using compact results: detail=\"compact\", group_mode=\"top\", include_support_signals=true, limit=3, persona=\"analyst\".\n- For rate, conversion, or funnel questions, include the requested metric names literally in the query and set indicator_types=[\"metric\"] unless you are explicitly searching for raw measures.\n- When a metric row returns an expression, copy that expression exactly into SQL; do not substitute similarly named measures or invent a numerator/denominator.\n- Use support_signals, grain dimensions, and relation_name from search_indicator to apply every requested filter before SQL. Do not aggregate across a grain dimension named in the task, such as country, market, channel, segment, or device.\n- Treat relation_name, grain, and expression fields returned by search_indicator as the execution contract. Do not run schema inspection SQL such as DESCRIBE or information_schema when those fields are present.\n- Use execute_sql only after Nova discovery identifies the canonical execution entity or relation. Use one aggregate SQL statement for current and comparison periods when possible. Skip get_entity when search_indicator already returns the relation, grain, measures, and metric expressions you need; otherwise use get_entity with id_or_name and detail=\"compact\".\n- Keep Nova calls to the minimum needed: usually search_indicator plus one execute_sql for calculations, and only search_indicator for model or metric lookup tasks. Avoid get_context, get_lineage, get_sql, and full-detail responses unless blocked.\n- If using the CLI, assume $DBT_NOVA_EVAL_BIN is set. For search/get calls, use --params-json. For execute_sql with quotes or newlines, write a JSON params file like {{\"statement\":\"select ...\",\"row_limit\":50}} and call $DBT_NOVA_EVAL_BIN tool call execute_sql --params-file <file> --json; do not inline multiline SQL in --params-json. Parameter reminders: get_entity uses id_or_name; execute_sql uses statement. Do not run echo, grep, read, or source inspection for normal tool usage.\n\nFinish with a concise answer that cites the Nova evidence, the SQL result, and the explicit filter values used.",
-        case.task
+        "You are running a dbt-nova analytics-agent eval.\n\nTask:\n{}\n{}\nRules:\n- Use Nova discovery and execution tools directly. Do not inspect repository files, source code, fixtures, or Rust params unless a Nova command fails and you cannot recover from the error message.\n- For KPI, metric, conversion, funnel, checkout, or business-concept questions, start with search_indicator using compact results: detail=\"compact\", group_mode=\"top\", include_support_signals=true, limit=3, persona=\"analyst\".\n- For rate, conversion, or funnel questions, include the requested metric names literally in the query and set indicator_types=[\"metric\"] unless you are explicitly searching for raw measures.\n- When a metric row returns an expression, copy that expression exactly into SQL; do not substitute similarly named measures or invent a numerator/denominator.\n- Use support_signals, grain dimensions, and relation_name from search_indicator to apply every requested filter before SQL. Do not aggregate across a grain dimension named in the task, such as country, market, channel, segment, or device.\n- Treat relation_name, grain, and expression fields returned by search_indicator as the execution contract. Do not run schema inspection SQL such as DESCRIBE or information_schema when those fields are present.\n- Use execute_sql only after Nova discovery identifies the canonical execution entity or relation. Use one aggregate SQL statement for current and comparison periods when possible. Skip get_entity when search_indicator already returns the relation, grain, measures, and metric expressions you need; otherwise use get_entity with id_or_name and detail=\"compact\".\n- Keep Nova calls to the minimum needed: usually search_indicator plus one execute_sql for calculations, and only search_indicator for model or metric lookup tasks. Avoid get_context, get_lineage, get_sql, and full-detail responses unless blocked.\n- If using the CLI, assume $DBT_NOVA_EVAL_BIN is set. For search/get calls, use --params-json. For execute_sql with quotes or newlines, write a JSON params file like {{\"statement\":\"select ...\",\"row_limit\":50}} and call $DBT_NOVA_EVAL_BIN tool call execute_sql --params-file <file> --json; do not inline multiline SQL in --params-json. Parameter reminders: get_entity uses id_or_name; execute_sql uses statement. Do not run echo, grep, read, or source inspection for normal tool usage.\n\nFinish with a concise answer that cites the Nova evidence, the SQL result, and the explicit filter values used.",
+        case.task, date_anchor_section
     )
 }
 

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -5,19 +5,20 @@ use serde_json::json;
 use tempfile::{NamedTempFile, TempDir};
 
 use super::{
-    AgentCalledWith, AgentEntityRank, AgentExpected, AgentOrder, AssertionResult, EvalCardProvider,
-    EvalCardRunContext, EvalCaseReport, EvalDefaults, EvalRunArgs, EvalSuite, EvalValidateArgs,
-    FinalAnswerExpected, apply_telemetry_retention, build_agent_eval_tool_response,
-    build_eval_gate_report, build_eval_gate_tool_response, build_eval_history_tool_response,
-    build_eval_init_tool_response, build_eval_validate_tool_response, build_report,
-    contains_rank_assertion, context_contains_assertion, context_field_equals_assertion,
-    eval_case_telemetry_from_trace, format_utc_timestamp_millis, json_has_field_path,
-    metadata_score_max_assertion, metadata_score_min_assertion, read_tool_trace,
-    recipe_rank_assertion, refresh_eval_card, render_eval_card_markdown, resolve_mcp_writable_path,
-    run_eval_command, run_validate_command, safe_path_segment, score_agent_expectations,
-    selected_agent_cases, selected_bridge_cases, suite_file_hash, telemetry_path_for_suite,
-    telemetry_row_matches_since, tool_response_budget_assertion, tool_success_assertion,
-    validate_since_date, validate_suite, validate_telemetry_suite_name,
+    AgentCalledWith, AgentEntityRank, AgentExpected, AgentOrder, AssertionResult, DateAnchor,
+    EvalCardProvider, EvalCardRunContext, EvalCaseReport, EvalDefaults, EvalRunArgs, EvalSuite,
+    EvalValidateArgs, FinalAnswerExpected, agent_prompt, apply_telemetry_retention,
+    build_agent_eval_tool_response, build_eval_gate_report, build_eval_gate_tool_response,
+    build_eval_history_tool_response, build_eval_init_tool_response, build_eval_validate_payload,
+    build_eval_validate_tool_response, build_report, contains_rank_assertion,
+    context_contains_assertion, context_field_equals_assertion, eval_case_telemetry_from_trace,
+    format_utc_timestamp_millis, json_has_field_path, metadata_score_max_assertion,
+    metadata_score_min_assertion, read_tool_trace, recipe_rank_assertion, refresh_eval_card,
+    render_eval_card_markdown, resolve_mcp_writable_path, run_eval_command, run_validate_command,
+    safe_path_segment, score_agent_expectations, selected_agent_cases, selected_bridge_cases,
+    suite_file_hash, telemetry_path_for_suite, telemetry_row_matches_since,
+    tool_response_budget_assertion, tool_success_assertion, validate_since_date, validate_suite,
+    validate_telemetry_suite_name,
 };
 use crate::params::{
     GetEvalGateParams, GetEvalHistoryParams, InitEvalSuiteParams, RunAgentEvalParams,
@@ -661,6 +662,7 @@ fn telemetry_requires_named_suite() {
         manifest_scope: None,
         known_gaps: Vec::new(),
         gate: None,
+        date_anchor: DateAnchor::default(),
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
         agent_cases: Vec::new(),
@@ -1024,12 +1026,154 @@ fn validate_suite_rejects_invalid_gate_threshold() {
         manifest_scope: None,
         known_gaps: Vec::new(),
         gate: Some(super::EvalGateConfig { threshold: 1.1 }),
+        date_anchor: DateAnchor::default(),
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
         agent_cases: Vec::new(),
     };
     let error = validate_suite(&suite).expect_err("invalid gate threshold should fail");
     assert!(error.to_string().contains("gate.threshold"));
+}
+
+#[test]
+fn eval_validate_accepts_snapshot_date_anchor_fields() {
+    let suite = NamedTempFile::new().expect("suite file");
+    std::fs::write(
+        suite.path(),
+        r#"
+version: 1
+name: date-anchor-smoke
+snapshot_date: "2026-03-31"
+date_field: order_date
+cases:
+  - id: anchored-bridge
+    date_range_start: "2026-03-01"
+    date_range_end: "2026-03-31"
+    assertions:
+      - type: tool_success
+        tool: search
+        params: {}
+agent_cases:
+  - id: anchored-agent
+    task: Compare revenue last month.
+    expected: {}
+"#,
+    )
+    .expect("write suite");
+
+    let payload =
+        build_eval_validate_payload(&suite.path().display().to_string()).expect("valid suite");
+    assert_eq!(payload["date_anchor"]["snapshot_date"], json!("2026-03-31"));
+    assert_eq!(payload["date_anchor"]["date_field"], json!("order_date"));
+    assert_eq!(payload["date_anchor_case_count"], json!(2));
+}
+
+#[test]
+fn eval_validate_accepts_inherited_date_anchor_fields() {
+    let suite = NamedTempFile::new().expect("suite file");
+    std::fs::write(
+        suite.path(),
+        r#"
+version: 1
+name: inherited-date-anchor-smoke
+date_range_start: "2026-03-01"
+date_range_end: "2026-03-31"
+date_field: order_date
+cases:
+  - id: inherited-range-end
+    date_range_start: "2026-03-15"
+    assertions:
+      - type: tool_success
+        tool: search
+        params: {}
+agent_cases:
+  - id: inherited-field
+    task: Compare revenue last month.
+    snapshot_date: "2026-03-31"
+    expected: {}
+"#,
+    )
+    .expect("write suite");
+
+    let payload =
+        build_eval_validate_payload(&suite.path().display().to_string()).expect("valid suite");
+    assert_eq!(payload["date_anchor_case_count"], json!(2));
+}
+
+#[test]
+fn eval_validate_rejects_invalid_snapshot_date_anchor() {
+    let suite = NamedTempFile::new().expect("suite file");
+    std::fs::write(
+        suite.path(),
+        r#"
+version: 1
+name: bad-date-anchor
+snapshot_date: "2026-02-30"
+cases: []
+agent_cases: []
+"#,
+    )
+    .expect("write suite");
+
+    let error = build_eval_validate_payload(&suite.path().display().to_string())
+        .expect_err("invalid date should fail");
+    let error = error.to_string();
+    assert!(error.contains("snapshot_date"));
+    assert!(error.contains("YYYY-MM-DD"));
+}
+
+#[test]
+fn eval_validate_rejects_incomplete_date_range_anchor() {
+    let suite = EvalSuite {
+        version: 1,
+        name: None,
+        purpose: None,
+        manifest_scope: None,
+        known_gaps: Vec::new(),
+        gate: None,
+        date_anchor: DateAnchor::default(),
+        defaults: EvalDefaults::default(),
+        cases: vec![super::EvalCase {
+            id: "range".to_string(),
+            question: None,
+            persona: None,
+            date_anchor: DateAnchor {
+                date_range_start: Some("2026-03-01".to_string()),
+                ..DateAnchor::default()
+            },
+            assertions: vec![super::EvalAssertion::ToolSuccess {
+                tool: "search".to_string(),
+                params: json!({}),
+            }],
+        }],
+        agent_cases: Vec::new(),
+    };
+
+    let error = validate_suite(&suite).expect_err("incomplete date range should fail");
+    assert!(error.to_string().contains("date_range_end"));
+}
+
+#[test]
+fn agent_prompt_includes_date_anchor_section() {
+    let case = super::AgentCase {
+        id: "agent".to_string(),
+        task: "Compare gross revenue last month.".to_string(),
+        date_anchor: DateAnchor::default(),
+        expected: AgentExpected::default(),
+    };
+    let anchor = DateAnchor {
+        snapshot_date: Some("2026-03-31".to_string()),
+        date_range_start: Some("2026-03-01".to_string()),
+        date_range_end: Some("2026-03-31".to_string()),
+        date_field: Some("order_date".to_string()),
+    };
+
+    let prompt = agent_prompt(&case, Some(&anchor));
+    assert!(prompt.contains("Date anchor:"));
+    assert!(prompt.contains("snapshot_date: 2026-03-31"));
+    assert!(prompt.contains("date_range: 2026-03-01 to 2026-03-31"));
+    assert!(prompt.contains("date_field: order_date"));
+    assert!(prompt.contains("Do not reinterpret them using today's date"));
 }
 
 #[test]
@@ -1041,17 +1185,20 @@ fn validate_suite_rejects_duplicate_agent_case_ids() {
         manifest_scope: None,
         known_gaps: Vec::new(),
         gate: None,
+        date_anchor: DateAnchor::default(),
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
         agent_cases: vec![
             super::AgentCase {
                 id: "same".to_string(),
                 task: "one".to_string(),
+                date_anchor: DateAnchor::default(),
                 expected: AgentExpected::default(),
             },
             super::AgentCase {
                 id: "same".to_string(),
                 task: "two".to_string(),
+                date_anchor: DateAnchor::default(),
                 expected: AgentExpected::default(),
             },
         ],
@@ -1069,17 +1216,20 @@ fn validate_suite_rejects_duplicate_artifact_segments() {
         manifest_scope: None,
         known_gaps: Vec::new(),
         gate: None,
+        date_anchor: DateAnchor::default(),
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
         agent_cases: vec![
             super::AgentCase {
                 id: "a/b".to_string(),
                 task: "one".to_string(),
+                date_anchor: DateAnchor::default(),
                 expected: AgentExpected::default(),
             },
             super::AgentCase {
                 id: "a b".to_string(),
                 task: "two".to_string(),
+                date_anchor: DateAnchor::default(),
                 expected: AgentExpected::default(),
             },
         ],
@@ -1097,17 +1247,20 @@ fn validate_suite_rejects_case_insensitive_artifact_segment_collisions() {
         manifest_scope: None,
         known_gaps: Vec::new(),
         gate: None,
+        date_anchor: DateAnchor::default(),
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
         agent_cases: vec![
             super::AgentCase {
                 id: "RevenueFlow".to_string(),
                 task: "one".to_string(),
+                date_anchor: DateAnchor::default(),
                 expected: AgentExpected::default(),
             },
             super::AgentCase {
                 id: "revenueflow".to_string(),
                 task: "two".to_string(),
+                date_anchor: DateAnchor::default(),
                 expected: AgentExpected::default(),
             },
         ],
@@ -1125,11 +1278,13 @@ fn validate_suite_rejects_vacuous_search_columns_rank_assertion() {
         manifest_scope: None,
         known_gaps: Vec::new(),
         gate: None,
+        date_anchor: DateAnchor::default(),
         defaults: EvalDefaults::default(),
         cases: vec![super::EvalCase {
             id: "columns".to_string(),
             question: None,
             persona: None,
+            date_anchor: DateAnchor::default(),
             assertions: vec![super::EvalAssertion::SearchColumnsRank {
                 query: "revenue".to_string(),
                 expected_column: None,
@@ -1152,11 +1307,13 @@ fn validate_suite_rejects_unmatchable_called_with_param_values() {
         manifest_scope: None,
         known_gaps: Vec::new(),
         gate: None,
+        date_anchor: DateAnchor::default(),
         defaults: EvalDefaults::default(),
         cases: Vec::new(),
         agent_cases: vec![super::AgentCase {
             id: "agent".to_string(),
             task: "use nova".to_string(),
+            date_anchor: DateAnchor::default(),
             expected: AgentExpected {
                 called_with: vec![AgentCalledWith {
                     tool: "search".to_string(),
@@ -1177,6 +1334,7 @@ fn selected_case_filters_reject_missing_ids() {
         id: "one".to_string(),
         question: None,
         persona: None,
+        date_anchor: DateAnchor::default(),
         assertions: vec![super::EvalAssertion::ToolSuccess {
             tool: "search".to_string(),
             params: json!({}),
@@ -1193,11 +1351,13 @@ fn selected_agent_case_filters_return_requested_cases() {
         super::AgentCase {
             id: "one".to_string(),
             task: "task one".to_string(),
+            date_anchor: DateAnchor::default(),
             expected: AgentExpected::default(),
         },
         super::AgentCase {
             id: "two".to_string(),
             task: "task two".to_string(),
+            date_anchor: DateAnchor::default(),
             expected: AgentExpected::default(),
         },
     ];
@@ -1462,17 +1622,21 @@ async fn bridge_eval_writes_result_artifacts() {
     let suite_path = temp_dir.path().join("suite.yml");
     std::fs::write(
         &suite_path,
-        r"
+        r#"
 version: 1
-name: bridge-smoke
+name: bridge-date-anchor-smoke
+snapshot_date: "2026-03-31"
+date_field: order_date
 cases:
   - id: orders-search
+    date_range_start: "2026-03-01"
+    date_range_end: "2026-03-31"
     assertions:
       - type: search_rank
         query: orders
         expected_unique_id: model.nova_test.fct__orders
         max_rank: 5
-",
+"#,
     )
     .expect("write suite");
     let output_dir = temp_dir.path().join("out");
@@ -1485,6 +1649,7 @@ cases:
         ),
         output_dir: Some(output_dir.display().to_string()),
         fail_under: Some(1.0),
+        telemetry: true,
         json: true,
         ..EvalRunArgs::default()
     })
@@ -1508,6 +1673,39 @@ cases:
         json!("eval_card.v1")
     );
     assert_eq!(results["eval_card"]["mode"], json!("bridge"));
+    assert_eq!(
+        results["eval_card"]["date_anchor"]["snapshot_date"],
+        json!("2026-03-31")
+    );
+    assert_eq!(
+        results["cases"][0]["date_anchor"]["snapshot_date"],
+        json!("2026-03-31")
+    );
+    assert_eq!(
+        results["cases"][0]["date_anchor"]["date_range_start"],
+        json!("2026-03-01")
+    );
+    assert_eq!(
+        results["cases"][0]["date_anchor"]["date_range_end"],
+        json!("2026-03-31")
+    );
+    assert_eq!(
+        results["cases"][0]["date_anchor"]["date_field"],
+        json!("order_date")
+    );
+    let report_md = std::fs::read_to_string(output_dir.join("report.md")).expect("report md");
+    assert!(report_md.contains("Suite date anchor"));
+    assert!(report_md.contains("date_range: `2026-03-01` to `2026-03-31`"));
+
+    let telemetry_path = telemetry_path_for_suite("bridge-date-anchor-smoke");
+    let telemetry = std::fs::read_to_string(&telemetry_path).expect("telemetry jsonl");
+    let latest = telemetry.lines().last().expect("telemetry line");
+    let latest: serde_json::Value = serde_json::from_str(latest).expect("telemetry json");
+    assert_eq!(latest["snapshot_date"], json!("2026-03-31"));
+    assert_eq!(latest["date_range_start"], json!("2026-03-01"));
+    assert_eq!(latest["date_range_end"], json!("2026-03-31"));
+    assert_eq!(latest["date_field"], json!("order_date"));
+    std::fs::remove_file(telemetry_path).expect("remove telemetry");
 }
 
 #[test]
@@ -1533,6 +1731,7 @@ fn eval_card_suite(name: &str, threshold: Option<f64>, include_agent_case: bool)
         manifest_scope: Some("synthetic starter manifest".to_string()),
         known_gaps: vec!["does not cover live warehouse freshness".to_string()],
         gate: threshold.map(|threshold| super::EvalGateConfig { threshold }),
+        date_anchor: DateAnchor::default(),
         defaults: EvalDefaults {
             persona: Some("analyst".to_string()),
             top_k: 5,
@@ -1544,6 +1743,7 @@ fn eval_card_suite(name: &str, threshold: Option<f64>, include_agent_case: bool)
                 id: "bridge_case".to_string(),
                 question: Some("Find canonical orders".to_string()),
                 persona: None,
+                date_anchor: DateAnchor::default(),
                 assertions: vec![super::EvalAssertion::ToolSuccess {
                     tool: "search".to_string(),
                     params: json!({}),
@@ -1554,6 +1754,7 @@ fn eval_card_suite(name: &str, threshold: Option<f64>, include_agent_case: bool)
             vec![super::AgentCase {
                 id: "agent_case".to_string(),
                 task: "Use Nova to answer the task".to_string(),
+                date_anchor: DateAnchor::default(),
                 expected: AgentExpected::default(),
             }]
         } else {


### PR DESCRIPTION
## Summary
- add suite/case date anchor metadata for eval suites (`snapshot_date`, `date_range_start`, `date_range_end`, `date_field`)
- validate raw dates and effective inherited anchors, then surface anchors in validate payloads, reports, eval cards, and telemetry
- inject effective date anchors into agent eval prompts and document how anchoring differs from query-structure grading

Linear: JOE-17

## Validation
- `cargo test --locked eval_cmd`
- `cargo fmt --check`
- `git diff --check`
- `uv run --with-requirements docs/requirements.txt mkdocs build --strict`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`