### PR TITLE
Add eval ablation comparisons and negative-results log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a development negative-results log for ranking, retrieval, skill, and
   eval experiments that do not improve accuracy, latency, maintainability, or
   agent behavior.
+- Updated `memmap2` to `0.9.11` to resolve `RUSTSEC-2026-0186`.
 - Documented bridge and provider-backed eval CI templates with GitHub Actions
   examples for manifest generation, telemetry retention, eval gates, artifact
   upload, private OpenCode provider runs, and redacted trace handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   agent `expected.sql_structures`, comparing tables, joins, projections,
   filters, and groupings while masking string/date/numeric literals and
   reporting structured clause diffs.
+- Added `dbt-nova eval compare` and MCP/CLI `tool call` parity through
+  `compare_eval_runs` for PR-ready before/after eval deltas, including pass-rate
+  movement, newly passing/failing cases, and agent trace counters when available.
+- Added a development negative-results log for ranking, retrieval, skill, and
+  eval experiments that do not improve accuracy, latency, maintainability, or
+  agent behavior.
 - Documented bridge and provider-backed eval CI templates with GitHub Actions
   examples for manifest generation, telemetry retention, eval gates, artifact
   upload, private OpenCode provider runs, and redacted trace handling.
@@ -97,10 +103,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the `validate_nova_meta` MCP tool and CLI `tool call` bridge support
   for nova-meta schema/semantic validation with scoped local path access.
 - Added MCP and CLI `tool call` parity for eval workflows:
-  `validate_eval_suite`, `get_eval_gate`, `get_eval_history`, `run_eval`,
-  `init_eval_suite`, and `run_agent_eval`, with explicit opt-in environment
-  gates for local writes, bridge eval execution, provider-backed agent evals,
-  and custom provider commands.
+  `validate_eval_suite`, `get_eval_gate`, `get_eval_history`,
+  `compare_eval_runs`, `run_eval`, `init_eval_suite`, and `run_agent_eval`, with
+  explicit opt-in environment gates for local writes, bridge eval execution,
+  provider-backed agent evals, and custom provider commands.
 - Added safety-gated `warm_manifest` MCP and CLI `tool call` parity for
   semantic cache warmup, using the current manifest source and requiring
   `DBT_NOVA_MCP_ENABLE_MANIFEST_WARM=1`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,9 @@ Nova metadata is defined in `schemas/nova/v0.json`. If you add or change fields:
 
 All new behavior should be covered with tests. Avoid `unwrap_or(false)` or
 implicit assertions. Prefer explicit checks and descriptive failure messages.
+For ranking, retrieval, skill, or eval experiments that do not improve the
+project, add a short entry to `docs/development/negative-results.md` so future
+work can learn from the result.
 
 Recommended commands:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3192,9 +3192,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/docs/api/mcp-cli-parity.md
+++ b/docs/api/mcp-cli-parity.md
@@ -5,7 +5,7 @@ dbt-nova exposes two callable product surfaces:
 - MCP tools, used by MCP clients and hosted deployments.
 - CLI commands, used for one-shot local workflows and CI automation.
 
-The MCP catalog currently contains 52 MCP tools. `dbt-nova tool call` is the
+The MCP catalog currently contains 53 MCP tools. `dbt-nova tool call` is the
 CLI bridge to that same canonical tool catalog. Other CLI leaf commands are
 tracked below so each capability is either MCP-equivalent, a known parity gap,
 explicitly safety-gated, or a lifecycle exception.
@@ -31,7 +31,7 @@ sets the documented opt-in environment variable for local execution or writes.
 | `manifest load` | `health` | Lifecycle exception | - | MCP server startup performs the initial manifest load; `health` reports the active loaded manifest and `reload_manifest` replaces it. |
 | `manifest reload` | `reload_manifest` | Equivalent | - | MCP starts a background reload for the live server; CLI `manifest reload` and CLI `tool call reload_manifest` are one-shot reloads. |
 | `manifest warm` | `warm_manifest` | SafetyGated | - | MCP semantic cache warmup requires `DBT_NOVA_MCP_ENABLE_MANIFEST_WARM=1` and uses the current manifest source. |
-| `tool call <tool_name>` | 52 MCP tools | Equivalent | - | CLI tool-call mode supports the canonical MCP tool catalog. |
+| `tool call <tool_name>` | 53 MCP tools | Equivalent | - | CLI tool-call mode supports the canonical MCP tool catalog. |
 | `audit agent-readiness` | `get_agent_readiness` | Equivalent | - | MCP returns the same `agent_readiness.v1` report without CLI file writes. |
 | `audit metadata-score` | `get_metadata_audit` | Equivalent | - | MCP returns the same metadata audit report without CLI file writes or exit semantics. |
 | `audit nova-meta` | `validate_nova_meta` | Equivalent | - | MCP returns the same nova-meta validation report with scoped local path access. |
@@ -46,6 +46,7 @@ sets the documented opt-in environment variable for local execution or writes.
 | `eval agent run` | `run_agent_eval` | SafetyGated | - | MCP provider execution requires `DBT_NOVA_MCP_ENABLE_AGENT_EVAL=1`; custom commands also require `DBT_NOVA_MCP_ENABLE_CUSTOM_AGENT_PROVIDER=1`. |
 | `eval gate` | `get_eval_gate` | Equivalent | - | MCP returns the same eval gate report data. |
 | `eval history` | `get_eval_history` | Equivalent | - | MCP returns filtered eval telemetry rows in a standard envelope. |
+| `eval compare` | `compare_eval_runs` | Equivalent | - | MCP returns the same local `results.json` comparison and PR-ready Markdown while scoping paths under the server working directory. |
 | `trace inspect` | `inspect_tool_trace` | Equivalent | - | MCP returns the same trace rows, parse warnings, and summary while scoping local paths under the server working directory. |
 | `trace summarize` | `summarize_tool_trace` | SafetyGated | - | MCP returns the same summary data; Markdown report writes require `DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1`. |
 | `trace redact` | `redact_tool_trace` | SafetyGated | - | MCP safe-sharing redaction writes require `DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1`. |

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -1,6 +1,6 @@
 # Tools Quick Reference
 
-One-page cheatsheet for all 52 dbt-nova MCP tools.
+One-page cheatsheet for all 53 dbt-nova MCP tools.
 
 ## Discovery
 
@@ -68,6 +68,7 @@ One-page cheatsheet for all 52 dbt-nova MCP tools.
 | `validate_eval_suite` | Validate eval suite YAML/JSON | `suite` |
 | `get_eval_gate` | Latest eval gate report | `suite` |
 | `get_eval_history` | Filtered eval telemetry rows | `suite`, `since` |
+| `compare_eval_runs` | Compare two eval result directories or files | `before`, `after` |
 | `run_eval` | Run deterministic bridge evals against loaded manifest | `suite`, `output_dir`, `telemetry`, `case_ids`, `fail_under` |
 | `init_eval_suite` | Write a starter eval suite | `persona`, `out`, `force` |
 | `run_agent_eval` | Run provider-backed agent evals | `suite`, `provider`, `manifest_path`, `output_dir`, `case_ids`, `timeout_secs`, `fail_under` |

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-This reference lists all 52 MCP tools exposed by dbt‑nova, grouped by category.
+This reference lists all 53 MCP tools exposed by dbt‑nova, grouped by category.
 All tools return the standard envelope described in [Response Format](response-format.md).
 For CLI equivalents and known parity gaps, see
 [MCP/CLI Parity](mcp-cli-parity.md).
@@ -808,6 +808,29 @@ The response `data` includes `suite_name`, the normalized `since` boundary,
 
 ```json
 {"name":"get_eval_history","arguments":{"suite":"analyst-smoke","since":"2026-06-01"}}
+```
+
+### `compare_eval_runs`
+Compare two local eval result directories or `results.json` files and return
+the same before/after data used by `dbt-nova eval compare`.
+
+Required:
+- `before`: baseline result directory or `results.json` path under the MCP
+  server working directory
+- `after`: candidate result directory or `results.json` path under the MCP
+  server working directory
+
+The response `data` uses `eval_comparison.v1` and includes `before`, `after`,
+`delta`, and `markdown`. The Markdown is suitable for PR descriptions. The delta
+includes pass-rate movement, assertion count changes, newly passing/failing
+cases, still-failing cases, added/removed cases, and status changes. For agent
+evals, Nova reads trace artifact paths from each `results.json` and includes
+tool-call counts, duration, response bytes, and token counters when the traces
+exist and contain those fields. Missing trace artifacts are returned as warnings
+instead of tool errors.
+
+```json
+{"name":"compare_eval_runs","arguments":{"before":"out/evals/before","after":"out/evals/after/results.json"}}
 ```
 
 ### `run_eval`

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -27,7 +27,7 @@ flowchart TD
 
 ## Architecture Overview (Detailed)
 
-### Tool Map (52 MCP tools)
+### Tool Map (53 MCP tools)
 
 <div class="diagram-large diagram-vertical" markdown>
 
@@ -87,6 +87,7 @@ flowchart LR
     TR --> T_validate_eval_suite["validate_eval_suite"]
     TR --> T_get_eval_gate["get_eval_gate"]
     TR --> T_get_eval_history["get_eval_history"]
+    TR --> T_compare_eval_runs["compare_eval_runs"]
     TR --> T_run_eval["run_eval"]
     TR --> T_init_eval_suite["init_eval_suite"]
     TR --> T_run_agent_eval["run_agent_eval"]
@@ -194,6 +195,7 @@ Implementation note:
 | `validate_eval_suite` | Eval suite validator + local path policy |
 | `get_eval_gate` | Eval telemetry + gate logic |
 | `get_eval_history` | Eval telemetry |
