### PR TITLE
Implement extended metadata search indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added default-off extended metadata search config for allowlisted non-Nova
   dbt `meta.*` paths, including value modes, caps, sensitive-key guardrails,
   docs/reference output, and manifest-scoped search index identity.
+- Extended metadata search now indexes configured entity-level and column-level
+  allowlisted fields into dedicated `meta.<alias>` Tantivy fields, including
+  fielded alias queries and deterministic extraction-time caps.
 - Hardened CI workflows by caching reusable semantic model snapshots during
   model artifact builds and upgrading maintained GitHub Actions to Node
   24-compatible pinned releases.

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -239,8 +239,8 @@ Note: `DBT_NOVA_MAX_LINEAGE_RESULTS` applies to **column lineage** (`get_column_
 ## Extended Metadata Search
 
 Extended metadata search config is default-off. It only describes an explicit
-allowlist for later indexing; extraction and summary output are not enabled when
-`fields` is empty.
+allowlist of non-Nova dbt metadata paths that Nova extracts into dedicated
+search fields. No extended metadata is indexed when `fields` is empty.
 
 - `DBT_NOVA_SEARCH_EXTENDED_META_FIELDS_JSON` – JSON array of allowlisted non-Nova dbt metadata fields (default: `[]`)
 - `DBT_NOVA_SEARCH_EXTENDED_META_MAX_FIELDS` – max configured fields (default: `32`, hard cap: `128`)
@@ -249,7 +249,7 @@ allowlist for later indexing; extraction and summary output are not enabled when
 
 Each field object accepts:
 - `path` – logical dbt metadata path beginning with `meta.` or `columns.*.meta.`
-- `alias` – lowercase ASCII field alias for future fielded search
+- `alias` – lowercase ASCII field alias exposed as `meta.<alias>` for fielded search
 - `mode` – one of `keyword`, `text`, `string_array`, or `bool`
 - `boost` – non-negative ranking boost (default: `1.0`)
 - `summary` – whether the field is eligible for future summaries (default: `false`)
@@ -263,11 +263,21 @@ export DBT_NOVA_SEARCH_EXTENDED_META_FIELDS_JSON='[
 ]'
 ```
 
+With that config, unfielded searches can match allowlisted values, and fielded
+queries can target the configured aliases:
+
+```text
+meta.owner:alice
+meta.semantic_group:lifecycle
+```
+
 Guardrails:
 - No fields preserves current behavior and produces no search-index fingerprint.
 - `meta.nova` paths are rejected because Nova metadata is already indexed.
 - Sensitive key segments are rejected before indexing: `token`, `secret`, `password`, `credential`, `private_key`, and `api_key`.
 - `*` is only accepted in `columns.*.meta.` paths; runtime schema discovery is not performed.
+- Values are capped deterministically by `max_values_per_field` and
+  `max_bytes_per_value`; excess values are dropped during indexing.
 - Changing extended metadata config changes the manifest-scoped search index identity.
 
 ## Embeddings (Dense + Sparse)

--- a/docs/configuration/search-defaults.md
+++ b/docs/configuration/search-defaults.md
@@ -108,7 +108,9 @@ Canonical defaults are also captured in `docs/config_defaults.json`
 
 Extended metadata indexing is default-off. Configure
 `search.extended_meta.fields` only for selected non-Nova dbt metadata paths that
-should become searchable in the extended metadata bridge.
+should become searchable in the extended metadata bridge. Configured fields are
+indexed into dedicated `meta.<alias>` search fields, so both normal keyword
+search and fielded queries such as `meta.owner:alice` can match them.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
@@ -121,7 +123,9 @@ Supported field modes are `keyword`, `text`, `string_array`, and `bool`.
 Paths must start with `meta.` or `columns.*.meta.`, must not target
 `meta.nova`, and sensitive key segments such as `token`, `secret`, `password`,
 `credential`, `private_key`, and `api_key` are rejected during config
-validation.
+validation. At indexing time, Nova keeps values in deterministic path/column
+order and drops any values beyond `extended_meta.max_values_per_field` after
+truncating each retained value to `extended_meta.max_bytes_per_value`.
 
 ### Hybrid Search
 

--- a/docs/features/search-ranking.md
+++ b/docs/features/search-ranking.md
@@ -29,6 +29,25 @@ Nova meta is indexed into dedicated search fields:
 Column‑level `meta.nova.synonyms`, `semantic_type`, and `example_values` are appended
 to the `columns` search field to improve column discovery (e.g., “UK” → `country_code`).
 
+## Optional Extended Metadata Fields
+
+Nova can also index selected non-Nova dbt metadata when
+`search.extended_meta.fields` is configured. This is intended as a bridge for
+existing project conventions, not a replacement for the first-class `meta.nova`
+contract.
+
+Each allowlisted field maps a dbt metadata path to a search alias:
+
+| Config path | Alias | Search field | Notes |
+| --- | --- | --- | --- |
+| `meta.owner` | `owner` | `meta.owner` | Entity-level metadata from legacy `meta` or dbt 1.11+ `config.meta` |
+| `columns.*.meta.semantic_group` | `semantic_group` | `meta.semantic_group` | Column metadata collected deterministically by column name |
+
+Unconfigured metadata is not searchable. Configured values are capped at
+indexing time with `extended_meta.max_values_per_field` and
+`extended_meta.max_bytes_per_value`, and sensitive key paths are rejected during
+configuration validation.
+
 ## Default Boosts (Config)
 
 These values are tuned for high signal with minimal noise:

--- a/src/manifest/entity.rs
+++ b/src/manifest/entity.rs
@@ -322,6 +322,25 @@ pub fn entity_nova_meta_json(value: &JsonValue) -> Option<Cow<'_, JsonValue>> {
 }
 
 #[must_use]
