### PR TITLE
Enforce semantic-first analyst workflow

### DIFF
--- a/.github/skills/analyst/SKILL.md
+++ b/.github/skills/analyst/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: "Bash Read Write mcp__nova__show_metadata mcp__nova__health mcp__
 metadata:
   owner: "dbt-nova"
   persona: "analyst"
-  version: "0.0.4"
+  version: "0.0.5"
 ---
 
 # Analyst Skill (dbt-nova)
@@ -42,6 +42,30 @@ A question is not ready for final SQL until you can name:
 - the exact validated filter value(s)
 - the comparison basis when the ask is period-based
 
+## Semantic-first KPI contract (required)
+
+For KPI, metric, measure, rate, funnel, and conversion questions, semantic
+discovery is the default path. Use Nova indicator discovery before broad model
+search, context loading, raw SQL inspection, or warehouse execution.
+
+Required order:
+1. Search governed indicators with `search_indicator` using compact defaults.
+2. Prefer returned metrics/measures and their parent execution entities.
+3. Use compact entity or column checks only after selecting a semantic parent.
+4. Execute SQL or recipes only after the semantic definition, grain, time field,
+   and filter fields are known.
+
+Raw model search is fallback, not a parallel first step. Use it only after you
+can state one of these evidence-backed reasons:
+- `search_indicator` returned no relevant measure or metric.
+- The relevant indicator has no credible execution parent for the ask.
+- The ask is not KPI-shaped after decomposition.
+- A recipe fully covers the recurring deliverable and provides the semantic
+  contract itself.
+
+When you fall back to raw model search, say what semantic discovery you tried
+and why it was insufficient.
+
 ## Transport selection (required)
 
 Choose transport before loading transport-specific references:
@@ -55,18 +79,23 @@ Do not mix transports in one answer unless you are explicitly debugging transpor
 
 ## Deterministic flow
 
-1. Decide whether the ask is recurring or ad hoc.
-2. Resolve requested indicators one at a time.
-3. Choose one credible execution entity.
-4. Verify fields only after choosing the entity.
-5. Validate non-trivial filter values before aggregation.
-6. Escalate trust checks only when useful.
-7. Execute.
-8. Report with explicit evidence.
+1. Decide whether the ask is recurring, KPI-shaped, or ad hoc.
+2. Use recipes first only when the user asks for a recurring deliverable.
+3. For KPI-shaped asks, resolve requested indicators one at a time before broad
+   model search.
+4. Choose one credible execution entity from semantic parent evidence.
+5. Verify fields only after choosing the entity.
+6. Validate non-trivial filter values before aggregation.
+7. Escalate trust checks only when useful.
+8. Execute.
+9. Report with explicit evidence.
 
 Rules:
 - Prefer a common parent across requested indicators.
 - If no credible shared parent exists, do not force one query. Either answer in separate entity sections or ask for clarification.
+- Do not call broad `search`, `get_context`, `get_sql`, or `execute_sql` before
+  `search_indicator` for metric/KPI questions unless you have documented a
+  fallback reason.
 - Do not assume friendly labels map directly to raw warehouse values without validation.
 - Keep validation probes close to the target slice. Do not scan a year-plus range just to confirm one filter member.
 - Do not front-load every trust tool by default. Escalate only when the answer is high-stakes or the entity choice is ambiguous.
@@ -98,6 +127,8 @@ Every final answer must include:
 - selected filter field(s) and explicit validated value(s), including coded values such as `country_code = 'GB'`
 - comparison basis and exact prior period when a comparison is included
 - recipe id/query names when a recipe was used, or a concise calculation-method summary when direct execution was used
+- fallback evidence when a raw model path was used instead of a governed
+  measure or metric
 - any trust caveat that materially affects interpretation
 
 Default output behavior:

--- a/.github/skills/analyst/assets/evidence-block.md
+++ b/.github/skills/analyst/assets/evidence-block.md
@@ -16,6 +16,8 @@
 - Validated filter values:
 
 - Indicator definition source:
+- Semantic discovery:
+- Raw-search fallback reason:
 - Execution method:
 - Recipe id / query names:
 

--- a/.github/skills/analyst/assets/report-template.md
+++ b/.github/skills/analyst/assets/report-template.md
@@ -21,6 +21,8 @@
 - Geo/segment column:
 - Validated filter values:
 - Metric definition source:
+- Semantic discovery:
+- Raw-search fallback reason:
 - Execution method:
 
 ## Assumptions

--- a/.github/skills/analyst/references/transport-cli.md
+++ b/.github/skills/analyst/references/transport-cli.md
@@ -25,6 +25,13 @@ Common mappings:
 - trust checks: `dbt-nova tool call get_context`, `get_lineage`, `get_test_coverage`, `get_metadata_score`
 - SQL execution: `dbt-nova tool call execute_sql`
 
+For KPI, metric, measure, rate, funnel, or conversion questions, run
+`search_indicator` before broad `search`, `get_context`, `get_sql`, or
+`execute_sql`. Raw model search is fallback only after the CLI response shows
+no relevant governed indicator or no credible semantic parent. Keep the
+`search_indicator` command and rejection reason as final-answer evidence when
+fallback is used.
+
 ## CLI guardrails
 
 - Use `tool call` for tool-surface parity first.

--- a/.github/skills/analyst/references/transport-mcp.md
+++ b/.github/skills/analyst/references/transport-mcp.md
@@ -26,6 +26,13 @@ Use this reference when the client exposes `mcp__nova__*` tools directly.
      provide enough evidence and no filter-value mapping is needed
 3. `indicator_inventory` when comparing KPI families
 4. `search` for supporting entity discovery when the ask is not yet KPI-shaped
+   or semantic discovery produced an explicit fallback reason.
+
+For KPI, metric, measure, rate, funnel, or conversion questions, this order is
+mandatory. Do not call broad `search`, `get_context`, `get_sql`, or
+`execute_sql` before `search_indicator` unless the ask is not KPI-shaped or a
+recipe already answers the deliverable. When fallback is needed, preserve the
+`search_indicator` query and rejection reason as final-answer evidence.
 
 ## Entity selection
 

--- a/.github/skills/analyst/references/workflow.md
+++ b/.github/skills/analyst/references/workflow.md
@@ -31,7 +31,9 @@ Use this prompt when needed:
    - dimensional lookup
    - provenance or trust audit
 2. Look for a recipe first only when the request is for the recurring deliverable itself.
-3. Resolve indicators directly, one requested indicator at a time.
+3. For KPI, metric, measure, rate, funnel, or conversion questions, resolve
+   indicators directly before broad model search, one requested indicator at a
+   time.
    - Use domain-specific query terms and compact indicator search defaults.
 4. Choose one execution entity from the top shared parent, not isolated indicator rows.
    - If the requested indicators do not share a credible parent, do not force a synthetic combined query.
@@ -42,6 +44,28 @@ Use this prompt when needed:
 9. Report the answer with explicit evidence.
 
 Do not skip filter-value validation when the question includes geography, market, segment, or channel constraints.
+
+## Semantic-first gate
+
+For KPI-shaped asks, broad model search is allowed only after semantic
+discovery is exhausted or shown to be irrelevant. Do not call broad `search`,
+`get_context`, `get_sql`, or `execute_sql` before `search_indicator` unless the
+ask is not KPI-shaped or a recipe already answers the recurring deliverable.
+
+Semantic discovery evidence must include:
+- the `search_indicator` query terms used
+- whether you searched metrics, measures, or both
+- the top relevant indicator names and parent entities when present
+- why the top semantic result was accepted or rejected
+
+Fallback to raw model search only when one of these is true:
+- no relevant indicator is returned
+- relevant indicators lack a credible execution parent for the ask
+- requested outputs are dimensional, provenance, or entity-comparison work, not
+  KPI work
+- a recipe covers the deliverable and supplies the contract
+
+If fallback is used, carry the fallback reason into the final evidence block.
 
 ## Recipe-first rule
 
@@ -77,7 +101,8 @@ Prefer the candidate that satisfies the most checks:
 If two candidates tie, prefer the one with clearer definitions and fewer assumptions.
 
 Use direct KPI resolution first.
-Use supporting discovery only when the ask is not yet KPI-shaped.
+Use supporting discovery only when the ask is not yet KPI-shaped or semantic
+discovery produced an explicit fallback reason.
 
 Low-token KPI discovery defaults:
 - `search_indicator` with `limit: 3`