+| `compare_eval_runs` | Eval results comparison + Markdown renderer |
 | `run_eval` | Eval harness + loaded ManifestSearch |
 | `init_eval_suite` | Eval suite starter writer |
 | `run_agent_eval` | Eval harness + provider process |

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -183,6 +183,12 @@ mkdocs build --strict
 cargo deny check advisories licenses sources
 ```
 
+For ranking, retrieval, skill, or eval experiments, include before/after eval
+evidence where possible. If the change does not improve accuracy, latency,
+maintainability, or agent behavior, record the decision in the
+[Negative Results Log](negative-results.md) instead of letting the lesson vanish
+inside a closed PR.
+
 ## Release Flow Diagram
 
 ```mermaid

--- a/docs/development/negative-results.md
+++ b/docs/development/negative-results.md
@@ -1,0 +1,43 @@
+# Negative Results Log
+
+Use this log for experiments that did not improve Nova accuracy, latency,
+maintainability, or agent behavior. Keep entries short, evidence-first, and
+easy to scan during future ranking, retrieval, skill, and eval work.
+
+Negative results are not failures. They are product evidence: they preserve the
+reason a path was rejected so the project does not spend future time rediscovering
+the same boundary.
+
+## Entry Template
+
+```markdown
+## YYYY-MM-DD - Short Experiment Name
+
+- Hypothesis:
+- Eval suite:
+- Change tested:
+- Result:
+- Decision:
+- Related PR/issue:
+```
+
+Use `dbt-nova eval compare --before <DIR> --after <DIR>` when a before/after
+suite exists, and paste the comparison summary or artifact path into `Result`.
+If no eval suite exists yet, state what evidence was available and whether a new
+eval should be added before revisiting the idea.
+
+## 2026-06-22 - Raw Query Corpus Retrieval Is Not A Planning Source Of Truth
+
+- Hypothesis: A corpus of raw historical queries could be a primary source for
+  Nova's near-term agent-planning and retrieval strategy.
+- Eval suite: Not run; this is a planning guardrail seeded before adding more
+  retrieval or skill complexity.
+- Change tested: Product direction based on raw query-corpus retrieval as a
+  first-class source of truth.
+- Result: Rejected for the near-term plan. Raw queries can contain stale,
+  duplicated, idiosyncratic, or bypassed logic, and they do not reliably encode
+  governed semantic intent.
+- Decision: Prefer curated semantic metadata, `meta.nova` contracts, domain
+  references, explicit eval evidence, and reviewed skills. Treat raw query
+  corpora as optional supporting evidence only after a suite proves value.
+- Related PR/issue: JOE-26

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -293,6 +293,82 @@ When a comparison fails, the assertion message names the changed clause such as
 structured `diff` with missing and unexpected clause entries, and `report.md`
 prints the same diff in compact form.
 
+## Ablation Comparisons
+
+Use ablation comparisons when changing ranking, metadata scoring, packaged
+skills, prompts, provider settings, or trace-budget expectations. The workflow
+is deliberately file-based so it works in local PR review and CI artifacts:
+
+1. Run the unchanged baseline suite into a stable output directory.
+2. Apply the ranking, skill, or metadata change.
+3. Run the same suite into a second output directory.
+4. Compare the two result directories and paste the Markdown into the PR.
+
+Bridge example:
+
+```bash
+dbt-nova eval run \
+  --suite evals/analyst-smoke.yml \
+  --manifest-path target/manifest.json \
+  --output-dir out/evals/before \
+  --json
+
+dbt-nova eval run \
+  --suite evals/analyst-smoke.yml \
+  --manifest-path target/manifest.json \
+  --output-dir out/evals/after \
+  --json
+
+dbt-nova eval compare \
+  --before out/evals/before \
+  --after out/evals/after
+```
+
+Agent example:
+
+```bash
+dbt-nova eval agent run \
+  --suite evals/analyst-agent.yml \
+  --provider opencode \
+  --manifest-path target/manifest.json \
+  --output-dir out/agent-evals/before \
+  --json
+
+dbt-nova eval agent run \
+  --suite evals/analyst-agent.yml \
+  --provider opencode \
+  --manifest-path target/manifest.json \
+  --output-dir out/agent-evals/after \
+  --json
+
+dbt-nova eval compare \
+  --before out/agent-evals/before/results.json \
+  --after out/agent-evals/after/results.json
+```
+
+The comparison emits PR-ready Markdown by default. Pass `--json` to return a
+CLI envelope containing the same `eval_comparison.v1` data plus the rendered
+Markdown:
+
+```bash
+dbt-nova eval compare \
+  --before out/evals/before \
+  --after out/evals/after \
+  --json
+```
+
+The delta includes pass-rate movement, assertion count changes, newly passing
+cases, newly failing cases, still-failing cases, added/removed cases, and
+status changes. For agent evals, Nova reads the trace artifact paths recorded in
+`results.json` and includes tool-call counts, duration, response bytes, and
+token counters when the traces contain them. Missing or moved trace artifacts
+produce warnings in the comparison instead of failing the whole comparison.
+
+Regressions, no-change results, and negative deltas are successful comparison
+outputs. Treat them as evidence for the PR decision. When an experiment does
+not improve accuracy, latency, maintainability, or agent behavior, record the
+lesson in the [negative-results log](../development/negative-results.md).
+
 ## MCP Tool Parity
 
 Eval workflows are available through MCP and `dbt-nova tool call` with the same
@@ -303,6 +379,7 @@ report contracts used by the CLI:
 | `eval validate` | `validate_eval_suite` | Reads suite files under the server working directory. |
 | `eval gate` | `get_eval_gate` | Reads eval telemetry and returns gate report JSON. |
 | `eval history` | `get_eval_history` | Reads eval telemetry and returns filtered rows. |
+| `eval compare` | `compare_eval_runs` | Reads two local result directories or `results.json` files and returns the same comparison Markdown and JSON data. |
 | `eval run` | `run_eval` | Disabled unless `DBT_NOVA_MCP_ENABLE_EVAL_RUN=1`. |
 | `eval init` | `init_eval_suite` | Disabled unless `DBT_NOVA_MCP_ENABLE_EVAL_WRITES=1`. |
 | `eval agent run` | `run_agent_eval` | Disabled unless `DBT_NOVA_MCP_ENABLE_AGENT_EVAL=1`; custom provider commands also require `DBT_NOVA_MCP_ENABLE_CUSTOM_AGENT_PROVIDER=1`. |

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -4,7 +4,7 @@ Use `dbt-nova` in two modes:
 
 - No subcommand: start MCP server (backward compatible behavior)
 - Subcommand: run one-shot CLI commands and exit
-- CLI surface: 24 CLI leaf commands, including `tool call` access to all 52 MCP tools
+- CLI surface: 25 CLI leaf commands, including `tool call` access to all 53 MCP tools
 
 For the command-by-command MCP equivalent map, see
 [MCP/CLI Parity](../api/mcp-cli-parity.md).
@@ -34,6 +34,7 @@ dbt-nova
 ├── eval validate --suite <PATH> [--json]
 ├── eval run --suite <PATH> [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--telemetry] [--telemetry-retention] [--case-id <ID>...] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
 ├── eval agent run --suite <PATH> [--provider] [--provider-command] [--provider-args-json] [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--telemetry] [--telemetry-retention] [--case-id <ID>...] [--timeout-secs] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
+├── eval compare --before <PATH> --after <PATH> [--json]
 ├── eval gate <NAME> [--json]
 ├── eval history --suite <NAME> --since <YYYY-MM-DD>
 └── health check [--manifest-path|--manifest-uri] [--json]

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,8 +105,8 @@ dbt-nova
 
 | Feature | Description |
 |---------|-------------|
-| **52 MCP Tools** | Server-exposed MCP surface for search, lineage, coverage, scoring, SQL execution, reports, evals, trace review, cache warming, config, storage, and recipes |
-| **24 CLI Leaf Commands** | One-shot commands for server startup, manifest lifecycle, audits, config, storage, evals, trace review, health, and tool calls |
+| **53 MCP Tools** | Server-exposed MCP surface for search, lineage, coverage, scoring, SQL execution, reports, evals, trace review, cache warming, config, storage, and recipes |
+| **25 CLI Leaf Commands** | One-shot commands for server startup, manifest lifecycle, audits, config, storage, evals, trace review, health, and tool calls |
 | **Hybrid Search** | Tantivy BM25 + vector + sparse + reranking |
 | **Multi-Source** | Local files, HTTP, S3, GCS, DBFS |
 | **Personas** | Analyst, Engineer, Governance profiles |

--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -37,9 +37,10 @@ outside the selected project, but callers still control which in-scope project
 files are scanned.
 
 Eval MCP tools also use the server filesystem. `validate_eval_suite`,
-`get_eval_gate`, and `get_eval_history` are read/reporting tools. `run_eval`,
-`init_eval_suite`, and `run_agent_eval` are disabled by default and return
-structured invalid-parameter errors until the operator opts in:
+`get_eval_gate`, `get_eval_history`, and `compare_eval_runs` are read/reporting
+tools. `run_eval`, `init_eval_suite`, and `run_agent_eval` are disabled by
+default and return structured invalid-parameter errors until the operator opts
+in:
 
 - `DBT_NOVA_MCP_ENABLE_EVAL_RUN=1` for bridge eval execution.
 - `DBT_NOVA_MCP_ENABLE_EVAL_WRITES=1` for starter suite file writes.

--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -54,6 +54,12 @@ rows when comparing whether metadata or prompt changes improved a suite over
 time. Add `--telemetry-retention <ROWS>` to keep only the newest rows for that
 suite after each run.
 
+For PR evidence on ranking, skill, or metadata changes, run the same suite into
+two output directories and compare them with
+`dbt-nova eval compare --before <DIR> --after <DIR>`. The comparison prints
+Markdown with pass-rate movement, newly passing/failing cases, and agent
+tool-call or token deltas when trace artifacts are available.
+
 When a suite declares `gate.threshold`, run the full suite with `--telemetry`
 and then run `dbt-nova eval gate <NAME> --json`. Configured gates reject latest
 telemetry from stale suite files, filtered `--case-id` runs, or row-retention

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
     - Testing: operations/testing.md
   - Development:
     - Architecture: development/architecture.md