+pub fn normalized_entity_meta_json(value: &JsonValue) -> Option<JsonValue> {
+    let legacy = value.get("meta").filter(|meta| !meta.is_null());
+    let config = value
+        .get("config")
+        .and_then(|config| config.get("meta"))
+        .filter(|meta| !meta.is_null());
+
+    match (legacy, config) {
+        (Some(JsonValue::Object(legacy_obj)), Some(JsonValue::Object(config_obj))) => {
+            let mut merged = JsonValue::Object(config_obj.clone());
+            merge_json_value(&mut merged, &JsonValue::Object(legacy_obj.clone()));
+            Some(merged)
+        }
+        (Some(value), _) | (None, Some(value)) => Some(value.clone()),
+        (None, None) => None,
+    }
+}
+
+#[must_use]
 pub fn column_meta_json(column: &JsonValue) -> Option<&JsonValue> {
     column
         .get("meta")
@@ -1053,6 +1072,31 @@ mod tests {
 
         let nova = entity_nova_meta_json(&entity).expect("expected nova metadata");
         assert_eq!(nova["role"].as_str(), Some("dimension"));
+    }
+
+    #[test]
+    fn normalized_entity_meta_merges_partial_legacy_and_config_objects() {
+        let entity = serde_json::json!({
+            "meta": {
+                "owner": "analytics_reporting",
+                "business": {
+                    "domain": null
+                }
+            },
+            "config": {
+                "meta": {
+                    "business": {
+                        "domain": "orders",
+                        "steward": "data_platform"
+                    }
+                }
+            }
+        });
+
+        let meta = normalized_entity_meta_json(&entity).expect("expected merged meta");
+        assert_eq!(meta["owner"].as_str(), Some("analytics_reporting"));
+        assert_eq!(meta["business"]["domain"].as_str(), Some("orders"));
+        assert_eq!(meta["business"]["steward"].as_str(), Some("data_platform"));
     }
 
     #[test]

--- a/src/manifest/tantivy_search.rs
+++ b/src/manifest/tantivy_search.rs
@@ -17,9 +17,12 @@ use tantivy::tokenizer::{
 };
 use tantivy::{Index, IndexReader, IndexWriter, Term};
 
-use crate::config::SearchConfig;
+use crate::config::{ExtendedMetaFieldConfig, ExtendedMetaFieldMode, SearchConfig};
 use crate::error::{DbtNovaError, Result};
-use crate::manifest::entity::{column_nova_meta_json, entity_nova_meta_json};
+use crate::manifest::entity::{
+    column_nova_meta_json, entity_nova_meta_json, normalized_column_meta_json,
+    normalized_entity_meta_json,
+};
 use crate::manifest::store::EntityStore;
 use crate::utils::{SearchPersona, has_query_syntax, tokenize_alnum_lowercase};
 use tracing::{debug, info, instrument, warn};
@@ -58,6 +61,21 @@ pub struct FieldHandles {
     pub nova_compliance: Field,
 }
 
+#[derive(Clone)]
+struct ExtendedMetaFieldHandle {
+    path: ExtendedMetaPath,
+    alias: String,
+    field: Field,
+    mode: ExtendedMetaFieldMode,
+    boost: f32,
+}
+
+#[derive(Clone)]
+enum ExtendedMetaPath {
+    Entity { segments: Vec<String> },
+    ColumnWildcard { segments: Vec<String> },
+}
+
 /// Search hit with score and optional highlights.
 pub struct SearchHit {
     pub unique_id: String,
@@ -91,6 +109,7 @@ pub struct TantivySearcher {
     index: Index,
     reader: IndexReader,
     fields: FieldHandles,
+    extended_meta_fields: Vec<ExtendedMetaFieldHandle>,
 }
 
 impl TantivySearcher {
@@ -103,7 +122,7 @@ impl TantivySearcher {
         if !index_dir.exists() {
             return Ok(None);
         }
-        let (schema, fields) = Self::build_schema();
+        let (schema, fields, extended_meta_fields) = Self::build_schema(config);
         let index = match Index::open_in_dir(&index_dir) {
             Ok(index) => index,
             Err(err) => {
@@ -121,6 +140,7 @@ impl TantivySearcher {
             index,
             reader,
             fields,
+            extended_meta_fields,
         }))
     }
     /// Build a new Tantivy index from on-disk entity storage.
@@ -145,7 +165,7 @@ impl TantivySearcher {
         tags_by_id: &HashMap<String, Vec<String>>,
         config: &SearchConfig,
     ) -> Result<Self> {
-        let (schema, fields) = Self::build_schema();
+        let (schema, fields, extended_meta_fields) = Self::build_schema(config);
 
         let index_dir = storage_dir.join(&config.index_dir);
         if index_dir.exists() {
@@ -442,6 +462,14 @@ impl TantivySearcher {
                 }
             }
 
+            Self::add_extended_meta_fields(
+                &mut doc,
+                unique_id,
+                &entity_json,
+                &extended_meta_fields,
+                config,
+            );
+
             writer.add_document(doc)?;
             doc_count += 1;
         }
@@ -459,6 +487,7 @@ impl TantivySearcher {
             index,
             reader,
             fields,
+            extended_meta_fields,
         })
     }
 
@@ -524,7 +553,7 @@ impl TantivySearcher {
         Ok(())
     }
 
-    fn build_schema() -> (Schema, FieldHandles) {
+    fn build_schema(config: &SearchConfig) -> (Schema, FieldHandles, Vec<ExtendedMetaFieldHandle>) {
         let mut schema_builder = Schema::builder();
 
         let simple_options = TextOptions::default()
@@ -548,6 +577,8 @@ impl TantivySearcher {
                 .set_tokenizer("code_lower")
                 .set_index_option(IndexRecordOption::WithFreqsAndPositions),
         );
+
+        let code_stored_options = code_options.clone().set_stored();
 
         let ngram_options = TextOptions::default().set_indexing_options(
             TextFieldIndexing::default()
@@ -617,7 +648,10 @@ impl TantivySearcher {
             nova_compliance,
         };
 
-        (schema_builder.build(), fields)
+        let extended_meta_fields =
+            add_extended_meta_schema_fields(&mut schema_builder, config, &code_stored_options);
+
+        (schema_builder.build(), fields, extended_meta_fields)
     }
 
     /// Search with boosted fields. Returns `unique_id`/`score` with optional highlights.
@@ -772,6 +806,21 @@ impl TantivySearcher {
                         };
 
                         let boosted = Box::new(BoostQuery::new(term_query, boost));
+                        field_queries.push((Occur::Should, boosted));
+                    }
+                    for field_config in &self.extended_meta_fields {
+                        let term_query: Box<dyn Query> = match distance_loose {
+                            Some(dist) => Box::new(FuzzyTermQuery::new(
+                                Term::from_field_text(field_config.field, term),
+                                dist,
+                                true,
+                            )),
+                            None => Box::new(TermQuery::new(
+                                Term::from_field_text(field_config.field, term),
+                                IndexRecordOption::WithFreqs,
+                            )),
+                        };
+                        let boosted = Box::new(BoostQuery::new(term_query, field_config.boost));
                         field_queries.push((Occur::Should, boosted));
                     }
 
@@ -959,6 +1008,9 @@ impl TantivySearcher {
                 self.fields.tags_ngram,
             ]);
         }