--- a/.github/skills/eval-author/SKILL.md
+++ b/.github/skills/eval-author/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: "Bash Read Write mcp__nova__show_metadata mcp__nova__health mcp__
 metadata:
   owner: "dbt-nova"
   persona: "eval-author"
-  version: "0.0.4"
+  version: "0.0.5"
 ---
 
 # Eval Author Skill (dbt-nova)
@@ -60,6 +60,11 @@ Eval execution is CLI-only. MCP is for discovering ground truth and debugging ex
 - Prefer stable identifiers such as `unique_id`, `parent_unique_id`, recipe id, and column name.
 - Use bridge evals for search rank, indicator rank, column rank, context fields, lineage edges, metadata score, recipe discovery, and generic tool success.
 - Use agent evals for required tool calls, forbidden tools, ordering, selected entities, ranked entity evidence, safe parameter checks, and final-answer text.
+- For KPI or metric workflows, assert semantic-first behavior explicitly:
+  `search_indicator` before `get_context` for definition/context tasks, and
+  `search_indicator` before `execute_sql` for execution tasks.
+- When semantic coverage exists in the fixture, forbid broad `search` unless
+  the case is intentionally testing fallback.
 - Do not use agent evals to compensate for weak metadata. Fix bridge failures first.
 - Do not assert every possible tool call. Assert the minimum behavior that proves the workflow.
 - Avoid brittle prose checks. Use `final_answer.must_contain` only for short, durable business terms.
@@ -76,6 +81,7 @@ When handing off an eval suite or eval fix, include:
 - declared manifest scope and known gaps
 - bridge cases and what each proves
 - agent cases and what each proves
+- semantic-first or fallback behavior each agent case proves
 - gate threshold and intended run cadence
 - command lines to validate and run
 - expected artifacts and how to debug failures

--- a/.github/skills/eval-author/assets/eval-suite-template.yml
+++ b/.github/skills/eval-author/assets/eval-suite-template.yml
@@ -1,6 +1,6 @@
 version: 1
 name: nova-analyst-smoke
-purpose: Prove that analyst discovery can find the canonical governed metric, model, and context for the target workflow.
+purpose: Prove that analyst discovery uses semantic-first KPI lookup to find the canonical governed metric, model, and context for the target workflow.
 manifest_scope: target/manifest.json for the analytics project
 known_gaps:
   - Replace this with any workflow, domain, freshness, or provider behavior not covered by the suite.
@@ -35,6 +35,7 @@ agent_cases:
         - search_indicator
         - get_context
       must_not_call:
+        - search
         - execute_sql
       ordered:
         - before: get_context

--- a/.github/skills/eval-author/references/provider-patterns.md
+++ b/.github/skills/eval-author/references/provider-patterns.md
@@ -16,6 +16,63 @@ safe scalar or scalar-array values such as `query`, `id_or_name`, `persona`,
 `execute_sql`, nested `parameters` and raw SQL are intentionally not exposed;
 check presence through the `keys` summary instead of asserting query text.
 