+    - Negative Results Log: development/negative-results.md
     - Agent Tokenomics Plan: development/agent-tokenomics-plan.md
     - CI & Automation: development/ci.md
     - Release: development/release.md

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -440,6 +440,8 @@ pub enum EvalCommand {
     Run(EvalRunArgs),
     /// Run provider-backed agent evals and score observed Nova tool use.
     Agent(EvalAgentArgs),
+    /// Compare two eval result directories or results.json files.
+    Compare(EvalCompareArgs),
     /// Report readiness from the latest eval telemetry for a suite.
     Gate(EvalGateArgs),
     /// Print filtered JSONL eval telemetry history.
@@ -640,6 +642,24 @@ pub struct EvalAgentRunArgs {
 }
 
 #[derive(Debug, Clone, Args, Default)]
+pub struct EvalCompareArgs {
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Before eval result directory or results.json path"
+    )]
+    pub before: String,
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "After eval result directory or results.json path"
+    )]
+    pub after: String,
+    #[arg(long, default_value_t = false, help = "Emit a JSON CLI envelope")]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Args, Default)]
 pub struct EvalHistoryArgs {
     #[arg(
         long,
@@ -817,6 +837,31 @@ mod tests {
                     }
                 },
                 _ => panic!("expected eval agent run"),
