### PR TITLE
Add SQL structure eval grading (JOE-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `date_range_end`, and `date_field` anchors at suite or case level; Nova
   validates anchor dates, injects effective anchors into agent prompts, and
   includes them in reports and eval telemetry.
+- Eval suites can now grade SQL structure with `sql_structure` assertions and
+  agent `expected.sql_structures`, comparing tables, joins, projections,
+  filters, and groupings while masking string/date/numeric literals and
+  reporting structured clause diffs.
 - Documented bridge and provider-backed eval CI templates with GitHub Actions
   examples for manifest generation, telemetry retention, eval gates, artifact
   upload, private OpenCode provider runs, and redacted trace handling.

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -194,6 +194,7 @@ Bridge assertions currently support:
 - `lineage_contains`
 - `tool_success`
 - `tool_response_budget`
+- `sql_structure`
 
 `context_has` checks that field paths are present and non-null.
 `context_field_equals` compares a field path to an exact JSON value.
@@ -235,6 +236,62 @@ assertions:
       - parent_groups.1
       - data.0.explain
 ```
+
+## Query Structure Grading
+
+Use query structure grading when the important question is whether SQL used the
+right logic, not whether a live warehouse returned a stable value. This is
+especially useful for date-bounded evals where source rows can change over time.
+Use value assertions or normal tool assertions when the expected output is
+deterministic and should match exactly.
+
+Bridge suites can compare two SQL strings directly with `sql_structure`:
+
+```yaml
+assertions:
+  - type: sql_structure
+    actual_sql: |
+      select country, sum(amount) as revenue
+      from analytics.orders
+      where order_date between '2026-03-01' and '2026-03-31'
+        and country = 'US'
+      group by country
+    expected_sql: |
+      select country, sum(amount) as revenue
+      from analytics.orders
+      where order_date between '2024-01-01' and '2024-01-31'
+        and country = 'GB'
+      group by country
+```
+
+Agent suites can grade generated SQL from an observed `execute_sql` call:
+
+```yaml
+agent_cases:
+  - id: revenue_sql_shape
+    task: Query March revenue by country.
+    expected:
+      must_call:
+        - execute_sql
+      sql_structures:
+        - expected_sql: |
+            select country, sum(amount) as revenue
+            from analytics.orders
+            where order_date between '2024-01-01' and '2024-01-31'
+              and country = 'GB'
+            group by country
+```
+
+The grader parses SQL and compares referenced tables, joins, selected
+columns/expressions, filters, and groupings. String, date, and numeric literals
+are masked before comparison, so equivalent queries with different dates or
+threshold values can still pass. It does not prove full semantic SQL
+equivalence, optimizer equivalence, or fact-table correctness.
+
+When a comparison fails, the assertion message names the changed clause such as
+`FROM`, `JOIN`, `WHERE`, `SELECT`, or `GROUP BY`. `results.json` includes a
+structured `diff` with missing and unexpected clause entries, and `report.md`
+prints the same diff in compact form.
 
 ## MCP Tool Parity
 
@@ -315,6 +372,9 @@ sanitized parameter values exactly where possible, while `called_with.contains`
 checks case-insensitive substring matches against sanitized parameter summaries.
 `called_with.params` supports only scalar values or arrays of scalar values
 because trace rows intentionally drop nested objects.
+`sql_structures` compares generated SQL from sanitized `execute_sql` trace
+summaries. The trace stores a parsed `statement_structure` with literals masked;
+it does not store the raw SQL statement.
 Budget expectations score the sanitized trace:
 
 - `max_tool_calls` caps total observed Nova calls.
@@ -406,7 +466,10 @@ count, distinct tool count, response bytes, and token counts when a provider
 trace exposes them. When a suite or case declares date anchors, each assertion
 row also includes the effective `snapshot_date`, `date_range_start`,
 `date_range_end`, `date_field`, and nested `date_anchor` object. Telemetry does
-not store raw SQL parameter maps, provider stdout/stderr, or credentials.
+not store raw SQL parameter maps, provider stdout/stderr, or credentials. Query
+structure assertions write `grade_mode=query_structure`; ordinary bridge rows
+write `grade_mode=deterministic`, and ordinary agent rows write
+`grade_mode=provider_trace`.
 
 Use `eval history` for a thin date filter over the JSONL file:
 
@@ -463,6 +526,8 @@ rows for CLI, MCP, and eval tool calls. Rows include:
 - `duration_ms`
 - safe parameter summaries such as `query`, `persona`, `id_or_name`, and
   `resource_types`
+- masked `statement_structure` summaries for `execute_sql` statements when SQL
+  can be parsed
 - `response_bytes`
 - `response_truncated`
 - `result_count`

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -25,6 +25,10 @@ use crate::params::{
     RunEvalParams, ValidateEvalSuiteParams,
 };
 use crate::responses::SuccessResponse;
+use crate::utils::sql_structure::{
+    SqlStructureSignature, compare_sql_structure, compare_sql_structure_signatures,
+    sql_structure_signature,
+};
 use crate::utils::tool_trace::{normalize_tool_trace_indices, read_tool_trace_file};
 
 const DEFAULT_TOP_K: usize = 5;
@@ -247,6 +251,10 @@ enum EvalAssertion {
         #[serde(default)]
         must_not_contain_paths: Vec<String>,
     },
+    SqlStructure {
+        actual_sql: String,
+        expected_sql: String,
+    },
 }
 
 #[derive(Debug, Deserialize)]
@@ -273,6 +281,8 @@ struct AgentExpected {
     selected_entity_ranks: Vec<AgentEntityRank>,
     #[serde(default)]
     called_with: Vec<AgentCalledWith>,
+    #[serde(default)]
+    sql_structures: Vec<AgentSqlStructureExpected>,
     #[serde(default)]
     final_answer: Option<FinalAnswerExpected>,
     #[serde(default)]
@@ -308,6 +318,13 @@ struct AgentCalledWith {
     params: BTreeMap<String, JsonValue>,
     #[serde(default)]
     contains: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AgentSqlStructureExpected {
+    #[serde(default = "default_sql_structure_tool")]
+    tool: String,
+    expected_sql: String,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1231,6 +1248,10 @@ async fn evaluate_bridge_assertion(
                 AssertionResult::error(format!("tool_response_budget:{tool}"), error.to_string())
             }
         },
+        EvalAssertion::SqlStructure {
+            actual_sql,
+            expected_sql,
+        } => sql_structure_assertion("sql_structure", actual_sql, expected_sql),
     }
 }
 
@@ -1455,6 +1476,9 @@ fn score_agent_expectations(
     for called_with in &expected.called_with {
         assertions.push(called_with_assertion(trace, called_with));
     }
+    for sql_structure in &expected.sql_structures {
+        assertions.push(agent_sql_structure_assertion(trace, sql_structure));
+    }
     if let Some(max_tool_calls) = expected.max_tool_calls {
         assertions.push(max_tool_calls_assertion(trace, max_tool_calls));
     }
@@ -1476,6 +1500,122 @@ fn score_agent_expectations(
         assertions.extend(score_final_answer(final_answer, final_answer_text));
     }
     assertions
+}
+
+fn sql_structure_assertion(
+    name: impl Into<String>,
+    actual_sql: &str,
+    expected_sql: &str,
+) -> AssertionResult {
+    let name = name.into();
+    match compare_sql_structure(actual_sql, expected_sql) {
+        Ok(comparison) => sql_structure_comparison_assertion(name, &comparison),
+        Err(error) => AssertionResult::error(name, error),
+    }
+}
+
+fn sql_structure_comparison_assertion(
+    name: impl Into<String>,
+    comparison: &crate::utils::sql_structure::SqlStructureComparison,
+) -> AssertionResult {
+    let clauses = comparison.diff.changed_clauses();
+    if comparison.matches {
+        AssertionResult::pass(
+            name,
+            "SQL structure matched expected SELECT, FROM/JOIN, WHERE, and GROUP BY clauses",
+            sql_structure_evidence(comparison),
+        )
+    } else {
+        let clause_text = if clauses.is_empty() {
+            "unknown".to_string()
+        } else {
+            clauses.join(", ")
+        };
+        AssertionResult::fail(
+            name,
+            format!("SQL structure differed in clauses: {clause_text}"),
+            sql_structure_evidence(comparison),
+        )
+    }
+}
+
+fn sql_structure_evidence(
+    comparison: &crate::utils::sql_structure::SqlStructureComparison,
+) -> JsonValue {
+    json!({
+        "grade_mode": "query_structure",
+        "changed_clauses": comparison.diff.changed_clauses(),
+        "expected": &comparison.expected,
+        "actual": &comparison.actual,
+        "diff": &comparison.diff,
+    })
+}
+
+fn agent_sql_structure_assertion(
+    trace: &[JsonValue],
+    expected: &AgentSqlStructureExpected,
+) -> AssertionResult {
+    let name = format!("sql_structure:{}", expected.tool);
+    let expected_signature = match sql_structure_signature(&expected.expected_sql) {
+        Ok(signature) => signature,
+        Err(error) => return AssertionResult::error(name, error),
+    };
+    let matching_rows = trace
+        .iter()
+        .filter(|row| row.get("tool").and_then(JsonValue::as_str) == Some(expected.tool.as_str()))
+        .collect::<Vec<_>>();
+    let mut first_comparison = None;
+    let mut observed_errors = Vec::new();
+    let mut observed_structure_count = 0usize;
+
+    for row in &matching_rows {
+        let Some(summary) = row.get("params_summary") else {
+            continue;
+        };
+        if let Some(error) = summary
+            .get("statement_structure_error")
+            .and_then(JsonValue::as_str)
+        {
+            observed_errors.push(error.to_string());
+        }
+        let Some(structure) = summary.get("statement_structure") else {
+            continue;
+        };
+        observed_structure_count += 1;
+        let actual_signature =
+            match serde_json::from_value::<SqlStructureSignature>(structure.clone()) {
+                Ok(signature) => signature,
+                Err(error) => {
+                    observed_errors.push(format!("invalid statement_structure summary: {error}"));
+                    continue;
+                }
+            };
+        let comparison =
+            compare_sql_structure_signatures(actual_signature, expected_signature.clone());
+        if comparison.matches {
+            return sql_structure_comparison_assertion(name, &comparison);
+        }
+        if first_comparison.is_none() {
+            first_comparison = Some(comparison);
+        }
+    }
+
+    if let Some(comparison) = first_comparison {
+        return sql_structure_comparison_assertion(name, &comparison);
+    }
+
+    AssertionResult::fail(
+        name,
+        "no observed tool call included a matching SQL structure summary",
+        json!({
+            "grade_mode": "query_structure",
+            "tool": expected.tool,
+            "matching_tool_calls": matching_rows.len(),
+            "statement_structure_count": observed_structure_count,
+            "statement_structure_errors": observed_errors,
+            "observed": observed_params_for_tool(trace, &expected.tool),
+        }),
+    )
 }
 
 fn max_tool_calls_assertion(trace: &[JsonValue], max_tool_calls: usize) -> AssertionResult {
@@ -3112,7 +3252,7 @@ fn write_eval_telemetry(
             row.insert("status".to_string(), json!(assertion.status));
             row.insert(
                 "grade_mode".to_string(),
-                json!(telemetry_grade_mode(report.mode)),
+                json!(telemetry_grade_mode(report.mode, &assertion.name)),
             );
             row.insert("duration_ms".to_string(), json!(context.duration_ms));
             row.insert("output_dir".to_string(), json!(&report.output_dir));
@@ -3278,7 +3418,10 @@ fn validate_telemetry_suite_name(
     Ok(())
 }
 
-fn telemetry_grade_mode(mode: &str) -> &'static str {
+fn telemetry_grade_mode(mode: &str, assertion_name: &str) -> &'static str {
+    if assertion_type(assertion_name) == "sql_structure" {
+        return "query_structure";
+    }
     match mode {
         "agent" => "provider_trace",
         _ => "deterministic",
@@ -3461,10 +3604,60 @@ fn render_markdown(report: &EvalReport) -> String {
                 "- `{}` `{}`: {}",
                 assertion.status, assertion.name, assertion.message
             );
+            if assertion_type(&assertion.name) == "sql_structure" {
+                for line in sql_structure_markdown_evidence(&assertion.evidence) {
+                    let _ = writeln!(out, "  - {line}");
+                }
+            }
         }
         out.push('\n');
     }
     out
+}
+
+fn sql_structure_markdown_evidence(evidence: &JsonValue) -> Vec<String> {
+    let mut lines = Vec::new();
+    if let Some(changed) = evidence
+        .get("changed_clauses")
+        .and_then(JsonValue::as_array)
+        .map(|values| json_string_values(values))
+        .filter(|values| !values.is_empty())
+    {
+        lines.push(format!("Changed clauses: {}", changed.join(", ")));
+    }
+    let Some(diff) = evidence.get("diff") else {
+        return lines;
+    };
+    for (label, key) in [
+        ("Missing SELECT", "missing_select"),
+        ("Unexpected SELECT", "unexpected_select"),
+        ("Missing FROM", "missing_tables"),
+        ("Unexpected FROM", "unexpected_tables"),
+        ("Missing JOIN", "missing_joins"),
+        ("Unexpected JOIN", "unexpected_joins"),
+        ("Missing WHERE", "missing_filters"),
+        ("Unexpected WHERE", "unexpected_filters"),
+        ("Missing GROUP BY", "missing_group_by"),
+        ("Unexpected GROUP BY", "unexpected_group_by"),
+    ] {
+        if let Some(values) = diff
+            .get(key)
+            .and_then(JsonValue::as_array)
+            .map(|values| json_string_values(values))
+            .filter(|values| !values.is_empty())
+        {
+            lines.push(format!("{label}: {}", values.join("; ")));
+        }
+    }
+    lines
+}
+
+fn json_string_values(values: &[JsonValue]) -> Vec<String> {
+    values
+        .iter()
+        .filter_map(JsonValue::as_str)
+        .map(ToString::to_string)
+        .collect()
 }
 
 fn render_eval_card_markdown(card: &EvalCard) -> String {
@@ -3669,6 +3862,7 @@ impl AgentExpected {
             || !self.selected_entities.is_empty()
             || !self.selected_entity_ranks.is_empty()
             || !self.called_with.is_empty()
+            || !self.sql_structures.is_empty()
             || self.max_tool_calls.is_some()
             || self.max_distinct_tools.is_some()
             || self.max_total_response_bytes.is_some()
@@ -4210,9 +4404,29 @@ fn validate_assertion(assertion: &EvalAssertion, case_id: &str) -> crate::error:
                 )));
             }
         }
+        EvalAssertion::SqlStructure {
+            actual_sql,
+            expected_sql,
+        } => {
+            validate_sql_structure_field(actual_sql, case_id, "actual_sql")?;
+            validate_sql_structure_field(expected_sql, case_id, "expected_sql")?;
+        }
         _ => {}
     }
     Ok(())
+}
+
+fn validate_sql_structure_field(sql: &str, case_id: &str, field: &str) -> crate::error::Result<()> {
+    if sql.trim().is_empty() {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "sql_structure assertion in case '{case_id}' must include non-empty {field}"
+        )));
+    }
+    sql_structure_signature(sql).map(|_| ()).map_err(|error| {
+        DbtNovaError::InvalidParams(format!(
+            "sql_structure assertion in case '{case_id}' has invalid {field}: {error}"
+        ))
+    })
 }
 
 fn validate_agent_expected(expected: &AgentExpected, case_id: &str) -> crate::error::Result<()> {
@@ -4271,6 +4485,23 @@ fn validate_agent_expected(expected: &AgentExpected, case_id: &str) -> crate::er
                 "called_with params expectations in agent case '{case_id}' must use scalar values or arrays of scalar values"
             )));
         }
+    }
+    for sql_structure in &expected.sql_structures {
+        if sql_structure.tool.trim().is_empty() {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "sql_structures expectations in agent case '{case_id}' must include non-empty tool values"
+            )));
+        }
+        if sql_structure.expected_sql.trim().is_empty() {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "sql_structures expectations in agent case '{case_id}' must include non-empty expected_sql"
+            )));
+        }
+        sql_structure_signature(&sql_structure.expected_sql).map_err(|error| {
+            DbtNovaError::InvalidParams(format!(
+                "sql_structures expectation in agent case '{case_id}' has invalid expected_sql: {error}"
+            ))
+        })?;
     }
     if expected.max_tool_calls == Some(0)
         || expected.max_distinct_tools == Some(0)
@@ -4488,6 +4719,10 @@ agent_cases:
 
 fn empty_object() -> JsonValue {
     json!({})
+}
+
+fn default_sql_structure_tool() -> String {
+    "execute_sql".to_string()
 }
 
 fn default_top_k() -> usize {

--- a/src/cli/eval_cmd/provider.rs
+++ b/src/cli/eval_cmd/provider.rs
@@ -761,7 +761,31 @@ fn provider_params_summary(params: Option<&JsonValue>) -> JsonValue {
             summary.insert(key.to_string(), value);
         }
     }
+    insert_provider_statement_structure(
+        &mut summary,
+        map.get("statement").and_then(JsonValue::as_str),
+    );
     JsonValue::Object(summary)
+}
+
+fn insert_provider_statement_structure(
+    summary: &mut serde_json::Map<String, JsonValue>,
+    statement: Option<&str>,
+) {
+    let Some(statement) = statement.map(str::trim).filter(|value| !value.is_empty()) else {
+        return;
+    };
+    match crate::utils::sql_structure::sql_structure_summary_json(statement) {
+        Ok(structure) => {
+            summary.insert("statement_structure".to_string(), structure);
+        }
+        Err(_error) => {
+            summary.insert(
+                "statement_structure_error".to_string(),
+                JsonValue::String("failed to parse SQL structure summary".to_string()),
+            );
+        }
+    }
 }
 
 fn provider_safe_value(value: &JsonValue) -> Option<JsonValue> {
@@ -1087,6 +1111,26 @@ mod tests {
                     .len()
             )
         );
+    }
+
+    #[test]
+    fn provider_trace_records_statement_structure_without_raw_sql() {
+        let stdout = r#"{"type":"item.completed","item":{"type":"mcp_tool_call","server":"nova","tool":"execute_sql","arguments":{"statement":"select country from analytics.orders where order_date = '2026-03-01'","row_limit":10},"result":{"data":[]},"error":null,"status":"completed"}}"#;
+        let trace = read_provider_tool_trace(stdout);
+        assert_eq!(trace.errors, Vec::<String>::new());
+        assert_eq!(trace.rows.len(), 1);
+        assert_eq!(trace.rows[0]["tool"], "execute_sql");
+        assert_eq!(trace.rows[0]["params_summary"]["row_limit"], 10);
+        assert_eq!(
+            trace.rows[0]["params_summary"]["statement_structure"]["tables"],
+            json!(["analytics.orders"])
+        );
+        assert_eq!(
+            trace.rows[0]["params_summary"]["statement_structure"]["filters"],
+            json!(["order_date = ?"])
+        );
+        assert!(trace.rows[0]["params_summary"].get("statement").is_none());
+        assert!(!trace.rows[0].to_string().contains("2026-03-01"));
     }
 
     #[test]

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -5,18 +5,19 @@ use serde_json::json;
 use tempfile::{NamedTempFile, TempDir};
 
 use super::{
-    AgentCalledWith, AgentEntityRank, AgentExpected, AgentOrder, AssertionResult, DateAnchor,
-    EvalCardProvider, EvalCardRunContext, EvalCaseReport, EvalDefaults, EvalRunArgs, EvalSuite,
-    EvalValidateArgs, FinalAnswerExpected, agent_prompt, apply_telemetry_retention,
-    build_agent_eval_tool_response, build_eval_gate_report, build_eval_gate_tool_response,
-    build_eval_history_tool_response, build_eval_init_tool_response, build_eval_validate_payload,
-    build_eval_validate_tool_response, build_report, contains_rank_assertion,
-    context_contains_assertion, context_field_equals_assertion, eval_case_telemetry_from_trace,
-    format_utc_timestamp_millis, json_has_field_path, metadata_score_max_assertion,
-    metadata_score_min_assertion, read_tool_trace, recipe_rank_assertion, refresh_eval_card,
-    render_eval_card_markdown, resolve_mcp_writable_path, run_eval_command, run_validate_command,
-    safe_path_segment, score_agent_expectations, selected_agent_cases, selected_bridge_cases,
-    suite_file_hash, telemetry_path_for_suite, telemetry_row_matches_since,
+    AgentCalledWith, AgentEntityRank, AgentExpected, AgentOrder, AgentSqlStructureExpected,
+    AssertionResult, DateAnchor, EvalCardProvider, EvalCardRunContext, EvalCaseReport,
+    EvalDefaults, EvalRunArgs, EvalSuite, EvalValidateArgs, FinalAnswerExpected, agent_prompt,
+    apply_telemetry_retention, build_agent_eval_tool_response, build_eval_gate_report,
+    build_eval_gate_tool_response, build_eval_history_tool_response, build_eval_init_tool_response,
+    build_eval_validate_payload, build_eval_validate_tool_response, build_report,
+    contains_rank_assertion, context_contains_assertion, context_field_equals_assertion,
+    eval_case_telemetry_from_trace, format_utc_timestamp_millis, json_has_field_path,
+    metadata_score_max_assertion, metadata_score_min_assertion, read_tool_trace,
+    recipe_rank_assertion, refresh_eval_card, render_eval_card_markdown, resolve_mcp_writable_path,
+    run_eval_command, run_validate_command, safe_path_segment, score_agent_expectations,
+    selected_agent_cases, selected_bridge_cases, sql_structure_assertion, suite_file_hash,
+    telemetry_grade_mode, telemetry_path_for_suite, telemetry_row_matches_since,
     tool_response_budget_assertion, tool_success_assertion, validate_since_date, validate_suite,
     validate_telemetry_suite_name,
 };
@@ -101,6 +102,129 @@ fn agent_expectations_score_tool_trace() {
     ];
     let results = score_agent_expectations(&expected, &trace, "GMV uses model.pkg.orders");
     assert!(results.iter().all(|result| result.status == "pass"));
+}
+
+#[test]
+fn sql_structure_assertion_passes_when_only_literals_differ() {
+    let result = sql_structure_assertion(
+        "sql_structure",
+        "
+            select o.country, sum(o.amount) as revenue
+            from analytics.orders o
+            where o.order_date between '2026-03-01' and '2026-03-31'
+              and o.country = 'US'
+              and o.amount > 100
+            group by o.country
+        ",
+        "
+            select orders.country, sum(orders.amount) as revenue
+            from analytics.orders
+            where orders.order_date between '2024-01-01' and '2024-01-31'
+              and orders.country = 'GB'
+              and orders.amount > 250
+            group by orders.country
+        ",
+    );
+
+    assert_eq!(result.status, "pass", "{result:#?}");
+    assert_eq!(result.evidence["grade_mode"], "query_structure");
+}
+
+#[test]
+fn sql_structure_assertion_fails_with_missing_filter_diff() {
+    let result = sql_structure_assertion(
+        "sql_structure",
+        "select country, sum(amount) from analytics.orders group by country",
+        "
+            select country, sum(amount)
+            from analytics.orders
+            where country = 'US'
+            group by country
+        ",
+    );
+
+    assert_eq!(result.status, "fail");
+    assert!(result.message.contains("WHERE"));
+    assert_eq!(
+        result.evidence["diff"]["missing_filters"],
+        json!(["country = ?"])
+    );
+}
+
+#[test]
+fn sql_structure_assertion_fails_with_wrong_table_diff() {
+    let result = sql_structure_assertion(
+        "sql_structure",
+        "select country, sum(amount) from analytics.customers group by country",
+        "select country, sum(amount) from analytics.orders group by country",
+    );
+
+    assert_eq!(result.status, "fail");
+    assert!(result.message.contains("FROM"));
+    assert_eq!(
+        result.evidence["diff"]["missing_tables"],
+        json!(["analytics.orders"])
+    );
+    assert_eq!(
+        result.evidence["diff"]["unexpected_tables"],
+        json!(["analytics.customers"])
+    );
+}
+
+#[test]
+fn agent_sql_structure_scores_execute_sql_trace_without_raw_sql() {
+    let expected = AgentExpected {
+        sql_structures: vec![AgentSqlStructureExpected {
+            tool: "execute_sql".to_string(),
+            expected_sql: "
+                select country, sum(amount) as revenue
+                from analytics.orders
+                where order_date between '2024-01-01' and '2024-01-31'
+                  and country = 'GB'
+                group by country
+            "
+            .to_string(),
+        }],
+        ..AgentExpected::default()
+    };
+    let actual_sql = "
+        select o.country, sum(o.amount) as revenue
+        from analytics.orders o
+        where o.order_date between '2026-03-01' and '2026-03-31'
+          and o.country = 'US'
+        group by o.country
+    ";
+    let trace = vec![json!({
+        "tool": "execute_sql",
+        "params_summary": {
+            "keys": ["statement"],
+            "statement_structure": crate::utils::sql_structure::sql_structure_summary_json(actual_sql)
+                .expect("structure")
+        }
+    })];
+
+    let results = score_agent_expectations(&expected, &trace, "");
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].status, "pass", "{results:#?}");
+    assert!(!results[0].evidence.to_string().contains("2026-03-01"));
+    assert!(!trace[0].to_string().contains("select o.country"));
+}
+
+#[test]
+fn query_structure_telemetry_grade_mode_is_explicit() {
+    assert_eq!(
+        telemetry_grade_mode("agent", "sql_structure:execute_sql"),
+        "query_structure"
+    );
+    assert_eq!(
+        telemetry_grade_mode("agent", "must_call:search"),
+        "provider_trace"
+    );
+    assert_eq!(
+        telemetry_grade_mode("bridge", "search_rank"),
+        "deterministic"
+    );
 }
 
 #[test]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,6 +4,7 @@ pub mod glob;
 pub mod id;
 pub mod metrics;
 pub mod persona;
+pub mod sql_structure;
 pub mod storage;
 pub mod string;
 pub mod tool_trace;

--- a/src/utils/sql_structure.rs
+++ b/src/utils/sql_structure.rs
@@ -1,0 +1,786 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use sqlparser::ast::{
+    BinaryOperator, Expr, GroupByExpr, Join, JoinConstraint, JoinOperator, Query, Select,
+    SelectItem, SetExpr, Statement, TableFactor, TableWithJoins,
+};
+use sqlparser::dialect::{
+    BigQueryDialect, DatabricksDialect, DuckDbDialect, GenericDialect, SnowflakeDialect,
+};
+use sqlparser::parser::Parser;
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub(crate) struct SqlStructureSignature {
+    pub(crate) tables: Vec<String>,
+    pub(crate) joins: Vec<String>,
+    pub(crate) select: Vec<String>,
+    pub(crate) filters: Vec<String>,
+    pub(crate) group_by: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+pub(crate) struct SqlStructureDiff {
+    pub(crate) missing_tables: Vec<String>,
+    pub(crate) unexpected_tables: Vec<String>,
+    pub(crate) missing_joins: Vec<String>,
+    pub(crate) unexpected_joins: Vec<String>,
+    pub(crate) missing_select: Vec<String>,
+    pub(crate) unexpected_select: Vec<String>,
+    pub(crate) missing_filters: Vec<String>,
+    pub(crate) unexpected_filters: Vec<String>,
+    pub(crate) missing_group_by: Vec<String>,
+    pub(crate) unexpected_group_by: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct SqlStructureComparison {
+    pub(crate) matches: bool,
+    pub(crate) expected: SqlStructureSignature,
+    pub(crate) actual: SqlStructureSignature,
+    pub(crate) diff: SqlStructureDiff,
+}
+
+impl SqlStructureDiff {
+    #[must_use]
+    pub(crate) fn changed_clauses(&self) -> Vec<&'static str> {
+        let mut clauses = Vec::new();
+        if !self.missing_select.is_empty() || !self.unexpected_select.is_empty() {
+            clauses.push("SELECT");
+        }
+        if !self.missing_tables.is_empty() || !self.unexpected_tables.is_empty() {
+            clauses.push("FROM");
+        }
+        if !self.missing_joins.is_empty() || !self.unexpected_joins.is_empty() {
+            clauses.push("JOIN");
+        }
+        if !self.missing_filters.is_empty() || !self.unexpected_filters.is_empty() {
+            clauses.push("WHERE");
+        }
+        if !self.missing_group_by.is_empty() || !self.unexpected_group_by.is_empty() {
+            clauses.push("GROUP BY");
+        }
+        clauses
+    }
+
+    fn is_empty(&self) -> bool {
+        self.missing_tables.is_empty()
+            && self.unexpected_tables.is_empty()
+            && self.missing_joins.is_empty()
+            && self.unexpected_joins.is_empty()
+            && self.missing_select.is_empty()
+            && self.unexpected_select.is_empty()
+            && self.missing_filters.is_empty()
+            && self.unexpected_filters.is_empty()
+            && self.missing_group_by.is_empty()
+            && self.unexpected_group_by.is_empty()
+    }
+}
+
+pub(crate) fn sql_structure_signature(sql: &str) -> Result<SqlStructureSignature, String> {
+    let statement = parse_single_statement(sql)?;
+    let Statement::Query(query) = statement else {
+        return Err("query structure grading supports SELECT queries only".to_string());
+    };
+    signature_for_query(&query)
+}
+
+pub(crate) fn sql_structure_summary_json(sql: &str) -> Result<JsonValue, String> {
+    serde_json::to_value(sql_structure_signature(sql)?)
+        .map_err(|error| format!("failed to serialize SQL structure summary: {error}"))
+}
+
+pub(crate) fn compare_sql_structure(
+    actual_sql: &str,
+    expected_sql: &str,
+) -> Result<SqlStructureComparison, String> {
+    let actual = sql_structure_signature(actual_sql)?;
+    let expected = sql_structure_signature(expected_sql)?;
+    Ok(compare_sql_structure_signatures(actual, expected))
+}
+
+pub(crate) fn compare_sql_structure_signatures(
+    actual: SqlStructureSignature,
+    expected: SqlStructureSignature,
+) -> SqlStructureComparison {
+    let diff = SqlStructureDiff {
+        missing_tables: missing_values(&actual.tables, &expected.tables),
+        unexpected_tables: unexpected_values(&actual.tables, &expected.tables),
+        missing_joins: missing_values(&actual.joins, &expected.joins),
+        unexpected_joins: unexpected_values(&actual.joins, &expected.joins),
+        missing_select: missing_values(&actual.select, &expected.select),
+        unexpected_select: unexpected_values(&actual.select, &expected.select),
+        missing_filters: missing_values(&actual.filters, &expected.filters),
+        unexpected_filters: unexpected_values(&actual.filters, &expected.filters),
+        missing_group_by: missing_values(&actual.group_by, &expected.group_by),
+        unexpected_group_by: unexpected_values(&actual.group_by, &expected.group_by),
+    };
+    SqlStructureComparison {
+        matches: diff.is_empty(),
+        expected,
+        actual,
+        diff,
+    }
+}
+
+fn parse_single_statement(sql: &str) -> Result<Statement, String> {
+    let trimmed = sql.trim();
+    if trimmed.is_empty() {
+        return Err("SQL must be non-empty".to_string());
+    }
+
+    let parse_attempts: [(&str, Result<Vec<Statement>, sqlparser::parser::ParserError>); 5] = [
+        ("generic", Parser::parse_sql(&GenericDialect {}, trimmed)),
+        (
+            "snowflake",
+            Parser::parse_sql(&SnowflakeDialect {}, trimmed),
+        ),
+        ("bigquery", Parser::parse_sql(&BigQueryDialect {}, trimmed)),
+        ("duckdb", Parser::parse_sql(&DuckDbDialect {}, trimmed)),
+        (
+            "databricks",
+            Parser::parse_sql(&DatabricksDialect {}, trimmed),
+        ),
+    ];
+    let mut errors = Vec::new();
+    for (dialect, result) in parse_attempts {
+        match result {
+            Ok(statements) if statements.len() == 1 => {
+                return statements
+                    .into_iter()
+                    .next()
+                    .ok_or_else(|| "SQL parser returned no statements".to_string());
+            }
+            Ok(statements) => errors.push(format!(
+                "{dialect}: expected exactly one statement, parsed {}",
+                statements.len()
+            )),
+            Err(error) => errors.push(format!("{dialect}: {error}")),
+        }
+    }
+    Err(format!(
+        "failed to parse SQL for query structure grading: {}",
+        errors.join("; ")
+    ))
+}
+
+fn signature_for_query(query: &Query) -> Result<SqlStructureSignature, String> {
+    match query.body.as_ref() {
+        SetExpr::Select(select) => signature_for_select(select),
+        SetExpr::Query(query) => signature_for_query(query),
+        _ => Err("query structure grading supports simple SELECT query bodies only".to_string()),
+    }
+}
+
+fn signature_for_select(select: &Select) -> Result<SqlStructureSignature, String> {
+    let aliases = qualifier_aliases(select);
+    let mut tables = BTreeSet::new();
+    let mut joins = BTreeSet::new();
+    for table in &select.from {
+        collect_table_with_joins(table, &aliases, &mut tables, &mut joins)?;
+    }
+
+    let select_items = select
+        .projection
+        .iter()
+        .map(|item| normalize_select_item(item, &aliases))
+        .collect::<BTreeSet<_>>();
+    let mut filters = BTreeSet::new();
+    if let Some(selection) = select.selection.as_ref() {
+        let mut conjuncts = Vec::new();
+        collect_and_conjuncts(selection, &mut conjuncts);
+        for conjunct in conjuncts {
+            filters.insert(normalize_expr(conjunct, &aliases));
+        }
+    }
+    if let Some(prewhere) = select.prewhere.as_ref() {
+        filters.insert(format!("prewhere {}", normalize_expr(prewhere, &aliases)));
+    }
+    if let Some(having) = select.having.as_ref() {
+        filters.insert(format!("having {}", normalize_expr(having, &aliases)));
+    }
+    if let Some(qualify) = select.qualify.as_ref() {
+        filters.insert(format!("qualify {}", normalize_expr(qualify, &aliases)));
+    }
+
+    Ok(SqlStructureSignature {
+        tables: tables.into_iter().collect(),
+        joins: joins.into_iter().collect(),
+        select: select_items.into_iter().collect(),
+        filters: filters.into_iter().collect(),
+        group_by: group_by_signature(&select.group_by, &aliases),
+    })
+}
+
+fn qualifier_aliases(select: &Select) -> BTreeMap<String, String> {
+    let mut aliases = BTreeMap::new();
+    for table in &select.from {
+        register_table_factor_aliases(&table.relation, &mut aliases);
+        for join in &table.joins {
+            register_table_factor_aliases(&join.relation, &mut aliases);
+        }
+    }
+    preserve_reused_table_aliases(&mut aliases);
+    aliases
+}
+
+fn preserve_reused_table_aliases(aliases: &mut BTreeMap<String, String>) {
+    let mut counts = BTreeMap::new();
+    for canonical in aliases.values() {
+        *counts.entry(canonical.clone()).or_insert(0usize) += 1;
+    }
+    for (alias, canonical) in aliases.iter_mut() {
+        if counts.get(canonical).copied().unwrap_or_default() > 2 && alias != canonical {
+            canonical.clone_from(alias);
+        }
+    }
+}
+
+fn register_table_factor_aliases(factor: &TableFactor, aliases: &mut BTreeMap<String, String>) {
+    match factor {
+        TableFactor::Table { name, alias, .. } => {
+            let relation = normalize_relation_name(&name.to_string());
+            let leaf = relation_leaf(&relation);
+            aliases.insert(relation, leaf.clone());
+            if let Some(alias) = alias {
+                aliases.insert(normalize_identifier(&alias.name.to_string()), leaf);
+            }
+        }
+        TableFactor::Derived { alias, .. }
+        | TableFactor::TableFunction { alias, .. }
+        | TableFactor::Function { alias, .. }
+        | TableFactor::UNNEST { alias, .. } => {
+            if let Some(alias) = alias {
+                let alias = normalize_identifier(&alias.name.to_string());
+                aliases.insert(alias.clone(), alias);
+            }
+        }
+        TableFactor::NestedJoin {
+            table_with_joins,
+            alias,
+        } => {
+            register_table_factor_aliases(&table_with_joins.relation, aliases);
+            for join in &table_with_joins.joins {
+                register_table_factor_aliases(&join.relation, aliases);
+            }
+            if let Some(alias) = alias {
+                let alias = normalize_identifier(&alias.name.to_string());
+                aliases.insert(alias.clone(), alias);
+            }
+        }
+        TableFactor::Pivot { table, alias, .. } | TableFactor::Unpivot { table, alias, .. } => {
+            register_table_factor_aliases(table, aliases);
+            if let Some(alias) = alias {
+                let alias = normalize_identifier(&alias.name.to_string());
+                aliases.insert(alias.clone(), alias);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_table_with_joins(
+    table: &TableWithJoins,
+    aliases: &BTreeMap<String, String>,
+    tables: &mut BTreeSet<String>,
+    joins: &mut BTreeSet<String>,
+) -> Result<(), String> {
+    collect_table_factor_refs(&table.relation, aliases, tables, joins)?;
+    for join in &table.joins {
+        collect_table_factor_refs(&join.relation, aliases, tables, joins)?;
+        joins.insert(join_signature(join, aliases));
+    }
+    Ok(())
+}
+
+fn collect_table_factor_refs(
+    factor: &TableFactor,
+    aliases: &BTreeMap<String, String>,
+    tables: &mut BTreeSet<String>,
+    joins: &mut BTreeSet<String>,
+) -> Result<(), String> {
+    match factor {
+        TableFactor::Table { name, .. } => {
+            tables.insert(normalize_relation_name(&name.to_string()));
+        }
+        TableFactor::Derived { subquery, .. } => {
+            let signature = signature_for_query(subquery)?;
+            tables.extend(signature.tables);
+            joins.extend(signature.joins);
+        }
+        TableFactor::NestedJoin {
+            table_with_joins, ..
+        } => collect_table_with_joins(table_with_joins, aliases, tables, joins)?,
+        TableFactor::Pivot { table, .. } | TableFactor::Unpivot { table, .. } => {
+            collect_table_factor_refs(table, aliases, tables, joins)?;
+        }
+        TableFactor::Function { name, .. } => {
+            tables.insert(format!(
+                "function:{}",
+                normalize_relation_name(&name.to_string())
+            ));
+        }
+        TableFactor::TableFunction { expr, .. } => {
+            tables.insert(format!("table_function:{}", normalize_expr(expr, aliases)));
+        }
+        TableFactor::UNNEST { array_exprs, .. } => {
+            let exprs = array_exprs
+                .iter()
+                .map(|expr| normalize_expr(expr, aliases))
+                .collect::<Vec<_>>()
+                .join(", ");
+            tables.insert(format!("unnest:{exprs}"));
+        }
+        _ => {
+            tables.insert(normalize_sql_fragment(&factor.to_string(), aliases));
+        }
+    }
+    Ok(())
+}
+
+fn join_signature(join: &Join, aliases: &BTreeMap<String, String>) -> String {
+    let relation = table_factor_label(&join.relation, aliases);
+    if let JoinOperator::AsOf {
+        match_condition,
+        constraint,
+    } = &join.join_operator
+    {
+        return join_constraint_signature(
+            format!(
+                "asof join {relation} match {}",
+                normalize_expr(match_condition, aliases)
+            ),
+            Some(constraint),
+            aliases,
+        );
+    }
+    let (kind, constraint) = join_kind_and_constraint(&join.join_operator);
+    join_constraint_signature(format!("{kind} {relation}"), constraint, aliases)
+}
+
+fn join_constraint_signature(
+    prefix: String,
+    constraint: Option<&JoinConstraint>,
+    aliases: &BTreeMap<String, String>,
+) -> String {
+    match constraint {
+        Some(JoinConstraint::On(expr)) => {
+            let mut conjuncts = Vec::new();
+            collect_and_conjuncts(expr, &mut conjuncts);
+            let constraints = conjuncts
+                .into_iter()
+                .map(|expr| normalize_expr(expr, aliases))
+                .collect::<Vec<_>>()
+                .join(" and ");
+            format!("{prefix} on {constraints}")
+        }
+        Some(JoinConstraint::Using(columns)) => {
+            let columns = columns
+                .iter()
+                .map(|column| normalize_sql_fragment(&column.to_string(), aliases))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{prefix} using ({columns})")
+        }
+        Some(JoinConstraint::Natural) => format!("{prefix} natural"),
+        Some(JoinConstraint::None) | None => prefix,
+    }
+}
+
+fn join_kind_and_constraint(operator: &JoinOperator) -> (&'static str, Option<&JoinConstraint>) {
+    match operator {
+        JoinOperator::Join(constraint) => ("join", Some(constraint)),
+        JoinOperator::Inner(constraint) => ("inner join", Some(constraint)),
+        JoinOperator::Left(constraint) | JoinOperator::LeftOuter(constraint) => {
+            ("left join", Some(constraint))
+        }
+        JoinOperator::Right(constraint) | JoinOperator::RightOuter(constraint) => {
+            ("right join", Some(constraint))
+        }
+        JoinOperator::FullOuter(constraint) => ("full join", Some(constraint)),
+        JoinOperator::CrossJoin(constraint) => ("cross join", Some(constraint)),
+        JoinOperator::Semi(constraint) | JoinOperator::LeftSemi(constraint) => {
+            ("semi join", Some(constraint))
+        }
+        JoinOperator::RightSemi(constraint) => ("right semi join", Some(constraint)),
+        JoinOperator::Anti(constraint) | JoinOperator::LeftAnti(constraint) => {
+            ("anti join", Some(constraint))
+        }
+        JoinOperator::RightAnti(constraint) => ("right anti join", Some(constraint)),
+        JoinOperator::CrossApply => ("cross apply", None),
+        JoinOperator::OuterApply => ("outer apply", None),
+        JoinOperator::AsOf { constraint, .. } => ("asof join", Some(constraint)),
+        JoinOperator::StraightJoin(constraint) => ("straight join", Some(constraint)),
+    }
+}
+
+fn table_factor_label(factor: &TableFactor, aliases: &BTreeMap<String, String>) -> String {
+    match factor {
+        TableFactor::Table { name, .. } => normalize_relation_name(&name.to_string()),
+        TableFactor::Derived { alias, .. } => alias.as_ref().map_or_else(
+            || "subquery".to_string(),
+            |alias| format!("subquery:{}", normalize_identifier(&alias.name.to_string())),
+        ),
+        TableFactor::Function { name, .. } => {
+            format!("function:{}", normalize_relation_name(&name.to_string()))
+        }
+        TableFactor::TableFunction { expr, .. } => {
+            format!("table_function:{}", normalize_expr(expr, aliases))
+        }
+        TableFactor::UNNEST { array_exprs, .. } => {
+            let exprs = array_exprs
+                .iter()
+                .map(|expr| normalize_expr(expr, aliases))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("unnest:{exprs}")
+        }
+        TableFactor::NestedJoin { .. } => "nested_join".to_string(),
+        _ => normalize_sql_fragment(&factor.to_string(), aliases),
+    }
+}
+
+fn normalize_select_item(item: &SelectItem, aliases: &BTreeMap<String, String>) -> String {
+    match item {
+        SelectItem::UnnamedExpr(expr) | SelectItem::ExprWithAlias { expr, .. } => {
+            normalize_expr(expr, aliases)
+        }
+        SelectItem::QualifiedWildcard(kind, _) => {
+            normalize_sql_fragment(&kind.to_string(), aliases)
+        }
+        SelectItem::Wildcard(_) => "*".to_string(),
+    }
+}
+
+fn group_by_signature(group_by: &GroupByExpr, aliases: &BTreeMap<String, String>) -> Vec<String> {
+    match group_by {
+        GroupByExpr::All(_) => vec!["all".to_string()],
+        GroupByExpr::Expressions(exprs, _) => exprs
+            .iter()
+            .map(|expr| normalize_expr(expr, aliases))
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect(),
+    }
+}
+
+fn collect_and_conjuncts<'a>(expr: &'a Expr, out: &mut Vec<&'a Expr>) {
+    match expr {
+        Expr::BinaryOp {
+            left,
+            op: BinaryOperator::And,
+            right,
+        } => {
+            collect_and_conjuncts(left, out);
+            collect_and_conjuncts(right, out);
+        }
+        Expr::Nested(expr) => collect_and_conjuncts(expr, out),
+        _ => out.push(expr),
+    }
+}
+
+fn normalize_expr(expr: &Expr, aliases: &BTreeMap<String, String>) -> String {
+    normalize_sql_fragment(&expr.to_string(), aliases)
+}
+
+fn normalize_relation_name(value: &str) -> String {
+    normalize_sql_fragment(value, &BTreeMap::new())
+}
+
+fn normalize_identifier(value: &str) -> String {
+    normalize_sql_fragment(value, &BTreeMap::new())
+}
+
+fn normalize_sql_fragment(value: &str, aliases: &BTreeMap<String, String>) -> String {
+    let masked = mask_sql_literals(value);
+    let mut normalized = masked
+        .replace(['"', '`', '[', ']'], "")
+        .to_ascii_lowercase();
+    normalized = collapse_whitespace(&normalized);
+    normalized = normalized
+        .replace(" . ", ".")
+        .replace(" .", ".")
+        .replace(". ", ".")
+        .replace("( ", "(")
+        .replace(" )", ")")
+        .replace(" ,", ",");
+    strip_single_table_qualifier(&apply_aliases(&normalized, aliases), aliases)
+}
+
+fn apply_aliases(value: &str, aliases: &BTreeMap<String, String>) -> String {
+    let mut out = value.to_string();
+    let mut entries = aliases.iter().collect::<Vec<_>>();
+    entries.sort_by(|(left, _), (right, _)| right.len().cmp(&left.len()).then(left.cmp(right)));
+    for (alias, canonical) in entries {
+        if alias == canonical {
+            continue;
+        }
+        out = replace_qualifier(&out, alias, canonical);
+    }
+    out
+}
+
+fn replace_qualifier(value: &str, alias: &str, canonical: &str) -> String {
+    let needle = format!("{alias}.");
+    let replacement = if canonical.is_empty() {
+        String::new()
+    } else {
+        format!("{canonical}.")
+    };
+    let mut out = String::with_capacity(value.len());
+    let mut cursor = 0usize;
+    while let Some(relative) = value[cursor..].find(&needle) {
+        let absolute = cursor + relative;
+        if absolute == 0 || is_qualifier_boundary(value[..absolute].chars().next_back()) {
+            out.push_str(&value[cursor..absolute]);
+            out.push_str(&replacement);
+            cursor = absolute + needle.len();
+        } else {
+            out.push_str(&value[cursor..absolute + needle.len()]);
+            cursor = absolute + needle.len();
+        }
+    }
+    out.push_str(&value[cursor..]);
+    out
+}
+
+fn strip_single_table_qualifier(value: &str, aliases: &BTreeMap<String, String>) -> String {
+    let canonical_tables = aliases
+        .values()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if canonical_tables.len() != 1 || aliases.len() > 2 {
+        return value.to_string();
+    }
+    replace_qualifier(value, canonical_tables[0], "")
+}
+
+fn is_qualifier_boundary(ch: Option<char>) -> bool {
+    ch.is_none_or(|ch| !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '$')))
+}
+
+fn mask_sql_literals(value: &str) -> String {
+    let chars = value.chars().collect::<Vec<_>>();
+    let mut out = String::with_capacity(value.len());
+    let mut index = 0usize;
+    while index < chars.len() {
+        match chars[index] {
+            '\'' => {
+                out.push('?');
+                index += 1;
+                while index < chars.len() {
+                    if chars[index] == '\'' {
+                        if index + 1 < chars.len() && chars[index + 1] == '\'' {
+                            index += 2;
+                        } else {
+                            index += 1;
+                            break;
+                        }
+                    } else {
+                        index += 1;
+                    }
+                }
+            }
+            '-' | '+' if index + 1 < chars.len() && chars[index + 1].is_ascii_digit() => {
+                if let Some(end) = numeric_literal_end(&chars, index) {
+                    out.push('?');
+                    index = end;
+                } else {
+                    out.push(chars[index]);
+                    index += 1;
+                }
+            }
+            ch if ch.is_ascii_digit() => {
+                if let Some(end) = numeric_literal_end(&chars, index) {
+                    out.push('?');
+                    index = end;
+                } else {
+                    out.push(ch);
+                    index += 1;
+                }
+            }
+            ch => {
+                out.push(ch);
+                index += 1;
+            }
+        }
+    }
+    out
+}
+
+fn numeric_literal_end(chars: &[char], start: usize) -> Option<usize> {
+    if start > 0 && !is_numeric_boundary(chars[start - 1]) {
+        return None;
+    }
+    let mut index = start;
+    if matches!(chars[index], '-' | '+') {
+        index += 1;
+    }
+    while index < chars.len() && chars[index].is_ascii_digit() {
+        index += 1;
+    }
+    if index < chars.len()
+        && chars[index] == '.'
+        && index + 1 < chars.len()
+        && chars[index + 1].is_ascii_digit()
+    {
+        index += 1;
+        while index < chars.len() && chars[index].is_ascii_digit() {
+            index += 1;
+        }
+    }
+    if index < chars.len() && matches!(chars[index], 'e' | 'E') {
+        let exponent_start = index;
+        index += 1;
+        if index < chars.len() && matches!(chars[index], '-' | '+') {
+            index += 1;
+        }
+        let digits_start = index;
+        while index < chars.len() && chars[index].is_ascii_digit() {
+            index += 1;
+        }
+        if index == digits_start {
+            index = exponent_start;
+        }
+    }
+    if index == start || (matches!(chars[start], '-' | '+') && index == start + 1) {
+        return None;
+    }
+    (index == chars.len() || is_numeric_boundary(chars[index])).then_some(index)
+}
+
+fn is_numeric_boundary(ch: char) -> bool {
+    !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '$'))
+}
+
+fn collapse_whitespace(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn relation_leaf(relation: &str) -> String {
+    relation.rsplit('.').next().unwrap_or(relation).to_string()
+}
+
+fn missing_values(actual: &[String], expected: &[String]) -> Vec<String> {
+    let actual = actual.iter().collect::<BTreeSet<_>>();
+    expected
+        .iter()
+        .filter(|value| !actual.contains(value))
+        .cloned()
+        .collect()
+}
+
+fn unexpected_values(actual: &[String], expected: &[String]) -> Vec<String> {
+    let expected = expected.iter().collect::<BTreeSet<_>>();
+    actual
+        .iter()
+        .filter(|value| !expected.contains(value))
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compare_sql_structure;
+
+    #[test]
+    fn query_structure_masks_string_date_and_numeric_literals() {
+        let actual = "
+            select o.country, sum(o.amount) as revenue
+            from analytics.orders o
+            where o.order_date between '2026-03-01' and '2026-03-31'
+              and o.country = 'US'
+              and o.amount > 100
+            group by o.country
+        ";
+        let expected = "
+            select orders.country, sum(orders.amount) as revenue
+            from analytics.orders
+            where orders.order_date between '2024-01-01' and '2024-01-31'
+              and orders.country = 'GB'
+              and orders.amount > 200
+            group by orders.country
+        ";
+
+        let comparison = compare_sql_structure(actual, expected).expect("comparison");
+
+        assert!(comparison.matches, "{comparison:#?}");
+    }
+
+    #[test]
+    fn query_structure_reports_missing_filter_clause() {
+        let actual = "select country, sum(amount) from analytics.orders group by country";
+        let expected = "
+            select country, sum(amount)
+            from analytics.orders
+            where country = 'US'
+            group by country
+        ";
+
+        let comparison = compare_sql_structure(actual, expected).expect("comparison");
+
+        assert!(!comparison.matches);
+        assert_eq!(comparison.diff.changed_clauses(), vec!["WHERE"]);
+        assert_eq!(comparison.diff.missing_filters, vec!["country = ?"]);
+    }
+
+    #[test]
+    fn query_structure_reports_wrong_table_clause() {
+        let actual = "select country, sum(amount) from analytics.customers group by country";
+        let expected = "select country, sum(amount) from analytics.orders group by country";
+
+        let comparison = compare_sql_structure(actual, expected).expect("comparison");
+
+        assert!(!comparison.matches);
+        assert_eq!(comparison.diff.changed_clauses(), vec!["FROM"]);
+        assert_eq!(comparison.diff.missing_tables, vec!["analytics.orders"]);
+        assert_eq!(
+            comparison.diff.unexpected_tables,
+            vec!["analytics.customers"]
+        );
+    }
+
+    #[test]
+    fn query_structure_preserves_self_join_qualifiers() {
+        let actual = "
+            select child.id
+            from analytics.accounts child
+            join analytics.accounts parent on child.parent_id = parent.id
+        ";
+        let expected = "
+            select child.id
+            from analytics.accounts child
+            join analytics.accounts parent on parent.parent_id = child.id
+        ";
+
+        let comparison = compare_sql_structure(actual, expected).expect("comparison");
+
+        assert!(!comparison.matches);
+        assert_eq!(comparison.diff.changed_clauses(), vec!["JOIN"]);
+    }
+
+    #[test]
+    fn query_structure_compares_asof_match_conditions() {
+        let actual = "
+            select q.symbol
+            from analytics.quotes q
+            asof join analytics.trades t
+              match_condition (q.observed_at >= t.executed_at)
+              on q.symbol = t.symbol
+        ";
+        let expected = "
+            select q.symbol
+            from analytics.quotes q
+            asof join analytics.trades t
+              match_condition (q.observed_at <= t.executed_at)
+              on q.symbol = t.symbol
+        ";
+
+        let comparison = compare_sql_structure(actual, expected).expect("comparison");
+
+        assert!(!comparison.matches);
+        assert_eq!(comparison.diff.changed_clauses(), vec!["JOIN"]);
+    }
+}

--- a/src/utils/tool_trace.rs
+++ b/src/utils/tool_trace.rs
@@ -1038,7 +1038,28 @@ fn summarize_params(params: &Value) -> Value {
             summary.insert(key.to_string(), value);
         }
     }