+        if scope == SearchScope::Full {
+            default_fields.extend(self.extended_meta_fields.iter().map(|field| field.field));
+        }
 
         let mut parser = QueryParser::for_index(&self.index, default_fields);
         parser.set_field_boost(self.fields.alias, config.field_boosts.alias);
@@ -991,6 +1043,9 @@ impl TantivySearcher {
             parser.set_field_boost(self.fields.file_path, config.field_boosts.path);
             parser.set_field_boost(self.fields.file_path_code, config.field_boosts.path);
             parser.set_field_boost(self.fields.raw_code, config.field_boosts.code);
+            for field_config in &self.extended_meta_fields {
+                parser.set_field_boost(field_config.field, field_config.boost);
+            }
         }
 
         if include_ngram && scope == SearchScope::Full {
@@ -1034,6 +1089,9 @@ impl TantivySearcher {
                 ];
                 for field in loose_fields {
                     parser.set_field_fuzzy(field, false, dist, true);
+                }
+                for field_config in &self.extended_meta_fields {
+                    parser.set_field_fuzzy(field_config.field, false, dist, true);
                 }
             }
         }
@@ -1137,6 +1195,222 @@ impl TantivySearcher {
                 ("raw_code", self.fields.raw_code),
             ],
         }
+    }
+}
+
+impl ExtendedMetaPath {
+    fn from_config_path(path: &str) -> Self {
+        let segments = path.trim().split('.').collect::<Vec<_>>();
+        if segments.len() >= 4
+            && segments.first() == Some(&"columns")
+            && segments.get(1) == Some(&"*")
+            && segments.get(2) == Some(&"meta")
+        {
+            return Self::ColumnWildcard {
+                segments: segments[3..]
+                    .iter()
+                    .map(|segment| (*segment).to_string())
+                    .collect(),
+            };
+        }
+
+        Self::Entity {
+            segments: segments
+                .get(1..)
+                .unwrap_or_default()
+                .iter()
+                .map(|segment| (*segment).to_string())
+                .collect(),
+        }
+    }
+}
+
+impl TantivySearcher {
+    fn add_extended_meta_fields(
+        doc: &mut tantivy::TantivyDocument,
+        unique_id: &str,
+        entity_json: &JsonValue,
+        fields: &[ExtendedMetaFieldHandle],
+        config: &SearchConfig,
+    ) {
+        if fields.is_empty() {
+            return;
+        }
+
+        for field in fields {
+            let values = collect_extended_meta_values(entity_json, field);
+            if values.is_empty() {
+                continue;
+            }
+
+            let mut retained = 0usize;
+            let mut dropped_for_cap = 0usize;
+            for value in values {
+                if retained >= config.extended_meta.max_values_per_field {
+                    dropped_for_cap += 1;
+                    continue;
+                }
+                let Some(value) =
+                    capped_non_empty_value(&value, config.extended_meta.max_bytes_per_value)
+                else {
+                    continue;
+                };
+                doc.add_text(field.field, &value);
+                retained += 1;
+            }
+
+            if dropped_for_cap > 0 {
+                warn!(
+                    unique_id,
+                    alias = %field.alias,
+                    retained_values = retained,
+                    dropped_values = dropped_for_cap,
+                    max_values_per_field = config.extended_meta.max_values_per_field,
+                    "extended metadata value cap exceeded; dropping excess values"
+                );
+            }
+        }
+    }
+}
+
+fn sorted_extended_meta_fields(config: &SearchConfig) -> Vec<&ExtendedMetaFieldConfig> {
+    let mut fields = config.extended_meta.fields.iter().collect::<Vec<_>>();
+    fields.sort_by(|left, right| {
+        left.alias
+            .cmp(&right.alias)
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    fields
+}
+
+fn add_extended_meta_schema_fields(
+    schema_builder: &mut tantivy::schema::SchemaBuilder,
+    config: &SearchConfig,
+    code_stored_options: &TextOptions,
+) -> Vec<ExtendedMetaFieldHandle> {
+    let text_options = TextOptions::default()
+        .set_indexing_options(
+            TextFieldIndexing::default()
+                .set_tokenizer("text_en")
+                .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+        )
+        .set_stored();
+
+    let mut extended_meta_fields = Vec::new();
+    for field_config in sorted_extended_meta_fields(config) {
+        let options = match field_config.mode {
+            ExtendedMetaFieldMode::Keyword
+            | ExtendedMetaFieldMode::StringArray
+            | ExtendedMetaFieldMode::Bool => code_stored_options.clone(),
+            ExtendedMetaFieldMode::Text => text_options.clone(),
+        };
+        let field_name = extended_meta_field_name(&field_config.alias);
+        let field = schema_builder.add_text_field(&field_name, options);
+        extended_meta_fields.push(ExtendedMetaFieldHandle {
+            path: ExtendedMetaPath::from_config_path(&field_config.path),
+            alias: field_config.alias.trim().to_string(),
+            field,
+            mode: field_config.mode,
+            boost: field_config.boost,
+        });
+    }
+    extended_meta_fields
+}
+
+fn extended_meta_field_name(alias: &str) -> String {
+    format!("meta.{}", alias.trim())
+}
+
+fn collect_extended_meta_values(
+    entity_json: &JsonValue,
+    field: &ExtendedMetaFieldHandle,
+) -> Vec<String> {
+    match &field.path {
+        ExtendedMetaPath::Entity { segments } => normalized_entity_meta_json(entity_json)
+            .as_ref()
+            .and_then(|meta| value_at_path(meta, segments))
+            .map(|value| values_for_mode(value, field.mode))
+            .unwrap_or_default(),
+        ExtendedMetaPath::ColumnWildcard { segments } => {
+            let Some(columns) = entity_json.get("columns").and_then(JsonValue::as_object) else {
+                return Vec::new();
+            };
+            let mut column_names = columns.keys().collect::<Vec<_>>();
+            column_names.sort();
+
+            let mut out = Vec::new();
+            for column_name in column_names {
+                let Some(column) = columns.get(column_name) else {
+                    continue;
+                };
+                let Some(meta) = normalized_column_meta_json(column) else {
+                    continue;
+                };
+                let Some(value) = value_at_path(&meta, segments) else {
+                    continue;
+                };
+                out.extend(values_for_mode(value, field.mode));
+            }
+            out
+        }
+    }
+}
+
+fn values_for_mode(value: &JsonValue, mode: ExtendedMetaFieldMode) -> Vec<String> {
+    match mode {
+        ExtendedMetaFieldMode::Keyword | ExtendedMetaFieldMode::Text => match value {
+            JsonValue::String(value) => vec![value.clone()],
+            JsonValue::Number(value) => vec![value.to_string()],
+            _ => Vec::new(),
+        },
+        ExtendedMetaFieldMode::StringArray => value
+            .as_array()
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(JsonValue::as_str)
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default(),
+        ExtendedMetaFieldMode::Bool => value
+            .as_bool()
+            .map(|value| value.to_string())
+            .into_iter()
+            .collect(),
+    }
+}
+
+fn capped_non_empty_value(value: &str, max_bytes: usize) -> Option<String> {
+    if max_bytes == 0 {
+        return None;
+    }
+
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+
+    let mut end = value.len().min(max_bytes);
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    value
+        .get(..end)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn value_at_path<'a>(root: &'a JsonValue, segments: &[String]) -> Option<&'a JsonValue> {
+    let mut current = root;
+    for segment in segments {
+        current = current.get(segment)?;
+    }
+    if current.is_null() {
+        None
+    } else {
+        Some(current)
     }
 }
 

--- a/tests/tantivy_search.rs
+++ b/tests/tantivy_search.rs
@@ -1,4 +1,7 @@
 //! Integration tests for Tantivy search behavior and ranking.
+use dbt_nova::config::{
+    ExtendedMetaFieldConfig, ExtendedMetaFieldMode, ExtendedMetaSearchConfig, SearchConfig,
+};
 use dbt_nova::params::PaginationParams;
 use dbt_nova::params::{DetailLevel, SearchParams};
 use dbt_nova::{DbtNovaConfig, ManifestSearch};
@@ -103,6 +106,270 @@ fn create_searcher(manifest_file: &tempfile::NamedTempFile) -> support_fixtures:
     // Use a temporary storage root to avoid polluting local state during tests.
     support_fixtures::load_manifest_path(manifest_file.path())
         .expect("failed to build searcher from test manifest")
+}
+
+fn create_searcher_with_config(
+    manifest_file: &tempfile::NamedTempFile,
+    search: SearchConfig,
+) -> (ManifestSearch, support_config::TestStorageGuard) {
+    let guard = support_config::TestStorageGuard::new();
+    let mut cfg = DbtNovaConfig {
+        manifest_path: manifest_file.path().to_string_lossy().to_string(),
+        search,
+        ..Default::default()
+    };
+    support_config::apply_test_storage(&mut cfg, &guard);
+    let searcher = ManifestSearch::new(cfg)
+        .expect("failed to build searcher from test manifest")
+        .search;
+    (searcher, guard)
+}
+
+fn create_extended_meta_manifest() -> tempfile::NamedTempFile {
+    let manifest = json!({
+        "metadata": {
+            "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+            "project_name": "extended_meta_project"
+        },
+        "nodes": {
+            "model.test.orders": {
+                "name": "orders",
+                "alias": "fct_orders",
+                "resource_type": "model",
+                "package_name": "test",
+                "description": "Orders model",
+                "original_file_path": "models/marts/orders.sql",
+                "raw_code": "select order_id, status, channel from stg_orders",
+                "meta": {
+                    "business_owner": "retention narrative steward",
+                    "team": "revenue operations",
+                    "unconfigured_probe": "hiddenneedle",
+                    "is_certified": true,
+                    "overflow_tags": ["one", "two", "three"],
+                    "long_code": "abcdef"
+                },
+                "columns": {
+                    "status": {
+                        "name": "status",
+                        "meta": {
+                            "semantic_group": ["lifecycle", "fulfillment"]
+                        }
+                    },
+                    "channel": {
+                        "name": "channel",
+                        "config": {
+                            "meta": {
+                                "semantic_group": ["acquisition"]
+                            }
+                        }
+                    }
+                }
+            },
+            "model.test.customers": {
+                "name": "customers",
+                "alias": "dim_customers",
+                "resource_type": "model",
+                "package_name": "test",
+                "description": "Customer dimension",
+                "original_file_path": "models/marts/customers.sql",
+                "raw_code": "select customer_id from stg_customers",
+                "config": {
+                    "meta": {
+                        "team": "customer operations"
+                    }
+                },
+                "columns": {
+                    "customer_id": {"name": "customer_id"}
+                }
+            }
+        },
+        "sources": {},
+        "macros": {},
+        "docs": {},
+        "groups": {},
+        "exposures": {},
+        "metrics": {},
+        "parent_map": {},
+        "child_map": {}
+    });
+
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(manifest.to_string().as_bytes()).unwrap();
+    file
+}
+
+fn extended_meta_search_config() -> SearchConfig {
+    let mut search = support_config::test_search_config();
+    search.enable_rrf = false;
+    search.extended_meta = ExtendedMetaSearchConfig {
+        fields: vec![
+            ExtendedMetaFieldConfig {
+                path: "meta.business_owner".to_string(),
+                alias: "owner".to_string(),
+                mode: ExtendedMetaFieldMode::Text,
+                boost: 3.0,
+                summary: true,
+            },
+            ExtendedMetaFieldConfig {
+                path: "columns.*.meta.semantic_group".to_string(),
+                alias: "semantic_group".to_string(),
+                mode: ExtendedMetaFieldMode::StringArray,
+                boost: 2.0,
+                summary: false,
+            },
+            ExtendedMetaFieldConfig {
+                path: "meta.team".to_string(),
+                alias: "team".to_string(),
+                mode: ExtendedMetaFieldMode::Keyword,
+                boost: 1.5,
+                summary: false,
+            },
+            ExtendedMetaFieldConfig {
+                path: "meta.is_certified".to_string(),
+                alias: "certified".to_string(),
+                mode: ExtendedMetaFieldMode::Bool,
+                boost: 1.0,
+                summary: false,
+            },
+        ],
+        ..Default::default()
+    };
+    search
+}
+
+async fn search_unique_ids(searcher: &ManifestSearch, query: &str) -> Vec<String> {
+    let params = SearchParams {
+        query: query.to_string(),
+        resource_types: vec!["model".to_string()],
+        persona: None,
+        detail: Some(DetailLevel::Standard),
+        min_score: None,
+        fuzzy: false,
+        include_highlights: false,
+        include_sql: false,
+        explain: false,
+        pagination: PaginationParams {
+            limit: Some(10),
+            offset: 0,
+        },
+    };
+
+    let result = searcher.search(&params).await.unwrap();
+    result["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|row| row["unique_id"].as_str().map(str::to_string))
+        .collect()
+}
+
+fn assert_has_id(ids: &[String], expected: &str) {
+    assert!(
+        ids.iter().any(|id| id == expected),
+        "expected search results to contain {expected}, got {ids:?}"
+    );
+}
+
+fn assert_missing_id(ids: &[String], unexpected: &str) {
+    assert!(
+        !ids.iter().any(|id| id == unexpected),
+        "expected search results not to contain {unexpected}, got {ids:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn extended_meta_indexes_allowlisted_entity_and_column_fields() {
+    let manifest_file = create_extended_meta_manifest();
+    let (searcher, _guard) =
+        create_searcher_with_config(&manifest_file, extended_meta_search_config());
+
+    let entity_text_ids = search_unique_ids(&searcher, "retention narrative").await;
+    assert_has_id(&entity_text_ids, "model.test.orders");
+
+    let column_wildcard_ids = search_unique_ids(&searcher, "lifecycle").await;
+    assert_has_id(&column_wildcard_ids, "model.test.orders");
+
+    let config_meta_column_ids = search_unique_ids(&searcher, "acquisition").await;
+    assert_has_id(&config_meta_column_ids, "model.test.orders");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn extended_meta_supports_fielded_alias_search() {
+    let manifest_file = create_extended_meta_manifest();
+    let (searcher, _guard) =
+        create_searcher_with_config(&manifest_file, extended_meta_search_config());
+
+    let owner_ids = search_unique_ids(&searcher, "meta.owner:retention").await;
+    assert_has_id(&owner_ids, "model.test.orders");
+
+    let team_ids = search_unique_ids(&searcher, "meta.team:revenue").await;
+    assert_has_id(&team_ids, "model.test.orders");
+    assert_missing_id(&team_ids, "model.test.customers");
+
+    let config_meta_team_ids = search_unique_ids(&searcher, "meta.team:customer").await;
+    assert_has_id(&config_meta_team_ids, "model.test.customers");
+    assert_missing_id(&config_meta_team_ids, "model.test.orders");
+
+    let bool_ids = search_unique_ids(&searcher, "meta.certified:true").await;
+    assert_has_id(&bool_ids, "model.test.orders");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn extended_meta_does_not_index_unconfigured_metadata() {
+    let manifest_file = create_extended_meta_manifest();
+    let (configured, _configured_guard) =
+        create_searcher_with_config(&manifest_file, extended_meta_search_config());
+    let hidden_ids = search_unique_ids(&configured, "hiddenneedle").await;
+    assert_missing_id(&hidden_ids, "model.test.orders");
+
+    let default_search = support_config::test_search_config();
+    let (default_off, _default_guard) = create_searcher_with_config(&manifest_file, default_search);
+    let owner_ids = search_unique_ids(&default_off, "retention narrative").await;
+    assert_missing_id(&owner_ids, "model.test.orders");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn extended_meta_enforces_value_caps_deterministically() {
+    let manifest_file = create_extended_meta_manifest();
+    let mut search = support_config::test_search_config();
+    search.enable_rrf = false;
+    search.extended_meta = ExtendedMetaSearchConfig {
+        fields: vec![
+            ExtendedMetaFieldConfig {
+                path: "meta.overflow_tags".to_string(),
+                alias: "overflow_tag".to_string(),
+                mode: ExtendedMetaFieldMode::StringArray,
+                boost: 1.0,
+                summary: false,
+            },
+            ExtendedMetaFieldConfig {
+                path: "meta.long_code".to_string(),
+                alias: "long_code".to_string(),
+                mode: ExtendedMetaFieldMode::Keyword,
+                boost: 1.0,
+                summary: false,
+            },
+        ],
+        max_values_per_field: 2,
+        max_bytes_per_value: 3,
+        ..Default::default()
+    };
+    let (searcher, _guard) = create_searcher_with_config(&manifest_file, search);
+
+    let first_ids = search_unique_ids(&searcher, "meta.overflow_tag:one").await;
+    assert_has_id(&first_ids, "model.test.orders");
+
+    let second_ids = search_unique_ids(&searcher, "meta.overflow_tag:two").await;
+    assert_has_id(&second_ids, "model.test.orders");
+
+    let dropped_ids = search_unique_ids(&searcher, "meta.overflow_tag:three").await;
+    assert_missing_id(&dropped_ids, "model.test.orders");
+
+    let retained_prefix_ids = search_unique_ids(&searcher, "meta.long_code:abc").await;
+    assert_has_id(&retained_prefix_ids, "model.test.orders");
+
+    let truncated_suffix_ids = search_unique_ids(&searcher, "meta.long_code:abcdef").await;
+    assert_missing_id(&truncated_suffix_ids, "model.test.orders");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary
- Add dynamic `meta.<alias>` Tantivy fields for allowlisted extended dbt metadata.
- Extract configured entity and `columns.*.meta.*` values with legacy/config-meta fallback and deterministic value caps.
- Document the searchable alias contract and add integration coverage for the JOE-23 acceptance criteria.

Refs JOE-23.

## Validation
- `cargo test --locked --test tantivy_search extended_meta -- --nocapture`
- `cargo test --locked normalized_entity_meta -- --nocapture`
- `cargo test --locked search`
- `cargo test --locked deep_metadata`
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `bash scripts/check_config_reference.sh`
- `uv run mkdocs build --strict` (passes; existing MkDocs/Material 2.0 warning remains)
- `bash scripts/check_dependency_watchlist.sh`
- `cargo deny check` (passes with existing duplicate-crate warnings)