+            },
+            _ => panic!("expected eval command"),
+        }
+    }
+
+    #[test]
+    fn eval_compare_parses_result_paths_and_json() {
+        let cli = Cli::parse_from([
+            "dbt-nova",
+            "eval",
+            "compare",
+            "--before",
+            ".nova/eval-runs/before",
+            "--after",
+            ".nova/eval-runs/after/results.json",
+            "--json",
+        ]);
+        match cli.command.expect("command") {
+            Command::Eval(eval) => match eval.command {
+                EvalCommand::Compare(args) => {
+                    assert_eq!(args.before, ".nova/eval-runs/before");
+                    assert_eq!(args.after, ".nova/eval-runs/after/results.json");
+                    assert!(args.json);
+                }
+                _ => panic!("expected eval compare"),
             },
             _ => panic!("expected eval command"),
         }

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -12,8 +12,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
 
 use crate::cli::args::{
-    EvalAgentRunArgs, EvalGateArgs, EvalHistoryArgs, EvalInitArgs, EvalRunArgs, EvalValidateArgs,
-    ManifestLoadArgs,
+    EvalAgentRunArgs, EvalCompareArgs, EvalGateArgs, EvalHistoryArgs, EvalInitArgs, EvalRunArgs,
+    EvalValidateArgs, ManifestLoadArgs,
 };
 use crate::cli::manifest::{build_manifest_load_config, execute_manifest_load};
 use crate::cli::output::{CliEnvelope, error_envelope};
@@ -21,8 +21,8 @@ use crate::cli::{DispatchError, DispatchResult};
 use crate::error::DbtNovaError;
 use crate::manifest::ManifestSearch;
 use crate::params::{
-    GetEvalGateParams, GetEvalHistoryParams, InitEvalSuiteParams, RunAgentEvalParams,
-    RunEvalParams, ValidateEvalSuiteParams,
+    CompareEvalRunsParams, GetEvalGateParams, GetEvalHistoryParams, InitEvalSuiteParams,
+    RunAgentEvalParams, RunEvalParams, ValidateEvalSuiteParams,
 };
 use crate::responses::SuccessResponse;
 use crate::utils::sql_structure::{
@@ -538,6 +538,101 @@ struct EvalHistoryPayload {
     safety_policy: EvalMcpSafetyPolicy,
 }
 
+#[derive(Debug, Serialize)]
+struct EvalComparisonReport {
+    schema_version: &'static str,
+    before: EvalComparisonRunSummary,
+    after: EvalComparisonRunSummary,
+    delta: EvalComparisonDelta,
+    markdown: String,
+}
+
+#[derive(Debug, Serialize)]
+struct EvalComparisonRunSummary {
+    results_path: String,
+    suite_name: String,
+    mode: String,
+    output_dir: String,
+    gate_status: String,
+    case_count: usize,
+    assertion_count: usize,
+    pass_count: usize,
+    fail_count: usize,
+    error_count: usize,
+    pass_rate: f64,
+    passing_cases: Vec<String>,
+    failing_cases: Vec<String>,
+    case_statuses: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "EvalComparisonMetrics::is_empty")]
+    metrics: EvalComparisonMetrics,
+    trace_case_count: usize,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+struct EvalComparisonMetrics {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_call_count: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    distinct_tool_count: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    total_response_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    duration_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    input_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    total_tokens: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct EvalComparisonDelta {
+    suite_name_changed: bool,
+    mode_changed: bool,
+    pass_rate: f64,
+    pass_rate_percentage_points: f64,
+    case_count: i64,
+    assertion_count: i64,
+    pass_count: i64,
+    fail_count: i64,
+    error_count: i64,
+    #[serde(skip_serializing_if = "EvalComparisonMetricDeltas::is_empty")]
+    metrics: EvalComparisonMetricDeltas,
+    newly_passing_cases: Vec<String>,
+    newly_failing_cases: Vec<String>,
+    unchanged_failing_cases: Vec<String>,
+    added_cases: Vec<String>,
+    removed_cases: Vec<String>,
+    changed_cases: Vec<EvalCaseStatusDelta>,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct EvalComparisonMetricDeltas {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_call_count: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    distinct_tool_count: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    total_response_bytes: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    duration_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    input_tokens: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_tokens: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    total_tokens: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+struct EvalCaseStatusDelta {
+    id: String,
+    before: Option<String>,
+    after: Option<String>,
+}
+
 #[derive(Debug, Clone, Default)]
 struct EvalCardRunContext {
     suite_path: Option<String>,
@@ -682,6 +777,26 @@ pub fn run_history_command(args: &EvalHistoryArgs) -> DispatchResult {
     Ok(())
 }
 
+/// Compares two eval result directories or results.json files.
+///
+/// # Errors
+/// Returns an error when either input cannot be resolved, read, or parsed.
+pub fn run_compare_command(args: &EvalCompareArgs) -> DispatchResult {
+    let started = Instant::now();
+    let before = resolve_eval_results_path(&args.before, "before")?;
+    let after = resolve_eval_results_path(&args.after, "after")?;
+    let report = build_eval_comparison_report(&before, &after, None)?;
+    if args.json {
+        let envelope = CliEnvelope::success("eval compare", &report, started.elapsed().as_millis());
+        let out = serde_json::to_string_pretty(&envelope)
+            .map_err(|error| server_error(error.to_string()))?;
+        println!("{out}");
+    } else {
+        print!("{}", report.markdown);
+    }
+    Ok(())
+}
+
 /// Builds the MCP/CLI-tool response for eval suite validation.
 ///
 /// # Errors
@@ -727,6 +842,23 @@ pub fn build_eval_history_tool_response(
         safety_policy: eval_mcp_safety_policy()?,
     };
     success_value(payload, row_count)
+}
+
+/// Builds the MCP/CLI-tool response for eval result comparison.
+///
+/// # Errors
+/// Returns an error when either results path is unsafe, unreadable, or invalid.
+pub fn build_eval_compare_tool_response(
+    params: &CompareEvalRunsParams,
+) -> crate::error::Result<JsonValue> {
+    let root = mcp_eval_filesystem_root()?;
+    let before = resolve_mcp_eval_results_path(&params.before, "before")?;
+    let after = resolve_mcp_eval_results_path(&params.after, "after")?;
+    let report = build_eval_comparison_report(&before, &after, Some(&root))?;
+    let payload = with_eval_safety_policy(serde_json::to_value(report).map_err(|error| {
+        DbtNovaError::ServerError(format!("failed to serialize eval comparison: {error}"))
+    })?)?;
+    success_value(payload, 1)
 }
 
 /// Builds the MCP/CLI-tool response for deterministic bridge eval execution.
@@ -2864,6 +2996,754 @@ fn write_report_artifacts(
         tracing::warn!(error = %error, suite_path, "failed to copy eval suite");
     }
     Ok(())
+}
+
+fn resolve_eval_results_path(raw_path: &str, label: &str) -> crate::error::Result<PathBuf> {
+    let trimmed = raw_path.trim();
+    if trimmed.is_empty() {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "{label} must not be empty"
+        )));
+    }
+    resolve_eval_results_candidate(&PathBuf::from(trimmed), label)
+}
+
+fn resolve_mcp_eval_results_path(raw_path: &str, label: &str) -> crate::error::Result<PathBuf> {
+    let (root, candidate) = mcp_eval_candidate_path(raw_path, label)?;
+    let results_path = resolve_eval_results_candidate(&candidate, label)?;
+    ensure_mcp_eval_path_under_root(&results_path, &root, label)?;
+    Ok(results_path)
+}
+
+fn resolve_eval_results_candidate(candidate: &Path, label: &str) -> crate::error::Result<PathBuf> {
+    let results_path = if candidate.is_dir() {
+        candidate.join("results.json")
+    } else {
+        candidate.to_path_buf()
+    };
+    if !results_path.exists() {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "{label} eval results '{}' do not exist; pass a result directory or results.json path",
+            results_path.display()
+        )));
+    }
+    let canonical = results_path.canonicalize().map_err(|error| {
+        DbtNovaError::InvalidParams(format!(
+            "failed to resolve {label} eval results '{}': {error}",
+            results_path.display()
+        ))
+    })?;
+    if !canonical.is_file() {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "{label} eval results '{}' is not a file",
+            canonical.display()
+        )));
+    }
+    Ok(canonical)
+}
+
+fn build_eval_comparison_report(
+    before_results: &Path,
+    after_results: &Path,
+    trace_root: Option<&Path>,
+) -> crate::error::Result<EvalComparisonReport> {
+    let before_json = read_eval_results_json(before_results)?;
+    let after_json = read_eval_results_json(after_results)?;
+    let before = summarize_eval_results(&before_json, before_results, trace_root)?;
+    let after = summarize_eval_results(&after_json, after_results, trace_root)?;
+    let delta = compare_eval_summaries(&before, &after);
+    let mut report = EvalComparisonReport {
+        schema_version: "eval_comparison.v1",
+        before,
+        after,
+        delta,
+        markdown: String::new(),
+    };
+    report.markdown = render_eval_comparison_markdown(&report);
+    Ok(report)
+}
+
+fn read_eval_results_json(path: &Path) -> crate::error::Result<JsonValue> {
+    let raw = fs::read_to_string(path).map_err(|error| {
+        DbtNovaError::ServerError(format!(
+            "failed to read eval results '{}': {error}",
+            path.display()
+        ))
+    })?;
+    serde_json::from_str(&raw).map_err(|error| {
+        DbtNovaError::InvalidParams(format!(
+            "failed to parse eval results '{}': {error}",
+            path.display()
+        ))
+    })
+}
+
+fn summarize_eval_results(
+    report: &JsonValue,
+    results_path: &Path,
+    trace_root: Option<&Path>,
+) -> crate::error::Result<EvalComparisonRunSummary> {
+    let results_dir = results_path.parent().unwrap_or_else(|| Path::new("."));
+    let suite_name = required_json_string(report, "suite_name")?;
+    let mode = required_json_string(report, "mode")?;
+    let output_dir = optional_json_string(report, "output_dir")
+        .unwrap_or_else(|| results_dir.display().to_string());
+    let gate_status =
+        optional_json_string(report, "gate_status").unwrap_or_else(|| "unknown".to_string());
+    let cases = report
+        .get("cases")
+        .and_then(JsonValue::as_array)
+        .ok_or_else(|| DbtNovaError::InvalidParams("eval results missing cases[]".to_string()))?;
+
+    let mut pass_count_sum = 0usize;
+    let mut fail_count_sum = 0usize;
+    let mut error_count_sum = 0usize;
+    let mut case_statuses = BTreeMap::new();
+    let mut passing_cases = Vec::new();
+    let mut failing_cases = Vec::new();
+    let mut metrics = EvalComparisonMetrics::default();
+    let mut distinct_tools = BTreeSet::new();
+    let mut trace_case_count = 0usize;
+    let mut warnings = Vec::new();
+
+    for (index, case) in cases.iter().enumerate() {
+        let id = case
+            .get("id")
+            .and_then(JsonValue::as_str)
+            .map_or_else(|| format!("case_{}", index + 1), str::to_string);
+        let pass_count = json_usize_or_else(case, "pass_count", || {
+            count_assertions_with_status(case, "pass")
+        });
+        let fail_count = json_usize_or_else(case, "fail_count", || {
+            count_assertions_with_status(case, "fail")
+        });
+        let error_count = json_usize_or_else(case, "error_count", || {
+            count_assertions_with_status(case, "error")
+        });
+        pass_count_sum = pass_count_sum.saturating_add(pass_count);
+        fail_count_sum = fail_count_sum.saturating_add(fail_count);
+        error_count_sum = error_count_sum.saturating_add(error_count);
+
+        let status = case_status(pass_count, fail_count, error_count);
+        if status == "pass" {
+            passing_cases.push(id.clone());
+        } else {
+            failing_cases.push(id.clone());
+        }
+        case_statuses.insert(id.clone(), status);
+
+        if let Some(trace) = read_case_trace_metrics(case, results_dir, trace_root, &mut warnings) {
+            trace_case_count += 1;
+            metrics.add_trace(&trace.metrics);
+            distinct_tools.extend(trace.distinct_tools);
+        }
+    }
+
+    if !distinct_tools.is_empty() {
+        metrics.distinct_tool_count = Some(usize_to_u64(distinct_tools.len()));
+    }
+
+    let pass_count = json_usize_or(report, "pass_count", pass_count_sum);
+    let fail_count = json_usize_or(report, "fail_count", fail_count_sum);
+    let error_count = json_usize_or(report, "error_count", error_count_sum);
+    let assertion_count = json_usize_or(
+        report,
+        "assertion_count",
+        pass_count
+            .saturating_add(fail_count)
+            .saturating_add(error_count),
+    );
+    let pass_rate = optional_json_f64(report, "pass_rate").unwrap_or_else(|| {
+        if assertion_count == 0 {
+            0.0
+        } else {
+            ratio(pass_count, assertion_count)
+        }
+    });
+
+    Ok(EvalComparisonRunSummary {
+        results_path: results_path.display().to_string(),
+        suite_name,
+        mode,
+        output_dir,
+        gate_status,
+        case_count: cases.len(),
+        assertion_count,
+        pass_count,
+        fail_count,
+        error_count,
+        pass_rate,
+        passing_cases,
+        failing_cases,
+        case_statuses,
+        metrics,
+        trace_case_count,
+        warnings,
+    })
+}
+
+fn read_case_trace_metrics(
+    case: &JsonValue,
+    results_dir: &Path,
+    trace_root: Option<&Path>,
+    warnings: &mut Vec<String>,
+) -> Option<EvalComparisonCaseTrace> {
+    let case_id = case
+        .get("id")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("unknown");
+    let trace_path = case
+        .get("artifacts")
+        .and_then(|artifacts| artifacts.get("tool_trace"))
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|path| !path.is_empty())?;
+    let resolved = resolve_case_trace_path(trace_path, results_dir, trace_root, warnings)?;
+    let read = read_tool_trace_file(&resolved);
+    if read.missing {
+        warnings.push(format!(
+            "case '{case_id}' trace artifact '{}' was not found",
+            resolved.display()
+        ));
+        return None;
+    }
+    if let Some(error) = read.read_error.as_ref() {
+        warnings.push(format!(
+            "case '{case_id}' trace artifact read failed: {error}"
+        ));
+        return None;
+    }
+    if !read.parse_warnings.is_empty() {
+        warnings.push(format!(
+            "case '{case_id}' trace artifact had {} malformed row(s)",
+            read.parse_warnings.len()
+        ));
+    }
+    let telemetry = eval_case_telemetry_from_trace(&read.rows);
+    let mut distinct_tools = BTreeSet::new();
+    for row in &read.rows {
+        if let Some(tool) = row.get("tool").and_then(JsonValue::as_str) {
+            distinct_tools.insert(tool.to_string());
+        }
+    }
+    Some(EvalComparisonCaseTrace {
+        metrics: EvalComparisonMetrics {
+            tool_call_count: Some(usize_to_u64(telemetry.tool_call_count)),
+            distinct_tool_count: Some(usize_to_u64(telemetry.distinct_tool_count)),
+            total_response_bytes: telemetry.total_response_bytes,
+            duration_ms: sum_json_u64_field(&read.rows, "duration_ms"),
+            input_tokens: telemetry.input_tokens,
+            output_tokens: telemetry.output_tokens,
+            total_tokens: telemetry.total_tokens,
+        },
+        distinct_tools,
+    })
+}
+
+fn resolve_case_trace_path(
+    raw_path: &str,
+    results_dir: &Path,
+    trace_root: Option<&Path>,
+    warnings: &mut Vec<String>,
+) -> Option<PathBuf> {
+    let mut blocked_paths = Vec::new();
+    for candidate in trace_path_candidates(raw_path, results_dir) {
+        if !candidate.exists() || !candidate.is_file() {
+            continue;
+        }
+        let Ok(canonical) = candidate.canonicalize() else {
+            continue;
+        };
+        if let Some(root) = trace_root
+            && let Err(error) = ensure_mcp_eval_path_under_root(&canonical, root, "tool_trace")
+        {
+            blocked_paths.push(format!("{} ({error})", canonical.display()));
+            continue;
+        }
+        return Some(canonical);
+    }
+    if blocked_paths.is_empty() {
+        warnings.push(format!(
+            "trace artifact '{raw_path}' was referenced but could not be resolved"
+        ));
+    } else {
+        warnings.push(format!(
+            "trace artifact path was skipped by MCP path policy: {}",
+            blocked_paths.join(", ")
+        ));
+    }
+    None
+}
+
+fn trace_path_candidates(raw_path: &str, results_dir: &Path) -> BTreeSet<PathBuf> {
+    let mut candidates = BTreeSet::new();
+    let path = PathBuf::from(raw_path);
+    candidates.insert(path.clone());
+    if path.is_absolute() {
+        return candidates;
+    }
+    candidates.insert(results_dir.join(&path));
+    if let Some(file_name) = path.file_name() {
+        candidates.insert(results_dir.join("tool-calls").join(file_name));
+    }
+    if let Some(results_dir_name) = results_dir.file_name()
+        && let Some(stripped) = strip_first_component(&path, results_dir_name)
+    {
+        candidates.insert(results_dir.join(stripped));
+    }
+    candidates
+}
+
+fn strip_first_component(path: &Path, expected: &std::ffi::OsStr) -> Option<PathBuf> {
+    let mut components = path.components();
+    match components.next()? {
+        Component::Normal(first) if first == expected => {}
+        _ => return None,
+    }
+    let mut stripped = PathBuf::new();
+    for component in components {
+        stripped.push(component.as_os_str());
+    }
+    (!stripped.as_os_str().is_empty()).then_some(stripped)
+}
+
+fn compare_eval_summaries(
+    before: &EvalComparisonRunSummary,
+    after: &EvalComparisonRunSummary,
+) -> EvalComparisonDelta {
+    let mut newly_passing_cases = Vec::new();
+    let mut newly_failing_cases = Vec::new();
+    let mut unchanged_failing_cases = Vec::new();
+    let mut added_cases = Vec::new();
+    let mut removed_cases = Vec::new();
+    let mut changed_cases = Vec::new();
+    let case_ids = before
+        .case_statuses
+        .keys()
+        .chain(after.case_statuses.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    for id in case_ids {
+        let before_status = before.case_statuses.get(&id).cloned();
+        let after_status = after.case_statuses.get(&id).cloned();
+        if before_status != after_status {
+            changed_cases.push(EvalCaseStatusDelta {
+                id: id.clone(),
+                before: before_status.clone(),
+                after: after_status.clone(),
+            });
+        }
+        match (before_status.as_deref(), after_status.as_deref()) {
+            (None, Some(status)) => {
+                added_cases.push(id.clone());
+                if status == "pass" {
+                    newly_passing_cases.push(id);
+                } else {
+                    newly_failing_cases.push(id);
+                }
+            }
+            (Some(_), None) => removed_cases.push(id),
+            (Some(before_status), Some("pass")) if before_status != "pass" => {
+                newly_passing_cases.push(id);
+            }
+            (Some("pass"), Some(after_status)) if after_status != "pass" => {
+                newly_failing_cases.push(id);
+            }
+            (Some(status), Some(_)) if status != "pass" => unchanged_failing_cases.push(id),
+            _ => {}
+        }
+    }
+
+    EvalComparisonDelta {
+        suite_name_changed: before.suite_name != after.suite_name,
+        mode_changed: before.mode != after.mode,
+        pass_rate: after.pass_rate - before.pass_rate,
+        pass_rate_percentage_points: (after.pass_rate - before.pass_rate) * 100.0,
+        case_count: usize_delta(after.case_count, before.case_count),
+        assertion_count: usize_delta(after.assertion_count, before.assertion_count),
+        pass_count: usize_delta(after.pass_count, before.pass_count),
+        fail_count: usize_delta(after.fail_count, before.fail_count),
+        error_count: usize_delta(after.error_count, before.error_count),
+        metrics: EvalComparisonMetricDeltas::between(&before.metrics, &after.metrics),
+        newly_passing_cases,
+        newly_failing_cases,
+        unchanged_failing_cases,
+        added_cases,
+        removed_cases,
+        changed_cases,
+    }
+}
+
+fn render_eval_comparison_markdown(report: &EvalComparisonReport) -> String {
+    let mut out = String::new();
+    out.push_str("# Nova Eval Comparison\n\n");
+    out.push_str("## Summary\n\n");
+    let _ = writeln!(
+        out,
+        "- Suite: `{}` -> `{}`",
+        report.before.suite_name, report.after.suite_name
+    );
+    let _ = writeln!(
+        out,
+        "- Mode: `{}` -> `{}`",
+        report.before.mode, report.after.mode
+    );
+    let _ = writeln!(
+        out,
+        "- Results: `{}` -> `{}`",
+        report.before.results_path, report.after.results_path
+    );
+    out.push('\n');
+    out.push_str("| Metric | Before | After | Delta |\n");
+    out.push_str("|---|---:|---:|---:|\n");
+    let _ = writeln!(
+        out,
+        "| Pass rate | {} | {} | {} |",
+        format_percent(report.before.pass_rate),
+        format_percent(report.after.pass_rate),
+        format_signed_percentage_points(report.delta.pass_rate_percentage_points)
+    );
+    let _ = writeln!(
+        out,
+        "| Cases | {} | {} | {} |",
+        report.before.case_count,
+        report.after.case_count,
+        format_signed_i64(report.delta.case_count)
+    );
+    let _ = writeln!(
+        out,
+        "| Assertions | {} | {} | {} |",
+        report.before.assertion_count,
+        report.after.assertion_count,
+        format_signed_i64(report.delta.assertion_count)
+    );
+    let _ = writeln!(
+        out,
+        "| Passed assertions | {} | {} | {} |",
+        report.before.pass_count,
+        report.after.pass_count,
+        format_signed_i64(report.delta.pass_count)
+    );
+    let _ = writeln!(
+        out,
+        "| Failed assertions | {} | {} | {} |",
+        report.before.fail_count,
+        report.after.fail_count,
+        format_signed_i64(report.delta.fail_count)
+    );
+    let _ = writeln!(
+        out,
+        "| Error assertions | {} | {} | {} |",
+        report.before.error_count,
+        report.after.error_count,
+        format_signed_i64(report.delta.error_count)
+    );
+    render_metric_row(
+        &mut out,
+        "Tool calls",
+        report.before.metrics.tool_call_count,
+        report.after.metrics.tool_call_count,
+        report.delta.metrics.tool_call_count,
+    );
+    render_metric_row(
+        &mut out,
+        "Duration ms",
+        report.before.metrics.duration_ms,
+        report.after.metrics.duration_ms,
+        report.delta.metrics.duration_ms,
+    );
+    render_metric_row(
+        &mut out,
+        "Input tokens",
+        report.before.metrics.input_tokens,
+        report.after.metrics.input_tokens,
+        report.delta.metrics.input_tokens,
+    );
+    render_metric_row(
+        &mut out,
+        "Output tokens",
+        report.before.metrics.output_tokens,
+        report.after.metrics.output_tokens,
+        report.delta.metrics.output_tokens,
+    );
+    render_metric_row(
+        &mut out,
+        "Total tokens",
+        report.before.metrics.total_tokens,
+        report.after.metrics.total_tokens,
+        report.delta.metrics.total_tokens,
+    );
+    render_metric_row(
+        &mut out,
+        "Response bytes",
+        report.before.metrics.total_response_bytes,
+        report.after.metrics.total_response_bytes,
+        report.delta.metrics.total_response_bytes,
+    );
+
+    out.push_str("\n## Case Changes\n\n");
+    render_case_list(&mut out, "Newly passing", &report.delta.newly_passing_cases);
+    render_case_list(&mut out, "Newly failing", &report.delta.newly_failing_cases);
+    render_case_list(
+        &mut out,
+        "Still failing",
+        &report.delta.unchanged_failing_cases,
+    );
+    render_case_list(&mut out, "Added", &report.delta.added_cases);
+    render_case_list(&mut out, "Removed", &report.delta.removed_cases);
+    if report.delta.changed_cases.is_empty() {
+        out.push_str("- Status changes: None.\n");
+    } else {
+        out.push_str("- Status changes:\n");
+        for change in &report.delta.changed_cases {
+            let before = change.before.as_deref().unwrap_or("missing");
+            let after = change.after.as_deref().unwrap_or("missing");
+            let _ = writeln!(out, "  - `{}`: `{}` -> `{}`", change.id, before, after);
+        }
+    }
+
+    out.push_str("\n## Notes\n\n");
+    if report.delta.suite_name_changed {
+        out.push_str("- Suite names differ; confirm this is an intentional comparison.\n");
+    }
+    if report.delta.mode_changed {
+        out.push_str("- Eval modes differ; compare bridge and agent runs carefully.\n");
+    }
+    if report.delta.pass_rate == 0.0
+        && report.delta.newly_passing_cases.is_empty()
+        && report.delta.newly_failing_cases.is_empty()
+        && report.delta.changed_cases.is_empty()
+    {
+        out.push_str("- No pass-rate or case-status change was observed.\n");
+    }
+    if report.before.trace_case_count == 0 && report.after.trace_case_count == 0 {
+        out.push_str("- No agent trace artifacts were available, so tool-call and token deltas are omitted.\n");
+    }
+    render_warning_list(&mut out, "Before warnings", &report.before.warnings);
+    render_warning_list(&mut out, "After warnings", &report.after.warnings);
+    out
+}
+
+fn render_metric_row(
+    out: &mut String,
+    label: &str,
+    before: Option<u64>,
+    after: Option<u64>,
+    delta: Option<i64>,
+) {
+    if before.is_none() && after.is_none() {
+        return;
+    }
+    let _ = writeln!(
+        out,
+        "| {label} | {} | {} | {} |",
+        format_optional_u64(before),
+        format_optional_u64(after),
+        delta.map_or_else(|| "n/a".to_string(), format_signed_i64)
+    );
+}
+
+fn render_case_list(out: &mut String, label: &str, cases: &[String]) {
+    if cases.is_empty() {
+        let _ = writeln!(out, "- {label}: None.");
+    } else {
+        let _ = writeln!(out, "- {label}: {}", backtick_join(cases));
+    }
+}
+
+fn render_warning_list(out: &mut String, label: &str, warnings: &[String]) {
+    if warnings.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "- {label}:");
+    for warning in warnings {
+        let _ = writeln!(out, "  - {warning}");
+    }
+}
+
+fn backtick_join(values: &[String]) -> String {
+    values
+        .iter()
+        .map(|value| format!("`{value}`"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn format_percent(value: f64) -> String {
+    format!("{:.1}%", value * 100.0)
+}
+
+fn format_signed_percentage_points(value: f64) -> String {
+    if value >= 0.0 {
+        format!("+{value:.1} pp")
+    } else {
+        format!("{value:.1} pp")
+    }
+}
+
+fn format_signed_i64(value: i64) -> String {
+    if value >= 0 {
+        format!("+{value}")
+    } else {
+        value.to_string()
+    }
+}
+
+fn format_optional_u64(value: Option<u64>) -> String {
+    value.map_or_else(|| "n/a".to_string(), |value| value.to_string())
+}
+
+fn required_json_string(value: &JsonValue, field: &str) -> crate::error::Result<String> {
+    value
+        .get(field)
+        .and_then(JsonValue::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| DbtNovaError::InvalidParams(format!("eval results missing {field}")))
+}
+
+fn optional_json_string(value: &JsonValue, field: &str) -> Option<String> {
+    value
+        .get(field)
+        .and_then(JsonValue::as_str)
+        .map(str::to_string)
+}
+
+fn optional_json_f64(value: &JsonValue, field: &str) -> Option<f64> {
+    value.get(field).and_then(JsonValue::as_f64)
+}
+
+fn json_usize_or(value: &JsonValue, field: &str, default: usize) -> usize {
+    json_usize(value, field).unwrap_or(default)
+}
+
+fn json_usize_or_else(value: &JsonValue, field: &str, default: impl FnOnce() -> usize) -> usize {
+    json_usize(value, field).unwrap_or_else(default)
+}
+
+fn json_usize(value: &JsonValue, field: &str) -> Option<usize> {
+    value
+        .get(field)
+        .and_then(JsonValue::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+}
+
+fn count_assertions_with_status(case: &JsonValue, status: &str) -> usize {
+    case.get("assertions")
+        .and_then(JsonValue::as_array)
+        .map_or(0, |assertions| {
+            assertions
+                .iter()
+                .filter(|assertion| {
+                    assertion.get("status").and_then(JsonValue::as_str) == Some(status)
+                })
+                .count()
+        })
+}
+
+fn case_status(pass_count: usize, fail_count: usize, error_count: usize) -> String {
+    if error_count > 0 {
+        "error"
+    } else if fail_count > 0 {
+        "fail"
+    } else if pass_count > 0 {
+        "pass"
+    } else {
+        "empty"
+    }
+    .to_string()
+}
+
+fn sum_json_u64_field(rows: &[JsonValue], field: &str) -> Option<u64> {
+    let mut seen = false;
+    let mut total = 0_u64;
+    for row in rows {
+        if let Some(value) = row.get(field).and_then(JsonValue::as_u64) {
+            seen = true;
+            total = total.saturating_add(value);
+        }
+    }
+    seen.then_some(total)
+}
+
+fn usize_to_u64(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
+}
+
+fn usize_delta(after: usize, before: usize) -> i64 {
+    u64_delta(usize_to_u64(after), usize_to_u64(before))
+}
+
+fn optional_u64_delta(after: Option<u64>, before: Option<u64>) -> Option<i64> {
+    Some(u64_delta(after?, before?))
+}
+
+fn u64_delta(after: u64, before: u64) -> i64 {
+    let after = i64::try_from(after).unwrap_or(i64::MAX);
+    let before = i64::try_from(before).unwrap_or(i64::MAX);
+    after.saturating_sub(before)
+}
+
+impl EvalComparisonMetrics {
+    fn is_empty(&self) -> bool {
+        self.tool_call_count.is_none()
+            && self.distinct_tool_count.is_none()
+            && self.total_response_bytes.is_none()
+            && self.duration_ms.is_none()
+            && self.input_tokens.is_none()
+            && self.output_tokens.is_none()
+            && self.total_tokens.is_none()
+    }
+
+    fn add_trace(&mut self, metrics: &Self) {
+        add_optional_u64(&mut self.tool_call_count, metrics.tool_call_count);
+        add_optional_u64(&mut self.total_response_bytes, metrics.total_response_bytes);
+        add_optional_u64(&mut self.duration_ms, metrics.duration_ms);
+        add_optional_u64(&mut self.input_tokens, metrics.input_tokens);
+        add_optional_u64(&mut self.output_tokens, metrics.output_tokens);
+        add_optional_u64(&mut self.total_tokens, metrics.total_tokens);
+    }
+}
+
+impl EvalComparisonMetricDeltas {
+    fn between(before: &EvalComparisonMetrics, after: &EvalComparisonMetrics) -> Self {
+        Self {
+            tool_call_count: optional_u64_delta(after.tool_call_count, before.tool_call_count),
+            distinct_tool_count: optional_u64_delta(
+                after.distinct_tool_count,
+                before.distinct_tool_count,
+            ),
+            total_response_bytes: optional_u64_delta(
+                after.total_response_bytes,
+                before.total_response_bytes,
+            ),
+            duration_ms: optional_u64_delta(after.duration_ms, before.duration_ms),
+            input_tokens: optional_u64_delta(after.input_tokens, before.input_tokens),
+            output_tokens: optional_u64_delta(after.output_tokens, before.output_tokens),
+            total_tokens: optional_u64_delta(after.total_tokens, before.total_tokens),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.tool_call_count.is_none()
+            && self.distinct_tool_count.is_none()
+            && self.total_response_bytes.is_none()
+            && self.duration_ms.is_none()
+            && self.input_tokens.is_none()
+            && self.output_tokens.is_none()
+            && self.total_tokens.is_none()
+    }
+}
+
+struct EvalComparisonCaseTrace {
+    metrics: EvalComparisonMetrics,
+    distinct_tools: BTreeSet<String>,
+}
+
+fn add_optional_u64(target: &mut Option<u64>, value: Option<u64>) {
+    if let Some(value) = value {
+        *target = Some(target.unwrap_or(0).saturating_add(value));
+    }
 }
 
 fn read_telemetry_rows_for_suite(suite_name: &str) -> crate::error::Result<Vec<JsonValue>> {

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -8,22 +8,22 @@ use super::{
     AgentCalledWith, AgentEntityRank, AgentExpected, AgentOrder, AgentSqlStructureExpected,
     AssertionResult, DateAnchor, EvalCardProvider, EvalCardRunContext, EvalCaseReport,
     EvalDefaults, EvalRunArgs, EvalSuite, EvalValidateArgs, FinalAnswerExpected, agent_prompt,
-    apply_telemetry_retention, build_agent_eval_tool_response, build_eval_gate_report,
-    build_eval_gate_tool_response, build_eval_history_tool_response, build_eval_init_tool_response,
-    build_eval_validate_payload, build_eval_validate_tool_response, build_report,
-    contains_rank_assertion, context_contains_assertion, context_field_equals_assertion,
-    eval_case_telemetry_from_trace, format_utc_timestamp_millis, json_has_field_path,
-    metadata_score_max_assertion, metadata_score_min_assertion, read_tool_trace,
-    recipe_rank_assertion, refresh_eval_card, render_eval_card_markdown, resolve_mcp_writable_path,
-    run_eval_command, run_validate_command, safe_path_segment, score_agent_expectations,
-    selected_agent_cases, selected_bridge_cases, sql_structure_assertion, suite_file_hash,
-    telemetry_grade_mode, telemetry_path_for_suite, telemetry_row_matches_since,
-    tool_response_budget_assertion, tool_success_assertion, validate_since_date, validate_suite,
-    validate_telemetry_suite_name,
+    apply_telemetry_retention, build_agent_eval_tool_response, build_eval_compare_tool_response,
+    build_eval_comparison_report, build_eval_gate_report, build_eval_gate_tool_response,
+    build_eval_history_tool_response, build_eval_init_tool_response, build_eval_validate_payload,
+    build_eval_validate_tool_response, build_report, contains_rank_assertion,
+    context_contains_assertion, context_field_equals_assertion, eval_case_telemetry_from_trace,
+    format_utc_timestamp_millis, json_has_field_path, metadata_score_max_assertion,
+    metadata_score_min_assertion, read_tool_trace, recipe_rank_assertion, refresh_eval_card,
+    render_eval_card_markdown, resolve_mcp_writable_path, run_eval_command, run_validate_command,
+    safe_path_segment, score_agent_expectations, selected_agent_cases, selected_bridge_cases,
+    sql_structure_assertion, suite_file_hash, telemetry_grade_mode, telemetry_path_for_suite,
+    telemetry_row_matches_since, tool_response_budget_assertion, tool_success_assertion,
+    validate_since_date, validate_suite, validate_telemetry_suite_name,
 };
 use crate::params::{
-    GetEvalGateParams, GetEvalHistoryParams, InitEvalSuiteParams, RunAgentEvalParams,
-    ValidateEvalSuiteParams,
+    CompareEvalRunsParams, GetEvalGateParams, GetEvalHistoryParams, InitEvalSuiteParams,
+    RunAgentEvalParams, ValidateEvalSuiteParams,
 };
 
 #[test]
@@ -1833,6 +1833,167 @@ cases:
 }
 
 #[test]
+fn eval_comparison_reports_before_after_case_deltas() {
+    let temp_dir = TempDir::new().expect("comparison dir");
+    let before_dir = temp_dir.path().join("before");
+    let after_dir = temp_dir.path().join("after");
+    write_eval_results(
+        &before_dir,
+        &json!({
+            "suite_name": "ablation-smoke",
+            "version": 1,
+            "mode": "bridge",
+            "output_dir": before_dir.display().to_string(),
+            "assertion_count": 2,
+            "pass_count": 1,
+            "fail_count": 1,
+            "error_count": 0,
+            "pass_rate": 0.5,
+            "gate_status": "fail",
+            "cases": [
+                {"id": "kept_pass", "pass_count": 1, "fail_count": 0, "error_count": 0, "assertions": [{"name": "search_rank", "status": "pass"}]},
+                {"id": "fixed_case", "pass_count": 0, "fail_count": 1, "error_count": 0, "assertions": [{"name": "context_contains", "status": "fail"}]}
+            ]
+        }),
+    );
+    write_eval_results(
+        &after_dir,
+        &json!({
+            "suite_name": "ablation-smoke",
+            "version": 1,
+            "mode": "bridge",
+            "output_dir": after_dir.display().to_string(),
+            "assertion_count": 3,
+            "pass_count": 2,
+            "fail_count": 1,
+            "error_count": 0,
+            "pass_rate": 0.666_666_666_7,
+            "gate_status": "fail",
+            "cases": [
+                {"id": "kept_pass", "pass_count": 1, "fail_count": 0, "error_count": 0, "assertions": [{"name": "search_rank", "status": "pass"}]},
+                {"id": "fixed_case", "pass_count": 1, "fail_count": 0, "error_count": 0, "assertions": [{"name": "context_contains", "status": "pass"}]},
+                {"id": "new_failure", "pass_count": 0, "fail_count": 1, "error_count": 0, "assertions": [{"name": "tool_success", "status": "fail"}]}
+            ]
+        }),
+    );
+
+    let report = build_eval_comparison_report(
+        &before_dir.join("results.json"),
+        &after_dir.join("results.json"),
+        None,
+    )
+    .expect("comparison report");
+
+    assert_eq!(
+        report.delta.newly_passing_cases,
+        vec!["fixed_case".to_string()]
+    );
+    assert_eq!(
+        report.delta.newly_failing_cases,
+        vec!["new_failure".to_string()]
+    );
+    assert_eq!(report.delta.assertion_count, 1);
+    assert!(
+        report
+            .markdown
+            .contains("| Pass rate | 50.0% | 66.7% | +16.7 pp |")
+    );
+    assert!(report.markdown.contains("`fixed_case`"));
+    assert!(report.markdown.contains("`new_failure`"));
+}
+
+#[test]
+fn eval_comparison_includes_agent_trace_metric_deltas_when_available() {
+    let temp_dir = TempDir::new().expect("comparison dir");
+    let before_dir = temp_dir.path().join("before-agent");
+    let after_dir = temp_dir.path().join("after-agent");
+    write_agent_results_with_trace(&before_dir, 2);
+    write_agent_results_with_trace(&after_dir, 3);
+
+    let report = build_eval_comparison_report(
+        &before_dir.join("results.json"),
+        &after_dir.join("results.json"),
+        None,
+    )
+    .expect("comparison report");
+
+    assert_eq!(report.before.metrics.tool_call_count, Some(2));
+    assert_eq!(report.after.metrics.tool_call_count, Some(3));
+    assert_eq!(report.delta.metrics.tool_call_count, Some(1));
+    assert_eq!(report.before.metrics.duration_ms, Some(30));
+    assert_eq!(report.after.metrics.duration_ms, Some(35));
+    assert_eq!(report.delta.metrics.total_tokens, Some(55));
+    assert!(report.markdown.contains("| Tool calls | 2 | 3 | +1 |"));
+    assert!(
+        report
+            .markdown
+            .contains("| Total tokens | 180 | 235 | +55 |")
+    );
+}
+
+#[test]
+fn eval_compare_tool_response_returns_markdown_and_safety_policy() {
+    let root = std::env::current_dir().expect("cwd");
+    let temp_dir = TempDir::new_in(&root).expect("comparison dir under root");
+    let before_dir = temp_dir.path().join("before");
+    let after_dir = temp_dir.path().join("after");
+    write_eval_results(
+        &before_dir,
+        &json!({
+            "suite_name": "mcp-compare",
+            "version": 1,
+            "mode": "bridge",
+            "output_dir": before_dir.display().to_string(),
+            "assertion_count": 1,
+            "pass_count": 1,
+            "fail_count": 0,
+            "error_count": 0,
+            "pass_rate": 1.0,
+            "gate_status": "pass",
+            "cases": [{"id": "case", "pass_count": 1, "fail_count": 0, "error_count": 0}]
+        }),
+    );
+    write_eval_results(
+        &after_dir,
+        &json!({
+            "suite_name": "mcp-compare",
+            "version": 1,
+            "mode": "bridge",
+            "output_dir": after_dir.display().to_string(),
+            "assertion_count": 1,
+            "pass_count": 1,
+            "fail_count": 0,
+            "error_count": 0,
+            "pass_rate": 1.0,
+            "gate_status": "pass",
+            "cases": [{"id": "case", "pass_count": 1, "fail_count": 0, "error_count": 0}]
+        }),
+    );
+
+    let response = build_eval_compare_tool_response(&CompareEvalRunsParams {
+        before: before_dir.display().to_string(),
+        after: after_dir.display().to_string(),
+    })
+    .expect("tool response");
+
+    assert_eq!(response["success"], json!(true));
+    assert_eq!(
+        response["data"]["schema_version"],
+        json!("eval_comparison.v1")
+    );
+    assert!(
+        response["data"]["markdown"]
+            .as_str()
+            .expect("markdown")
+            .contains("No pass-rate or case-status change was observed")
+    );
+    assert_eq!(
+        response["data"]["safety_policy"]["local_paths_must_stay_under_filesystem_root"],
+        json!(true)
+    );
+}
+
+#[test]
 fn safe_path_segment_blocks_dot_segments_and_caps_length() {
     assert_eq!(safe_path_segment("."), "eval");
     assert_eq!(safe_path_segment(".."), "eval");
@@ -1845,6 +2006,98 @@ fn fixture_manifest_path(name: &str) -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures")
         .join(name)
+}
+
+fn write_eval_results(dir: &Path, value: &serde_json::Value) {
+    std::fs::create_dir_all(dir).expect("create result dir");
+    std::fs::write(
+        dir.join("results.json"),
+        serde_json::to_string_pretty(&value).expect("serialize results"),
+    )
+    .expect("write results");
+}
+
+fn write_agent_results_with_trace(dir: &Path, tool_calls: usize) {
+    std::fs::create_dir_all(dir.join("tool-calls")).expect("create trace dir");
+    let rows = match tool_calls {
+        2 => vec![
+            json!({
+                "tool": "search_indicator",
+                "duration_ms": 10,
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+                "response_bytes": 500
+            }),
+            json!({
+                "tool": "get_context",
+                "duration_ms": 20,
+                "usage": {"input_tokens": 50, "output_tokens": 10, "total_tokens": 60},
+                "response_bytes": 250
+            }),
+        ],
+        3 => vec![
+            json!({
+                "tool": "search_indicator",
+                "duration_ms": 10,
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+                "response_bytes": 500
+            }),
+            json!({
+                "tool": "get_context",
+                "duration_ms": 20,
+                "usage": {"input_tokens": 50, "output_tokens": 10, "total_tokens": 60},
+                "response_bytes": 250
+            }),
+            json!({
+                "tool": "execute_sql",
+                "duration_ms": 5,
+                "usage": {"input_tokens": 40, "output_tokens": 15, "total_tokens": 55},
+                "response_bytes": 100
+            }),
+        ],
+        _ => panic!("unexpected trace size"),
+    };
+    let trace = rows
+        .into_iter()
+        .map(|row| row.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(
+        dir.join("tool-calls/agent_case.jsonl"),
+        format!("{trace}\n"),
+    )
+    .expect("write trace");
+    write_eval_results(
+        dir,
+        &json!({
+            "suite_name": "agent-ablation",
+            "version": 1,
+            "mode": "agent",
+            "output_dir": dir.display().to_string(),
+            "assertion_count": 1,
+            "pass_count": 1,
+            "fail_count": 0,
+            "error_count": 0,
+            "pass_rate": 1.0,
+            "gate_status": "pass",
+            "cases": [{
+                "id": "agent_case",
+                "question": "Find governed revenue",
+                "pass_count": 1,
+                "fail_count": 0,
+                "error_count": 0,
+                "assertions": [{"name": "must_call:search_indicator", "status": "pass"}],
+                "artifacts": {
+                    "stdout": "stdout.log",
+                    "stderr": "stderr.log",
+                    "tool_trace": "tool-calls/agent_case.jsonl"
+                }
+            }]
+        }),
+    );
 }
 
 fn eval_card_suite(name: &str, threshold: Option<f64>, include_agent_case: bool) -> EvalSuite {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -106,6 +106,9 @@ pub async fn dispatch(command: args::Command) -> DispatchResult {
                     eval_cmd::run_agent_eval_command(&run_args).await
                 }
             },
+            args::EvalCommand::Compare(compare_args) => {
+                eval_cmd::run_compare_command(&compare_args)
+            }
             args::EvalCommand::Gate(gate_args) => eval_cmd::run_gate_command(&gate_args),
             args::EvalCommand::History(history_args) => {
                 eval_cmd::run_history_command(&history_args)

--- a/src/cli/tool.rs
+++ b/src/cli/tool.rs
@@ -13,9 +13,9 @@ use crate::cli::config_cmd::{
     build_config_show_tool_response, build_config_validate_tool_response,
 };
 use crate::cli::eval_cmd::{
-    build_agent_eval_tool_response, build_eval_gate_tool_response,
-    build_eval_history_tool_response, build_eval_init_tool_response, build_eval_run_tool_response,
-    build_eval_validate_tool_response,
+    build_agent_eval_tool_response, build_eval_compare_tool_response,
+    build_eval_gate_tool_response, build_eval_history_tool_response, build_eval_init_tool_response,
+    build_eval_run_tool_response, build_eval_validate_tool_response,
 };
 use crate::cli::health_cmd::build_cli_health_payload;
 use crate::cli::manifest::{
@@ -35,8 +35,8 @@ use crate::cli::trace_cmd::{
 use crate::error::{DbtNovaError, Result};
 use crate::manifest::search::ManifestSearch;
 use crate::params::{
-    BatchGetParams, ColumnInventoryParams, CompareGrainsParams, ConfigShowParams,
-    ConfigValidateParams, DiffEntitiesParams, ExecuteSqlParams, FindByPathParams,
+    BatchGetParams, ColumnInventoryParams, CompareEvalRunsParams, CompareGrainsParams,
+    ConfigShowParams, ConfigValidateParams, DiffEntitiesParams, ExecuteSqlParams, FindByPathParams,
     FindEntityOverlapParams, GetAgentReadinessParams, GetColumnLineageParams, GetColumnsParams,
     GetContextParams, GetEntityParams, GetEvalGateParams, GetEvalHistoryParams, GetImpactParams,
     GetLineageParams, GetMetadataAuditParams, GetMetadataScoreParams, GetRecipeParams,
@@ -61,7 +61,7 @@ struct ToolRegistryEntry {
     dispatch: ToolDispatchFn,
 }
 
-const TOOL_REGISTRY: [ToolRegistryEntry; 52] = [
+const TOOL_REGISTRY: [ToolRegistryEntry; 53] = [
     ToolRegistryEntry {
         name: "search",
         dispatch: dispatch_search,
@@ -141,6 +141,10 @@ const TOOL_REGISTRY: [ToolRegistryEntry; 52] = [
     ToolRegistryEntry {
         name: "get_eval_history",
         dispatch: dispatch_get_eval_history,
+    },
+    ToolRegistryEntry {
+        name: "compare_eval_runs",
+        dispatch: dispatch_compare_eval_runs,
     },
     ToolRegistryEntry {
         name: "run_eval",
@@ -773,6 +777,13 @@ fn dispatch_get_eval_history(_searcher: &ManifestSearch, params: JsonValue) -> T
     Box::pin(async move {
         let decoded: GetEvalHistoryParams = decode_tool_params("get_eval_history", params)?;
         build_eval_history_tool_response(&decoded)
+    })
+}
+
+fn dispatch_compare_eval_runs(_searcher: &ManifestSearch, params: JsonValue) -> ToolFuture<'_> {
+    Box::pin(async move {
+        let decoded: CompareEvalRunsParams = decode_tool_params("compare_eval_runs", params)?;
+        build_eval_compare_tool_response(&decoded)
     })
 }
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -761,6 +761,15 @@ pub struct GetEvalHistoryParams {
     pub since: String,
 }
 
+/// Parameters for the compare_eval_runs tool.
+#[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+pub struct CompareEvalRunsParams {
+    /// Before eval result directory or results.json path under the server working directory.
+    pub before: String,
+    /// After eval result directory or results.json path under the server working directory.
+    pub after: String,
+}
+
 /// Parameters for the run_eval tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
 pub struct RunEvalParams {

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -20,9 +20,9 @@ use crate::cli::config_cmd::{
     build_config_show_tool_response, build_config_validate_tool_response,
 };
 use crate::cli::eval_cmd::{
-    build_agent_eval_tool_response, build_eval_gate_tool_response,
-    build_eval_history_tool_response, build_eval_init_tool_response, build_eval_run_tool_response,
-    build_eval_validate_tool_response,
+    build_agent_eval_tool_response, build_eval_compare_tool_response,
+    build_eval_gate_tool_response, build_eval_history_tool_response, build_eval_init_tool_response,
+    build_eval_run_tool_response, build_eval_validate_tool_response,
 };
 use crate::cli::manifest::build_manifest_warm_tool_response;
 use crate::cli::nova_meta_cmd::build_nova_meta_tool_response;
@@ -38,8 +38,8 @@ use crate::config::DbtNovaConfig;
 use crate::error::DbtNovaError;
 use crate::manifest::search::{ManifestSearch, ManifestSearchHandle};
 use crate::params::{
-    BatchGetParams, ColumnInventoryParams, CompareGrainsParams, ConfigShowParams,
-    ConfigValidateParams, DiffEntitiesParams, ExecuteSqlParams, FindByPathParams,
+    BatchGetParams, ColumnInventoryParams, CompareEvalRunsParams, CompareGrainsParams,
+    ConfigShowParams, ConfigValidateParams, DiffEntitiesParams, ExecuteSqlParams, FindByPathParams,
     FindEntityOverlapParams, GetAgentReadinessParams, GetColumnLineageParams, GetColumnsParams,
     GetContextParams, GetEntityParams, GetEvalGateParams, GetEvalHistoryParams, GetImpactParams,
     GetLineageParams, GetMetadataAuditParams, GetMetadataScoreParams, GetRecipeParams,
@@ -1717,6 +1717,19 @@ impl DbtNovaServer {
         .await
     }
 
+    /// Compare two eval result directories or results.json files.
+    #[tool(
+        name = "compare_eval_runs",
+        description = "Compare two local eval result directories or results.json files and return PR-ready Markdown plus structured pass-rate, case, and trace-counter deltas. Paths are scoped under the server working directory."
+    )]
+    #[instrument(level = "info", skip(self, params))]
+    async fn compare_eval_runs(&self, params: Parameters<CompareEvalRunsParams>) -> String {
+        self.handle_async("compare_eval_runs", None, |_searcher| async move {
+            build_eval_compare_tool_response(&params.0)
+        })
+        .await
+    }
+
     /// Run deterministic bridge evals against the loaded MCP manifest.
     #[tool(
         name = "run_eval",
@@ -2306,6 +2319,36 @@ mod tests {
         config.search.enable_sparse_search = false;
         config.search.enable_reranker = false;
         config
+    }
+
+    fn write_test_eval_results(dir: &Path, status: &str, pass_rate: f64) {
+        let pass_count = usize::from(status == "pass");
+        let fail_count = usize::from(status == "fail");
+        std::fs::create_dir_all(dir).expect("create eval results dir");
+        let payload = serde_json::json!({
+            "suite_name": "mcp-compare-smoke",
+            "version": 1,
+            "mode": "bridge",
+            "output_dir": dir.display().to_string(),
+            "assertion_count": 1,
+            "pass_count": pass_count,
+            "fail_count": fail_count,
+            "error_count": 0,
+            "pass_rate": pass_rate,
+            "gate_status": status,
+            "cases": [{
+                "id": "case",
+                "pass_count": pass_count,
+                "fail_count": fail_count,
+                "error_count": 0,
+                "assertions": [{"name": "tool_success", "status": status}]
+            }]
+        });
+        std::fs::write(
+            dir.join("results.json"),
+            serde_json::to_string_pretty(&payload).expect("serialize eval results"),
+        )
+        .expect("write eval results");
     }
 
     async fn spawn_ready_server(storage_root: &Path) -> DbtNovaServer {
@@ -3224,6 +3267,51 @@ cases:
             serde_json::json!("mcp-eval-smoke")
         );
         assert!(response["data"]["safety_policy"].is_object());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn compare_eval_runs_returns_markdown_contract() {
+        let root = std::env::current_dir()
+            .expect("cwd")
+            .canonicalize()
+            .expect("canonical cwd");
+        let comparison_dir = TempDir::new_in(&root).expect("temp comparison dir");
+        let before_dir = comparison_dir.path().join("before");
+        let after_dir = comparison_dir.path().join("after");
+        write_test_eval_results(&before_dir, "pass", 1.0);
+        write_test_eval_results(&after_dir, "fail", 0.0);
+
+        let temp_dir = TempDir::new().expect("temp dir");
+        let mut config = test_config(temp_dir.path());
+        config.mcp_max_response_bytes = 0;
+        let handle = ManifestSearchHandle::spawn(config);
+        handle
+            .wait_ready()
+            .await
+            .expect("fixture manifest should load");
+        let server = DbtNovaServer::new(handle);
+
+        let response: serde_json::Value = serde_json::from_str(
+            &server
+                .compare_eval_runs(Parameters(CompareEvalRunsParams {
+                    before: before_dir.display().to_string(),
+                    after: after_dir.display().to_string(),
+                }))
+                .await,
+        )
+        .expect("eval comparison response JSON");
+
+        assert_eq!(response["success"], serde_json::json!(true));
+        assert_eq!(
+            response["data"]["schema_version"],
+            serde_json::json!("eval_comparison.v1")
+        );
+        assert!(
+            response["data"]["markdown"]
+                .as_str()
+                .expect("markdown")
+                .contains("Newly failing")
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/tools/catalog.rs
+++ b/src/tools/catalog.rs
@@ -1,5 +1,5 @@
 /// Canonical MCP tool names exposed by dbt-nova.
-pub const MCP_TOOL_NAMES: [&str; 52] = [
+pub const MCP_TOOL_NAMES: [&str; 53] = [
     "search",
     "search_indicator",
     "indicator_inventory",
@@ -20,6 +20,7 @@ pub const MCP_TOOL_NAMES: [&str; 52] = [
     "validate_eval_suite",
     "get_eval_gate",
     "get_eval_history",
+    "compare_eval_runs",
     "run_eval",
     "init_eval_suite",
     "run_agent_eval",
@@ -90,7 +91,7 @@ pub struct CliMcpParityEntry {
 /// Keep this matrix in sync with `docs/getting-started/cli.md` and
 /// `docs/api/mcp-cli-parity.md`. Product capabilities should trend from `Gap`
 /// to `Equivalent`; process lifecycle commands may remain `LifecycleException`.
-pub const CLI_MCP_PARITY_MATRIX: [CliMcpParityEntry; 24] = [
+pub const CLI_MCP_PARITY_MATRIX: [CliMcpParityEntry; 25] = [
     CliMcpParityEntry {
         cli_command: "server start",
         mcp_tool: None,
@@ -223,6 +224,13 @@ pub const CLI_MCP_PARITY_MATRIX: [CliMcpParityEntry; 24] = [
         status: CliMcpParityStatus::Equivalent,
         issue: None,
         notes: "MCP returns filtered eval telemetry rows in a standard envelope",
+    },
+    CliMcpParityEntry {
+        cli_command: "eval compare",
+        mcp_tool: Some("compare_eval_runs"),
+        status: CliMcpParityStatus::Equivalent,
+        issue: None,
+        notes: "MCP returns the same local results.json comparison and PR-ready Markdown while scoping local paths under the server working directory",
     },
     CliMcpParityEntry {
         cli_command: "trace inspect",


### PR DESCRIPTION
## Summary

- Add `dbt-nova eval compare` plus MCP/tool-call parity through `compare_eval_runs` for local before/after eval result comparisons.
- Report pass-rate, assertion, case-status, newly passing/failing, added/removed, and agent trace counter deltas as PR-ready Markdown and structured `eval_comparison.v1` data.
- Add a negative-results log with a concise template, seeded raw-query-corpus planning guardrail, docs links, API docs, parity docs, and changelog entries.
- Update `memmap2` to `0.9.11` to resolve `RUSTSEC-2026-0186`, which was caught by the PR `deny` check.

Linear: JOE-25, JOE-26

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --locked eval_compare`
- `cargo test --locked tools::catalog`
- `cargo test --locked compare_eval_runs_returns_markdown_contract`
- `cargo test --locked eval_cmd`
- `uv run --with-requirements docs/requirements.txt mkdocs build --strict`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo deny check`
- `cargo test --locked --all-features`

After updating `memmap2`, reran: `cargo deny check`, `cargo fmt --check`, `git diff --check`, `uv run --with-requirements docs/requirements.txt mkdocs build --strict`, `cargo clippy --locked --all-targets --all-features -- -D warnings`, and `cargo test --locked --all-features`.

## Review Notes

- Deep-reviewed CLI, MCP, tool-call registry, parity catalog, path-safety handling, comparison rendering, docs, and acceptance criteria before opening.
- `compare_eval_runs` is read/reporting only and scopes MCP paths under the server working directory; missing trace artifacts produce warnings rather than failing the comparison.