+    insert_statement_structure_summary(&mut summary, map.get("statement").and_then(Value::as_str));
     Value::Object(summary)
+}
+
+fn insert_statement_structure_summary(
+    summary: &mut serde_json::Map<String, Value>,
+    statement: Option<&str>,
+) {
+    let Some(statement) = statement.map(str::trim).filter(|value| !value.is_empty()) else {
+        return;
+    };
+    match crate::utils::sql_structure::sql_structure_summary_json(statement) {
+        Ok(structure) => {
+            summary.insert("statement_structure".to_string(), structure);
+        }
+        Err(_error) => {
+            summary.insert(
+                "statement_structure_error".to_string(),
+                Value::String("failed to parse SQL structure summary".to_string()),
+            );
+        }
+    }
 }
 
 fn summarize_safe_value(value: &Value) -> Option<Value> {
@@ -1257,6 +1278,26 @@ mod tests {
             "resource_types": ["model", {"token": "secret"}]
         }));
         assert_eq!(summary["resource_types"], json!(["model"]));
+    }
+
+    #[test]
+    fn summarize_params_records_statement_structure_without_raw_sql() {
+        let summary = summarize_params(&json!({
+            "statement": "select country from analytics.orders where order_date = '2026-03-01'",
+            "row_limit": 10
+        }));
+
+        assert_eq!(summary["row_limit"], 10);
+        assert_eq!(
+            summary["statement_structure"]["tables"],
+            json!(["analytics.orders"])
+        );
+        assert_eq!(
+            summary["statement_structure"]["filters"],
+            json!(["order_date = ?"])
+        );
+        assert!(summary.get("statement").is_none());
+        assert!(!summary.to_string().contains("2026-03-01"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add SQL structure signatures/diffs for SELECT query grading, including tables, joins, projections, filters, groupings, alias normalization, and literal masking.
- Wire bridge `sql_structure` assertions and agent `expected.sql_structures` checks through sanitized trace `statement_structure` summaries.
- Update eval docs, changelog, and regression tests for privacy-safe query-structure grading.

Linear: JOE-10

## Validation
- `cargo fmt --check`
- `cargo test --locked sql_structure --lib`
- `cargo test --locked eval_cmd`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `uv run --with-requirements docs/requirements.txt mkdocs build --strict`
- `cargo test --locked --all-features`