+## Semantic-First KPI Pattern
+
+For metric/KPI tasks with known semantic coverage, assert that semantic
+discovery happens before context or execution. Also forbid broad `search` when
+the fixture has a governed indicator that should answer the question.
+
+Definition/context task:
+
+```yaml
+agent_cases:
+  - id: semantic_metric_context_flow
+    task: Which governed model and metric should be used for gross merchandise value? Do not execute SQL.
+    expected:
+      must_call:
+        - search_indicator
+        - get_context
+      must_not_call:
+        - search
+        - execute_sql
+      ordered:
+        - before: get_context
+          must_have_called:
+            - search_indicator
+      selected_entity_ranks:
+        - unique_id: model.pkg.orders
+          tool: search_indicator
+          max_rank: 3
+```
+
+Execution task:
+
+```yaml
+agent_cases:
+  - id: semantic_metric_execution_flow
+    task: Compute gross merchandise value for March 2026 from the governed metric.
+    expected:
+      must_call:
+        - search_indicator
+        - execute_sql
+      must_not_call:
+        - search
+        - get_sql
+      ordered:
+        - before: execute_sql
+          must_have_called:
+            - search_indicator
+      called_with:
+        - tool: search_indicator
+          contains:
+            query: gross merchandise
+```
+
+Fallback cases should be separate. They should still require a
+`search_indicator` attempt, then allow broad `search` only when the prompt and
+expected final answer capture why no governed indicator or semantic parent was
+usable.
+
 ## Useful Expectations
 
 ```yaml
@@ -27,6 +84,7 @@ agent_cases:
         - search_indicator
         - get_context
       must_not_call:
+        - search
         - execute_sql
       ordered:
         - before: get_context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Tightened the analyst skill around semantic-first KPI discovery, added
+  eval-author guidance and starter eval expectations for `search_indicator`
+  before context or SQL execution, and added scorer coverage for rejecting SQL
+  before semantic discovery.
 - Added an OpenCode reference pack design covering the target `.opencode`
   layout, role-to-tool permission model, local and remote MCP examples, smoke
   eval expectations, and portability boundaries for later Codex/Claude work.

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -119,8 +119,8 @@ a SQL-structure grader.
 dbt-nova ships `evals/starter.yml` plus a synthetic manifest fixture at
 `tests/fixtures/starter_eval_manifest.json`. The suite is intentionally small
 and strict: it checks canonical model search, indicator discovery, context,
-lineage, recipe discovery, metadata scoring, and one provider-backed agent
-tool-use flow.
+lineage, recipe discovery, metadata scoring, and provider-backed agent tool-use
+flows.
 
 Validate the starter suite:
 
@@ -458,6 +458,42 @@ Budget expectations score the sanitized trace:
 - `max_distinct_tools` caps tool-surface breadth.
 - `max_total_response_bytes` caps summed serialized response bytes.
 - `max_response_bytes_by_tool` caps the largest response for named tools.
+
+For KPI or metric workflows, encode semantic-first behavior directly in agent
+expectations. Definition tasks should require `search_indicator` before
+`get_context`; execution tasks should require `search_indicator` before
+`execute_sql`. When the fixture has a governed indicator for the question, add
+`search` to `must_not_call` so broad model search fails unless the case is
+explicitly testing fallback.
+
+```yaml
+agent_cases:
+  - id: semantic_metric_execution_flow
+    task: Compute conversion rate from the governed metric for a bounded period.
+    expected:
+      must_call:
+        - search_indicator
+        - execute_sql
+      must_not_call:
+        - search
+        - get_sql
+      ordered:
+        - before: execute_sql
+          must_have_called:
+            - search_indicator
+      called_with:
+        - tool: search_indicator
+          params:
+            detail: compact
+            group_mode: top
+          contains:
+            query: conversion
+```
+
+Fallback evals should be separate cases. They should still require a
+`search_indicator` attempt, then allow broad `search` only when the expected
+answer or trace evidence explains why no governed indicator or semantic parent
+could cover the ask.
 
 Run against the default `opencode` adapter:
 

--- a/evals/agent-tokenomics-opencode.yml
+++ b/evals/agent-tokenomics-opencode.yml
@@ -22,6 +22,7 @@ agent_cases:
         - search_indicator
         - execute_sql
       must_not_call:
+        - search
         - get_context
         - get_lineage
         - get_sql
@@ -78,6 +79,7 @@ agent_cases:
       must_call:
         - search_indicator
       must_not_call:
+        - search
         - execute_sql
         - get_context
         - get_lineage
@@ -109,6 +111,7 @@ agent_cases:
       must_call:
         - search_indicator
       must_not_call:
+        - search
         - execute_sql
         - get_context
         - get_lineage

--- a/evals/starter.yml
+++ b/evals/starter.yml
@@ -1,6 +1,6 @@
 version: 1
 name: starter
-purpose: Prove that the packaged synthetic manifest supports core Nova discovery, context, lineage, recipe, metadata-score, and agent tool-use flows.
+purpose: Prove that the packaged synthetic manifest supports core Nova discovery, semantic-first analyst context, lineage, recipe, metadata-score, and agent tool-use flows.
 manifest_scope: tests/fixtures/starter_eval_manifest.json synthetic commerce manifest
 known_gaps:
   - Does not execute warehouse SQL.
@@ -90,12 +90,13 @@ cases:
 
 agent_cases:
   - id: analyst_revenue_lookup_flow
-    task: Which canonical model and measure should an analyst use for gross revenue? Do not execute SQL.
+    task: Which canonical model and measure should an analyst use for gross revenue? Use semantic indicator discovery before context, do not use broad model search, and do not execute SQL.
     expected:
       must_call:
         - search_indicator
         - get_context
       must_not_call:
+        - search
         - execute_sql
         - get_lineage
       ordered:
@@ -110,6 +111,50 @@ agent_cases:
           max_rank: 3
       called_with:
         - tool: search_indicator
+          params:
+            detail: compact
+            group_mode: top
+            limit: 3
+          contains:
+            query: gross revenue
+      max_tool_calls: 4
+      max_distinct_tools: 3
+      max_total_response_bytes: 65536
+      max_response_bytes_by_tool:
+        search_indicator: 12000
+        get_context: 24000
+      final_answer:
+        must_contain:
+          - fct_orders
+          - gross_revenue
+
+  - id: semantic_first_revenue_context_flow
+    task: Resolve the governed gross revenue semantic definition, then fetch supporting context for the chosen execution entity. Do not execute SQL and do not use broad model search unless semantic discovery returns no relevant indicator.
+    expected:
+      must_call:
+        - search_indicator
+        - get_context
+      must_not_call:
+        - search
+        - execute_sql
+        - get_sql
+        - get_lineage
+      ordered:
+        - before: get_context
+          must_have_called:
+            - search_indicator
+      selected_entities:
+        - model.starter_eval.fct_orders
+      selected_entity_ranks:
+        - unique_id: model.starter_eval.fct_orders
+          tool: search_indicator
+          max_rank: 3
+      called_with:
+        - tool: search_indicator
+          params:
+            detail: compact
+            group_mode: top
+            limit: 3
           contains:
             query: gross revenue
       max_tool_calls: 4

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -105,6 +105,42 @@ fn agent_expectations_score_tool_trace() {
 }
 
 #[test]
+fn agent_order_fails_when_sql_precedes_semantic_discovery() {
+    let expected = AgentExpected {
+        must_call: vec!["search_indicator".to_string(), "execute_sql".to_string()],
+        ordered: vec![AgentOrder {
+            before: "execute_sql".to_string(),
+            must_have_called: vec!["search_indicator".to_string()],
+        }],
+        ..AgentExpected::default()
+    };
+    let trace = vec![
+        json!({"tool": "execute_sql"}),
+        json!({"tool": "search_indicator"}),
+    ];
+
+    let results = score_agent_expectations(&expected, &trace, "");
+
+    assert_eq!(
+        results
+            .iter()
+            .filter(|result| result.name.starts_with("must_call:"))
+            .filter(|result| result.status == "pass")
+            .count(),
+        2
+    );
+    let order_result = results
+        .iter()
+        .find(|result| result.name == "order:execute_sql")
+        .expect("order assertion");
+    assert_eq!(order_result.status, "fail");
+    assert_eq!(
+        order_result.evidence["observed_tools"],
+        json!(["execute_sql", "search_indicator"])
+    );
+}
+
+#[test]
 fn sql_structure_assertion_passes_when_only_literals_differ() {
     let result = sql_structure_assertion(
         "sql_structure",


### PR DESCRIPTION
## Summary
- Tighten the analyst skill contract so KPI/metric work must start with `search_indicator` before broad model search, context loading, SQL inspection, or execution.
- Add semantic-first fallback evidence to analyst report templates and document MCP/CLI transport ordering.
- Teach eval authors to encode semantic-first ordering and strengthen starter/tokenomics suites, including SQL-before-semantic regression coverage.

## Validation
- `git diff --check`
- `cargo fmt --check`
- `bash scripts/install_skills.sh --all --skills-dir <tmp>`
- `uv run mkdocs build --strict`
- `cargo test --locked eval_cmd`
- `cargo run --locked -- eval validate --suite evals/starter.yml`
- `cargo run --locked -- eval validate --suite evals/agent-tokenomics-opencode.yml`
- `cargo run --locked -- eval validate --suite .github/skills/eval-author/assets/eval-suite-template.yml`
- `cargo run --locked -- eval run --suite evals/starter.yml --manifest-path tests/fixtures/starter_eval_manifest.json --fail-under 1.0`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`

Closes JOE-24