### PR TITLE
Expose extended metadata search summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extended metadata search now indexes configured entity-level and column-level
   allowlisted fields into dedicated `meta.<alias>` Tantivy fields, including
   fielded alias queries and deterministic extraction-time caps.
+- Search results now expose `extended_meta_summary` for configured extended
+  metadata fields with `summary: true`, while full detail retains the complete
+  raw dbt metadata payload.
 - Hardened CI workflows by caching reusable semantic model snapshots during
   model artifact builds and upgrading maintained GitHub Actions to Node
   24-compatible pinned releases.

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -44,6 +44,17 @@ Common:
       "description": "Customer dimension with lifecycle attributes...",
       "columns_total": 18,
       "primary_key_columns": ["customer_id"],
+      "extended_meta_summary": {
+        "fields": [
+          {
+            "alias": "owner",
+            "path": "meta.owner",
+            "search_field": "meta.owner",
+            "mode": "keyword",
+            "values": ["analytics_reporting"]
+          }
+        ]
+      },
       "persona_payload": {
         "focus": "business_discovery",
         "business_definition": "Customer dimension with lifecycle attributes...",
@@ -100,6 +111,16 @@ Common:
 When omitted, `detail` uses the active result profile: `standard` for CLI/tool
 calls by default and `compact` for MCP by default. Explicit `detail` values
 override the profile.
+
+When `search.extended_meta.fields` contains fields with `summary: true`,
+`standard` and `full` search rows include `extended_meta_summary`. The summary is
+bounded by `extended_meta.max_values_per_field` and
+`extended_meta.max_bytes_per_value`, contains only configured summary fields,
+and uses aliases such as `meta.owner` for fielded search. A field sets
+`truncated: true` when summary caps drop values or trim bytes, with
+`dropped_values` and `byte_truncated_values` counts when applicable. Full rows
+still include the complete raw dbt `meta` and `columns.*.meta` payload for
+inspection.
 
 Search result rows include an additive `provenance` object for `compact`,
 `standard`, and `full` detail. `provenance.tier` is `semantic_layer` when

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -252,7 +252,8 @@ Each field object accepts:
 - `alias` – lowercase ASCII field alias exposed as `meta.<alias>` for fielded search
 - `mode` – one of `keyword`, `text`, `string_array`, or `bool`
 - `boost` – non-negative ranking boost (default: `1.0`)
-- `summary` – whether the field is eligible for future summaries (default: `false`)
+- `summary` – whether standard/full search rows include the field in
+  `extended_meta_summary` (default: `false`)
 
 Example:
 
@@ -271,13 +272,35 @@ meta.owner:alice
 meta.semantic_group:lifecycle
 ```
 
+Because `meta.owner` has `summary: true`, matching standard/full search rows can
+also include a compact summary:
+
+```json
+{
+  "extended_meta_summary": {
+    "fields": [
+      {
+        "alias": "owner",
+        "path": "meta.owner",
+        "search_field": "meta.owner",
+        "mode": "keyword",
+        "values": ["alice"]
+      }
+    ]
+  }
+}
+```
+
 Guardrails:
 - No fields preserves current behavior and produces no search-index fingerprint.
 - `meta.nova` paths are rejected because Nova metadata is already indexed.
 - Sensitive key segments are rejected before indexing: `token`, `secret`, `password`, `credential`, `private_key`, and `api_key`.
 - `*` is only accepted in `columns.*.meta.` paths; runtime schema discovery is not performed.
 - Values are capped deterministically by `max_values_per_field` and
-  `max_bytes_per_value`; excess values are dropped during indexing.
+  `max_bytes_per_value`; excess values are dropped during indexing and summary
+  rendering. Summary fields set `truncated: true` when values were dropped or
+  byte-truncated, with `dropped_values` and `byte_truncated_values` counts when
+  applicable.
 - Changing extended metadata config changes the manifest-scoped search index identity.
 
 ## Embeddings (Dense + Sparse)

--- a/docs/configuration/search-defaults.md
+++ b/docs/configuration/search-defaults.md
@@ -110,7 +110,9 @@ Extended metadata indexing is default-off. Configure
 `search.extended_meta.fields` only for selected non-Nova dbt metadata paths that
 should become searchable in the extended metadata bridge. Configured fields are
 indexed into dedicated `meta.<alias>` search fields, so both normal keyword
-search and fielded queries such as `meta.owner:alice` can match them.
+search and fielded queries such as `meta.owner:alice` can match them. Fields
+with `summary: true` are also returned in standard/full search rows under
+`extended_meta_summary`.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
@@ -125,7 +127,9 @@ Paths must start with `meta.` or `columns.*.meta.`, must not target
 `credential`, `private_key`, and `api_key` are rejected during config
 validation. At indexing time, Nova keeps values in deterministic path/column
 order and drops any values beyond `extended_meta.max_values_per_field` after
-truncating each retained value to `extended_meta.max_bytes_per_value`.
+truncating each retained value to `extended_meta.max_bytes_per_value`. The same
+caps apply to `extended_meta_summary`; use `detail=full` when an agent needs the
+complete raw dbt metadata object.
 
 ### Hybrid Search
 

--- a/docs/features/search-ranking.md
+++ b/docs/features/search-ranking.md
@@ -44,9 +44,47 @@ Each allowlisted field maps a dbt metadata path to a search alias:
 | `columns.*.meta.semantic_group` | `semantic_group` | `meta.semantic_group` | Column metadata collected deterministically by column name |
 
 Unconfigured metadata is not searchable. Configured values are capped at
-indexing time with `extended_meta.max_values_per_field` and
-`extended_meta.max_bytes_per_value`, and sensitive key paths are rejected during
-configuration validation.
+indexing and summary-rendering time with
+`extended_meta.max_values_per_field` and `extended_meta.max_bytes_per_value`,
+and sensitive key paths are rejected during configuration validation.
+
+Set `summary: true` on fields that should appear in search payloads. Standard
+and full search results then include `extended_meta_summary` with the alias,
+source path, fielded search name, mode, retained values, and column names for
+`columns.*.meta.*` fields:
+
+```json
+{
+  "extended_meta_summary": {
+    "fields": [
+      {
+        "alias": "owner",
+        "path": "meta.owner",
+        "search_field": "meta.owner",
+        "mode": "keyword",
+        "values": ["analytics_reporting"]
+      },
+      {
+        "alias": "semantic_group",
+        "path": "columns.*.meta.semantic_group",
+        "search_field": "meta.semantic_group",
+        "mode": "string_array",
+        "values": ["acquisition", "lifecycle"],
+        "columns": [
+          {"name": "channel", "values": ["acquisition"]},
+          {"name": "status", "values": ["lifecycle"]}
+        ]
+      }
+    ]
+  }
+}
+```
+
+`extended_meta_summary` is intentionally a bridge for existing conventions.
+The complete raw `meta` and `columns.*.meta` payload remains available in
+`detail=full`, while `meta.nova` remains Nova's first-class semantic contract.
+If summary caps apply, the field sets `truncated: true` and includes
+`dropped_values` and/or `byte_truncated_values` counts.
 
 ## Default Boosts (Config)
 

--- a/src/config/search.rs
+++ b/src/config/search.rs
@@ -28,19 +28,19 @@ pub enum ExtendedMetaFieldMode {
     Bool,
 }
 
-/// One allowlisted non-Nova dbt metadata path for future extended-meta indexing.
+/// One allowlisted non-Nova dbt metadata path for extended-meta search.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(default)]
 pub struct ExtendedMetaFieldConfig {
     /// Logical dbt metadata path, such as `meta.owner` or `columns.*.meta.semantic_group`.
     pub path: String,
-    /// Stable search alias used for future fielded search and summaries.
+    /// Stable search alias used for fielded search and optional summaries.
     pub alias: String,
     /// Value mode for this path.
     pub mode: ExtendedMetaFieldMode,
-    /// Optional ranking boost applied by later indexing work.
+    /// Optional ranking boost applied to this field in search.
     pub boost: f32,
-    /// Whether this field is eligible for future summary payloads.
+    /// Whether this field is included in `extended_meta_summary` payloads.
     pub summary: bool,
 }
 

--- a/src/manifest/extended_meta.rs
+++ b/src/manifest/extended_meta.rs
@@ -1,0 +1,209 @@
+use serde_json::Value as JsonValue;
+
+use crate::config::{ExtendedMetaFieldConfig, ExtendedMetaFieldMode, SearchConfig};
+use crate::manifest::entity::{normalized_column_meta_json, normalized_entity_meta_json};
+
+#[derive(Clone, Debug)]
+pub(crate) enum ExtendedMetaPath {
+    Entity { segments: Vec<String> },
+    ColumnWildcard { segments: Vec<String> },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ExtendedMetaValue {
+    pub(crate) column_name: Option<String>,
+    pub(crate) value: String,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct CappedExtendedMetaValues {
+    pub(crate) values: Vec<ExtendedMetaValue>,
+    pub(crate) dropped_values: usize,
+    pub(crate) byte_truncated_values: usize,
+}
+
+impl ExtendedMetaPath {
+    pub(crate) fn from_config_path(path: &str) -> Self {
+        let segments = path.trim().split('.').collect::<Vec<_>>();
+        if segments.len() >= 4
+            && segments.first() == Some(&"columns")
+            && segments.get(1) == Some(&"*")
+            && segments.get(2) == Some(&"meta")
+        {
+            return Self::ColumnWildcard {
+                segments: segments[3..]
+                    .iter()
+                    .map(|segment| (*segment).to_string())
+                    .collect(),
+            };
+        }
+
+        Self::Entity {
+            segments: segments
+                .get(1..)
+                .unwrap_or_default()
+                .iter()
+                .map(|segment| (*segment).to_string())
+                .collect(),
+        }
+    }
+}
+
+pub(crate) fn sorted_extended_meta_fields(config: &SearchConfig) -> Vec<&ExtendedMetaFieldConfig> {
+    let mut fields = config.extended_meta.fields.iter().collect::<Vec<_>>();
+    fields.sort_by(|left, right| {
+        left.alias
+            .cmp(&right.alias)
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    fields
+}
+
+pub(crate) fn extended_meta_field_name(alias: &str) -> String {
+    format!("meta.{}", alias.trim())
+}
+
+pub(crate) fn extended_meta_mode_name(mode: ExtendedMetaFieldMode) -> &'static str {
+    match mode {
+        ExtendedMetaFieldMode::Keyword => "keyword",
+        ExtendedMetaFieldMode::Text => "text",
+        ExtendedMetaFieldMode::StringArray => "string_array",
+        ExtendedMetaFieldMode::Bool => "bool",
+    }
+}
+
+pub(crate) fn collect_capped_extended_meta_values(
+    entity_json: &JsonValue,
+    path: &ExtendedMetaPath,
+    mode: ExtendedMetaFieldMode,
+    max_values: usize,
+    max_bytes: usize,
+) -> CappedExtendedMetaValues {
+    let raw_values = collect_extended_meta_values(entity_json, path, mode);
+    let mut out = CappedExtendedMetaValues::default();
+    for value in raw_values {
+        if out.values.len() >= max_values {
+            out.dropped_values += 1;
+            continue;
+        }
+        let Some((capped, byte_truncated)) = capped_non_empty_value(&value.value, max_bytes) else {
+            continue;
+        };
+        if byte_truncated {
+            out.byte_truncated_values += 1;
+        }
+        out.values.push(ExtendedMetaValue {
+            column_name: value.column_name,
+            value: capped,
+        });
+    }
+    out
+}
+
+fn collect_extended_meta_values(
+    entity_json: &JsonValue,
+    path: &ExtendedMetaPath,
+    mode: ExtendedMetaFieldMode,
+) -> Vec<ExtendedMetaValue> {
+    match path {
+        ExtendedMetaPath::Entity { segments } => normalized_entity_meta_json(entity_json)
+            .as_ref()
+            .and_then(|meta| value_at_path(meta, segments))
+            .map(|value| {
+                values_for_mode(value, mode)
+                    .into_iter()
+                    .map(|value| ExtendedMetaValue {
+                        column_name: None,
+                        value,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+        ExtendedMetaPath::ColumnWildcard { segments } => {
+            let Some(columns) = entity_json.get("columns").and_then(JsonValue::as_object) else {
+                return Vec::new();
+            };
+            let mut column_names = columns.keys().collect::<Vec<_>>();
+            column_names.sort();
+
+            let mut out = Vec::new();
+            for column_name in column_names {
+                let Some(column) = columns.get(column_name) else {
+                    continue;
+                };
+                let Some(meta) = normalized_column_meta_json(column) else {
+                    continue;
+                };
+                let Some(value) = value_at_path(&meta, segments) else {
+                    continue;
+                };
+                out.extend(values_for_mode(value, mode).into_iter().map(|value| {
+                    ExtendedMetaValue {
+                        column_name: Some(column_name.clone()),
+                        value,
+                    }
+                }));
+            }
+            out
+        }
+    }
+}
+
+fn values_for_mode(value: &JsonValue, mode: ExtendedMetaFieldMode) -> Vec<String> {
+    match mode {
+        ExtendedMetaFieldMode::Keyword | ExtendedMetaFieldMode::Text => match value {
+            JsonValue::String(value) => vec![value.clone()],
+            JsonValue::Number(value) => vec![value.to_string()],
+            _ => Vec::new(),
+        },
+        ExtendedMetaFieldMode::StringArray => value
+            .as_array()
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(JsonValue::as_str)
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default(),
+        ExtendedMetaFieldMode::Bool => value
+            .as_bool()
+            .map(|value| value.to_string())
+            .into_iter()
+            .collect(),
+    }
+}
+
+fn capped_non_empty_value(value: &str, max_bytes: usize) -> Option<(String, bool)> {
+    if max_bytes == 0 {
+        return None;
+    }
+
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+
+    let mut end = value.len().min(max_bytes);
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    let byte_truncated = end < value.len();
+    value
+        .get(..end)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| (value.to_string(), byte_truncated))
+}
+
+fn value_at_path<'a>(root: &'a JsonValue, segments: &[String]) -> Option<&'a JsonValue> {
+    let mut current = root;
+    for segment in segments {
+        current = current.get(segment)?;
+    }
+    if current.is_null() {
+        None
+    } else {
+        Some(current)
+    }
+}

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -1,5 +1,6 @@
 pub mod bootstrap;
 pub mod entity;
+pub(crate) mod extended_meta;
 pub(crate) mod lineage_sql;
 pub mod loader;
 pub mod prebuilt_assets;

--- a/src/manifest/search/summary.rs
+++ b/src/manifest/search/summary.rs
@@ -1,6 +1,10 @@
 use serde_json::Value as JsonValue;
 
 use crate::manifest::entity::ArchivedEntity;
+use crate::manifest::extended_meta::{
+    ExtendedMetaPath, ExtendedMetaValue, collect_capped_extended_meta_values,
+    extended_meta_field_name, extended_meta_mode_name, sorted_extended_meta_fields,
+};
 use crate::utils::SearchPersona;
 
 use super::core::ManifestSearch;
@@ -45,6 +49,7 @@ struct SummaryProfile {
     include_has_nova_meta: bool,
     include_semantic_preview: bool,
     include_persona_payload: bool,
+    include_extended_meta_summary: bool,
 }
 
 impl SummaryProfile {
@@ -84,6 +89,7 @@ impl SummaryProfile {
             include_has_nova_meta: false,
             include_semantic_preview: false,
             include_persona_payload: false,
+            include_extended_meta_summary: false,
         }
     }
 
@@ -113,6 +119,7 @@ impl SummaryProfile {
             include_nova_metrics: false,
             include_semantic_preview: true,
             include_persona_payload: true,
+            include_extended_meta_summary: true,
             ..Self::empty()
         }
     }
@@ -133,6 +140,7 @@ impl SummaryProfile {
             include_nova_search_candidates: true,
             include_semantic_preview: true,
             include_persona_payload: true,
+            include_extended_meta_summary: true,
             ..Self::empty()
         }
     }
@@ -153,6 +161,7 @@ impl SummaryProfile {
             include_has_nova_meta: true,
             include_semantic_preview: true,
             include_persona_payload: true,
+            include_extended_meta_summary: true,
             ..Self::empty()
         }
     }
@@ -167,6 +176,7 @@ impl SummaryProfile {
             description_limit: 120,
             include_nova_search_candidates: true,
             include_semantic_preview: true,
+            include_extended_meta_summary: true,
             ..Self::empty()
         }
     }
@@ -183,6 +193,7 @@ impl SummaryProfile {
             include_nova_search_candidates: true,
             include_nova_summary: true,
             include_semantic_preview: true,
+            include_extended_meta_summary: true,
             ..Self::empty()
         }
     }
@@ -482,6 +493,12 @@ impl ManifestSearch {
         {
             obj.insert("persona_payload".to_string(), payload);
         }
+        if profile.include_extended_meta_summary {
+            let entity_json = entity_json_cache.get_or_insert_with(|| entity.to_json_value());
+            if let Some(summary) = self.extended_meta_summary(entity_json) {
+                obj.insert("extended_meta_summary".to_string(), summary);
+            }
+        }
         compact_json_object(&mut obj);
         JsonValue::Object(obj)
     }
@@ -643,6 +660,81 @@ impl ManifestSearch {
         JsonValue::Object(obj)
     }
 
+    pub(crate) fn extended_meta_summary(&self, entity_json: &JsonValue) -> Option<JsonValue> {
+        let fields = sorted_extended_meta_fields(&self.config.search);
+        if fields.is_empty() {
+            return None;
+        }
+
+        let mut field_summaries = Vec::new();
+        for field in fields {
+            if !field.summary {
+                continue;
+            }
+            let path = ExtendedMetaPath::from_config_path(&field.path);
+            let values = collect_capped_extended_meta_values(
+                entity_json,
+                &path,
+                field.mode,
+                self.config.search.extended_meta.max_values_per_field,
+                self.config.search.extended_meta.max_bytes_per_value,
+            );
+            if values.values.is_empty() {
+                continue;
+            }
+
+            let mut obj = serde_json::Map::new();
+            obj.insert("alias".to_string(), JsonValue::String(field.alias.clone()));
+            obj.insert("path".to_string(), JsonValue::String(field.path.clone()));
+            obj.insert(
+                "search_field".to_string(),
+                JsonValue::String(extended_meta_field_name(&field.alias)),
+            );
+            obj.insert(
+                "mode".to_string(),
+                JsonValue::String(extended_meta_mode_name(field.mode).to_string()),
+            );
+            obj.insert(
+                "values".to_string(),
+                JsonValue::Array(
+                    values
+                        .values
+                        .iter()
+                        .map(|value| JsonValue::String(value.value.clone()))
+                        .collect(),
+                ),
+            );
+
+            let columns = extended_meta_column_summary(&values.values);
+            if !columns.is_empty() {
+                obj.insert("columns".to_string(), JsonValue::Array(columns));
+            }
+            if values.dropped_values > 0 || values.byte_truncated_values > 0 {
+                obj.insert("truncated".to_string(), JsonValue::from(true));
+            }
+            if values.dropped_values > 0 {
+                obj.insert(
+                    "dropped_values".to_string(),
+                    JsonValue::from(values.dropped_values as u64),
+                );
+            }
+            if values.byte_truncated_values > 0 {
+                obj.insert(
+                    "byte_truncated_values".to_string(),
+                    JsonValue::from(values.byte_truncated_values as u64),
+                );
+            }
+
+            field_summaries.push(JsonValue::Object(obj));
+        }
+
+        if field_summaries.is_empty() {
+            None
+        } else {
+            Some(serde_json::json!({ "fields": field_summaries }))
+        }
+    }
+
     fn documentation_status(entity: &ArchivedEntity) -> JsonValue {
         let has_desc = entity
             .description_str()
@@ -702,6 +794,33 @@ impl ManifestSearch {
             "missing": true,
         })
     }
+}
+
+fn extended_meta_column_summary(values: &[ExtendedMetaValue]) -> Vec<JsonValue> {
+    let mut columns: Vec<(String, Vec<String>)> = Vec::new();
+    for value in values {
+        let Some(column_name) = value.column_name.as_ref() else {
+            continue;
+        };
+        if let Some((_, existing_values)) = columns
+            .last_mut()
+            .filter(|(name, _)| name.as_str() == column_name.as_str())
+        {
+            existing_values.push(value.value.clone());
+        } else {
+            columns.push((column_name.clone(), vec![value.value.clone()]));
+        }
+    }
+
+    columns
+        .into_iter()
+        .map(|(name, values)| {
+            serde_json::json!({
+                "name": name,
+                "values": values,
+            })
+        })
+        .collect()
 }
 
 fn json_string_or_null(value: Option<&str>) -> JsonValue {

--- a/src/manifest/tantivy_search.rs
+++ b/src/manifest/tantivy_search.rs
@@ -17,11 +17,12 @@ use tantivy::tokenizer::{
 };
 use tantivy::{Index, IndexReader, IndexWriter, Term};
 
-use crate::config::{ExtendedMetaFieldConfig, ExtendedMetaFieldMode, SearchConfig};
+use crate::config::{ExtendedMetaFieldMode, SearchConfig};
 use crate::error::{DbtNovaError, Result};
-use crate::manifest::entity::{
-    column_nova_meta_json, entity_nova_meta_json, normalized_column_meta_json,
-    normalized_entity_meta_json,
+use crate::manifest::entity::{column_nova_meta_json, entity_nova_meta_json};
+use crate::manifest::extended_meta::{
+    ExtendedMetaPath, collect_capped_extended_meta_values, extended_meta_field_name,
+    sorted_extended_meta_fields,
 };
 use crate::manifest::store::EntityStore;
 use crate::utils::{SearchPersona, has_query_syntax, tokenize_alnum_lowercase};
@@ -68,12 +69,6 @@ struct ExtendedMetaFieldHandle {
     field: Field,
     mode: ExtendedMetaFieldMode,
     boost: f32,
-}
-
-#[derive(Clone)]
-enum ExtendedMetaPath {
-    Entity { segments: Vec<String> },
-    ColumnWildcard { segments: Vec<String> },
 }
 
 /// Search hit with score and optional highlights.
@@ -1198,33 +1193,6 @@ impl TantivySearcher {
     }
 }
 
-impl ExtendedMetaPath {
-    fn from_config_path(path: &str) -> Self {
-        let segments = path.trim().split('.').collect::<Vec<_>>();
-        if segments.len() >= 4
-            && segments.first() == Some(&"columns")
-            && segments.get(1) == Some(&"*")
-            && segments.get(2) == Some(&"meta")
-        {
-            return Self::ColumnWildcard {
-                segments: segments[3..]
-                    .iter()
-                    .map(|segment| (*segment).to_string())
-                    .collect(),
-            };
-        }
-
-        Self::Entity {
-            segments: segments
-                .get(1..)
-                .unwrap_or_default()
-                .iter()
-                .map(|segment| (*segment).to_string())
-                .collect(),
-        }
-    }
-}
-
 impl TantivySearcher {
     fn add_extended_meta_fields(
         doc: &mut tantivy::TantivyDocument,
@@ -1238,49 +1206,33 @@ impl TantivySearcher {
         }
 
         for field in fields {
-            let values = collect_extended_meta_values(entity_json, field);
-            if values.is_empty() {
+            let values = collect_capped_extended_meta_values(
+                entity_json,
+                &field.path,
+                field.mode,
+                config.extended_meta.max_values_per_field,
+                config.extended_meta.max_bytes_per_value,
+            );
+            if values.values.is_empty() {
                 continue;
             }
 
-            let mut retained = 0usize;
-            let mut dropped_for_cap = 0usize;
-            for value in values {
-                if retained >= config.extended_meta.max_values_per_field {
-                    dropped_for_cap += 1;
-                    continue;
-                }
-                let Some(value) =
-                    capped_non_empty_value(&value, config.extended_meta.max_bytes_per_value)
-                else {
-                    continue;
-                };
-                doc.add_text(field.field, &value);
-                retained += 1;
+            for value in &values.values {
+                doc.add_text(field.field, &value.value);
             }
 
-            if dropped_for_cap > 0 {
+            if values.dropped_values > 0 {
                 warn!(
                     unique_id,
                     alias = %field.alias,
-                    retained_values = retained,
-                    dropped_values = dropped_for_cap,
+                    retained_values = values.values.len(),
+                    dropped_values = values.dropped_values,
                     max_values_per_field = config.extended_meta.max_values_per_field,
                     "extended metadata value cap exceeded; dropping excess values"
                 );
             }
         }
     }
-}
-
-fn sorted_extended_meta_fields(config: &SearchConfig) -> Vec<&ExtendedMetaFieldConfig> {
-    let mut fields = config.extended_meta.fields.iter().collect::<Vec<_>>();
-    fields.sort_by(|left, right| {
-        left.alias
-            .cmp(&right.alias)
-            .then_with(|| left.path.cmp(&right.path))
-    });
-    fields
 }
 
 fn add_extended_meta_schema_fields(
@@ -1315,103 +1267,6 @@ fn add_extended_meta_schema_fields(
         });
     }
     extended_meta_fields
-}
-
-fn extended_meta_field_name(alias: &str) -> String {
-    format!("meta.{}", alias.trim())
-}
-
-fn collect_extended_meta_values(
-    entity_json: &JsonValue,
-    field: &ExtendedMetaFieldHandle,
-) -> Vec<String> {
-    match &field.path {
-        ExtendedMetaPath::Entity { segments } => normalized_entity_meta_json(entity_json)
-            .as_ref()
-            .and_then(|meta| value_at_path(meta, segments))
-            .map(|value| values_for_mode(value, field.mode))
-            .unwrap_or_default(),
-        ExtendedMetaPath::ColumnWildcard { segments } => {
-            let Some(columns) = entity_json.get("columns").and_then(JsonValue::as_object) else {
-                return Vec::new();
-            };
-            let mut column_names = columns.keys().collect::<Vec<_>>();
-            column_names.sort();
-
-            let mut out = Vec::new();
-            for column_name in column_names {
-                let Some(column) = columns.get(column_name) else {
-                    continue;
-                };
-                let Some(meta) = normalized_column_meta_json(column) else {
-                    continue;
-                };
-                let Some(value) = value_at_path(&meta, segments) else {
-                    continue;
-                };
-                out.extend(values_for_mode(value, field.mode));
-            }
-            out
-        }
-    }
-}
-
-fn values_for_mode(value: &JsonValue, mode: ExtendedMetaFieldMode) -> Vec<String> {
-    match mode {
-        ExtendedMetaFieldMode::Keyword | ExtendedMetaFieldMode::Text => match value {
-            JsonValue::String(value) => vec![value.clone()],
-            JsonValue::Number(value) => vec![value.to_string()],
-            _ => Vec::new(),
-        },
-        ExtendedMetaFieldMode::StringArray => value
-            .as_array()
-            .map(|values| {
-                values
-                    .iter()
-                    .filter_map(JsonValue::as_str)
-                    .map(str::to_string)
-                    .collect()
-            })
-            .unwrap_or_default(),
-        ExtendedMetaFieldMode::Bool => value
-            .as_bool()
-            .map(|value| value.to_string())
-            .into_iter()
-            .collect(),
-    }
-}
-
-fn capped_non_empty_value(value: &str, max_bytes: usize) -> Option<String> {
-    if max_bytes == 0 {
-        return None;
-    }
-
-    let value = value.trim();
-    if value.is_empty() {
-        return None;
-    }
-
-    let mut end = value.len().min(max_bytes);
-    while end > 0 && !value.is_char_boundary(end) {
-        end -= 1;
-    }
-    value
-        .get(..end)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
-}
-
-fn value_at_path<'a>(root: &'a JsonValue, segments: &[String]) -> Option<&'a JsonValue> {
-    let mut current = root;
-    for segment in segments {
-        current = current.get(segment)?;
-    }
-    if current.is_null() {
-        None
-    } else {
-        Some(current)
-    }
 }
 
 fn format_highlight(snippet: &Snippet, format: &str) -> String {

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -315,9 +315,13 @@ impl ManifestSearch {
                         entity,
                         &entity_json,
                     );
+                    let extended_meta_summary = self.extended_meta_summary(&entity_json);
                     if let Some(obj) = entity_json.as_object_mut() {
                         obj.insert("score".to_string(), JsonValue::from(candidate.score));
                         obj.insert("provenance".to_string(), provenance);
+                        if let Some(summary) = extended_meta_summary {
+                            obj.insert("extended_meta_summary".to_string(), summary);
+                        }
                         if let Some(highlights) = highlight_value {
                             obj.insert("highlights".to_string(), highlights);
                         }

--- a/tests/tantivy_search.rs
+++ b/tests/tantivy_search.rs
@@ -5,6 +5,7 @@ use dbt_nova::config::{
 use dbt_nova::params::PaginationParams;
 use dbt_nova::params::{DetailLevel, SearchParams};
 use dbt_nova::{DbtNovaConfig, ManifestSearch};
+use serde_json::Value as JsonValue;
 use serde_json::json;
 use std::io::Write;
 #[path = "support/config.rs"]
@@ -238,11 +239,23 @@ fn extended_meta_search_config() -> SearchConfig {
 }
 
 async fn search_unique_ids(searcher: &ManifestSearch, query: &str) -> Vec<String> {
+    search_rows(searcher, query, DetailLevel::Standard)
+        .await
+        .iter()
+        .filter_map(|row| row["unique_id"].as_str().map(str::to_string))
+        .collect()
+}
+
+async fn search_rows(
+    searcher: &ManifestSearch,
+    query: &str,
+    detail: DetailLevel,
+) -> Vec<JsonValue> {
     let params = SearchParams {
         query: query.to_string(),
         resource_types: vec!["model".to_string()],
         persona: None,
-        detail: Some(DetailLevel::Standard),
+        detail: Some(detail),
         min_score: None,
         fuzzy: false,
         include_highlights: false,
@@ -255,12 +268,24 @@ async fn search_unique_ids(searcher: &ManifestSearch, query: &str) -> Vec<String
     };
 
     let result = searcher.search(&params).await.unwrap();
-    result["data"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .filter_map(|row| row["unique_id"].as_str().map(str::to_string))
-        .collect()
+    result["data"].as_array().unwrap().clone()
+}
+
+fn row_for_id<'a>(rows: &'a [JsonValue], expected: &str) -> &'a JsonValue {
+    rows.iter()
+        .find(|row| row["unique_id"].as_str() == Some(expected))
+        .unwrap_or_else(|| panic!("expected row for {expected}, got {rows:?}"))
+}
+
+fn extended_meta_field<'a>(row: &'a JsonValue, alias: &str) -> Option<&'a JsonValue> {
+    row.get("extended_meta_summary")
+        .and_then(|summary| summary.get("fields"))
+        .and_then(JsonValue::as_array)
+        .and_then(|fields| {
+            fields
+                .iter()
+                .find(|field| field["alias"].as_str() == Some(alias))
+        })
 }
 
 fn assert_has_id(ids: &[String], expected: &str) {
@@ -370,6 +395,131 @@ async fn extended_meta_enforces_value_caps_deterministically() {
 
     let truncated_suffix_ids = search_unique_ids(&searcher, "meta.long_code:abcdef").await;
     assert_missing_id(&truncated_suffix_ids, "model.test.orders");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn extended_meta_summary_appears_in_standard_and_full_search_rows() {
+    let manifest_file = create_extended_meta_manifest();
+    let (searcher, _guard) =
+        create_searcher_with_config(&manifest_file, extended_meta_search_config());
+
+    let rows = search_rows(&searcher, "retention narrative", DetailLevel::Standard).await;
+    let orders = row_for_id(&rows, "model.test.orders");
+    let owner = extended_meta_field(orders, "owner").expect("owner summary field");
+    assert_eq!(owner["path"].as_str(), Some("meta.business_owner"));
+    assert_eq!(owner["search_field"].as_str(), Some("meta.owner"));
+    assert_eq!(owner["mode"].as_str(), Some("text"));
+    assert_eq!(owner["values"], json!(["retention narrative steward"]));
+    assert!(extended_meta_field(orders, "team").is_none());
+    assert!(extended_meta_field(orders, "semantic_group").is_none());
+    assert!(extended_meta_field(orders, "unconfigured_probe").is_none());
+
+    let full_rows = search_rows(&searcher, "retention narrative", DetailLevel::Full).await;
+    let full_orders = row_for_id(&full_rows, "model.test.orders");
+    assert_eq!(
+        full_orders["meta"]["unconfigured_probe"].as_str(),
+        Some("hiddenneedle")
+    );
+    assert!(extended_meta_field(full_orders, "owner").is_some());
+    assert!(extended_meta_field(full_orders, "team").is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn extended_meta_summary_handles_column_wildcards() {
+    let manifest_file = create_extended_meta_manifest();
+    let mut search = support_config::test_search_config();
+    search.enable_rrf = false;
+    search.extended_meta = ExtendedMetaSearchConfig {
+        fields: vec![ExtendedMetaFieldConfig {
+            path: "columns.*.meta.semantic_group".to_string(),
+            alias: "semantic_group".to_string(),
+            mode: ExtendedMetaFieldMode::StringArray,
+            boost: 2.0,
+            summary: true,
+        }],
+        ..Default::default()
+    };
+    let (searcher, _guard) = create_searcher_with_config(&manifest_file, search);
+
+    let rows = search_rows(&searcher, "lifecycle", DetailLevel::Standard).await;
+    let orders = row_for_id(&rows, "model.test.orders");
+    let semantic_group =
+        extended_meta_field(orders, "semantic_group").expect("semantic group summary field");
+    assert_eq!(
+        semantic_group["values"],
+        json!(["acquisition", "lifecycle", "fulfillment"])
+    );
+    assert_eq!(
+        semantic_group["columns"],
+        json!([
+            {"name": "channel", "values": ["acquisition"]},
+            {"name": "status", "values": ["lifecycle", "fulfillment"]}
+        ])
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn extended_meta_summary_respects_caps_and_truncation_metadata() {
+    let manifest_file = create_extended_meta_manifest();
+    let mut search = support_config::test_search_config();
+    search.enable_rrf = false;
+    search.extended_meta = ExtendedMetaSearchConfig {
+        fields: vec![
+            ExtendedMetaFieldConfig {
+                path: "meta.overflow_tags".to_string(),
+                alias: "overflow_tag".to_string(),
+                mode: ExtendedMetaFieldMode::StringArray,
+                boost: 1.0,
+                summary: true,
+            },
+            ExtendedMetaFieldConfig {
+                path: "meta.long_code".to_string(),
+                alias: "long_code".to_string(),
+                mode: ExtendedMetaFieldMode::Keyword,
+                boost: 1.0,
+                summary: true,
+            },
+        ],
+        max_values_per_field: 2,
+        max_bytes_per_value: 3,
+        ..Default::default()
+    };
+    let (searcher, _guard) = create_searcher_with_config(&manifest_file, search);
+
+    let rows = search_rows(&searcher, "meta.overflow_tag:one", DetailLevel::Standard).await;
+    let orders = row_for_id(&rows, "model.test.orders");
+    let overflow = extended_meta_field(orders, "overflow_tag").expect("overflow summary field");
+    assert_eq!(overflow["values"], json!(["one", "two"]));
+    assert_eq!(overflow["truncated"].as_bool(), Some(true));
+    assert_eq!(overflow["dropped_values"].as_u64(), Some(1));
+
+    let long_code = extended_meta_field(orders, "long_code").expect("long code summary field");
+    assert_eq!(long_code["values"], json!(["abc"]));
+    assert_eq!(long_code["truncated"].as_bool(), Some(true));
+    assert_eq!(long_code["byte_truncated_values"].as_u64(), Some(1));
+    assert!(long_code.get("dropped_values").is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn extended_meta_summary_is_omitted_without_summary_fields() {
+    let manifest_file = create_extended_meta_manifest();
+    let mut search = support_config::test_search_config();
+    search.enable_rrf = false;
+    search.extended_meta = ExtendedMetaSearchConfig {
+        fields: vec![ExtendedMetaFieldConfig {
+            path: "meta.team".to_string(),
+            alias: "team".to_string(),
+            mode: ExtendedMetaFieldMode::Keyword,
+            boost: 1.0,
+            summary: false,
+        }],
+        ..Default::default()
+    };
+    let (searcher, _guard) = create_searcher_with_config(&manifest_file, search);
+
+    let rows = search_rows(&searcher, "meta.team:revenue", DetailLevel::Standard).await;
+    let orders = row_for_id(&rows, "model.test.orders");
+    assert!(orders.get("extended_meta_summary").is_none());
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary
- Adds a shared extended metadata extraction/capping helper used by both Tantivy indexing and response summaries.
- Adds `extended_meta_summary` to standard/persona and full search rows for fields configured with `summary: true`, including column wildcard summaries and truncation metadata.
- Updates config comments, search/tool/config docs, changelog, and integration tests for JOE-21.

Refs JOE-21.

## Validation
- `cargo test --locked --test tantivy_search extended_meta -- --nocapture`
- `cargo test --locked search`
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `bash scripts/check_config_reference.sh`
- `uv run mkdocs build --strict` (passes; existing MkDocs/Material 2.0 warning remains)
- `bash scripts/check_dependency_watchlist.sh`
- `cargo deny check` (passes with existing duplicate-crate warnings)
- `git diff --check`