### PR TITLE
Add domain reference doc skeleton

### DIFF
--- a/.github/skills/analyst/SKILL.md
+++ b/.github/skills/analyst/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: "Bash Read Write mcp__nova__show_metadata mcp__nova__health mcp__
 metadata:
   owner: "dbt-nova"
   persona: "analyst"
-  version: "0.0.5"
+  version: "0.0.6"
 ---
 
 # Analyst Skill (dbt-nova)
@@ -93,6 +93,9 @@ Do not mix transports in one answer unless you are explicitly debugging transpor
 Rules:
 - Prefer a common parent across requested indicators.
 - If no credible shared parent exists, do not force one query. Either answer in separate entity sections or ask for clarification.
+- When a curated domain reference exists for the ask, use it after semantic
+  discovery to confirm canonical entity choice, grain, required hygiene filters,
+  gotchas, and cross-domain handoff boundaries.
 - Do not call broad `search`, `get_context`, `get_sql`, or `execute_sql` before
   `search_indicator` for metric/KPI questions unless you have documented a
   fallback reason.
@@ -142,4 +145,7 @@ Default output behavior:
 - Read exactly one transport file:
   - `references/transport-mcp.md`
   - `references/transport-cli.md`
+- Load `references/domain-references.md` only when a curated domain reference
+  is relevant to source selection, gotchas, required filters, or cross-domain
+  handoff.
 - Load the assets only when writing the final answer.

--- a/.github/skills/analyst/references/domain-references.md
+++ b/.github/skills/analyst/references/domain-references.md
@@ -1,0 +1,54 @@
+# Analyst Domain References
+
+Domain references are curated, human-authored guides for durable business
+domains or recurring workflow families. Use them as supporting context after
+semantic discovery, not as a substitute for Nova metadata or live validation.
+
+## When To Load
+
+Load a domain reference when:
+- the user names a business domain, standard workflow, or known reference doc
+- a recipe or semantic indicator points to a domain with documented gotchas
+- the question crosses domains or asks which source should be trusted
+- the answer is high-stakes and domain caveats could change interpretation
+
+Do not spend tokens looking for domain references for simple point lookups when
+the semantic contract is already complete.
+
+## How To Use
+
+1. Resolve governed indicators first with `search_indicator` for KPI-shaped
+   questions.
+2. Use the domain reference to confirm canonical entity choice, grain, required
+   hygiene filters, gotchas, and cross-domain handoffs.
+3. Verify current fields and filter values through Nova tools before execution.
+4. Carry material caveats from the domain reference into the final answer.
+
+If the domain reference conflicts with current Nova tool evidence, prefer the
+current manifest/tool evidence and report the reference as stale or ambiguous.
+
+## Evidence To Capture
+
+When a domain reference materially affects the answer, cite:
+- reference path or title
+- canonical entity and grain it recommends
+- required filters or exclusions it adds
+- gotcha, caveat, or handoff rule applied
+- any conflict with current `meta.nova`, lineage, tests, or freshness evidence
+
+## Boundaries
+
+- Domain references are curated sources of truth, not raw query dumps.
+- Historical SQL, notebooks, and dashboards can provide examples but do not
+  override `meta.nova.measures`, `meta.nova.metric(s)`, lineage, or tests.
+- Do not force joins across incompatible grains because a domain reference names
+  both entities. Ask for clarification or split the answer.
+- Do not copy formulas from a domain reference when a governed Nova indicator
+  already owns the expression.
+
+## Authoring Template
+
+The public convention is documented in `docs/features/domain-references.md`.
+When authoring or reviewing a domain reference, switch to the `meta-authoring`
+skill and load its `references/domain-reference-template.md`. The same skill
+carries a synthetic starter example at `references/domain-reference-example.md`.

--- a/.github/skills/analyst/references/workflow.md
+++ b/.github/skills/analyst/references/workflow.md
@@ -45,6 +45,23 @@ Use this prompt when needed:
 
 Do not skip filter-value validation when the question includes geography, market, segment, or channel constraints.
 
+## Domain reference rule
+
+Domain references are curated guides for durable domains or recurring workflow
+families. Use them after semantic discovery when they can clarify canonical
+entities, grain, standard hygiene filters, gotchas, or cross-domain handoffs.
+
+Do not use domain references as raw query corpora or as replacements for
+current Nova tool evidence. If a reference conflicts with `meta.nova`, lineage,
+tests, or freshness evidence, prefer the current manifest evidence and report
+the reference as stale or ambiguous.
+
+When a domain reference materially changes the answer, capture:
+- reference path or title
+- canonical entity and grain it recommends
+- required filters or exclusions it adds
+- gotcha, caveat, or handoff rule applied
+
 ## Semantic-first gate
 
 For KPI-shaped asks, broad model search is allowed only after semantic

--- a/.github/skills/meta-authoring/SKILL.md
+++ b/.github/skills/meta-authoring/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: meta-authoring
-description: "Builds and reviews high-signal `meta.nova` for dbt resources. Use when adding Nova metadata, choosing canonical datasets or indicators, defining model-bound measures or metric templates, annotating columns, de-ranking helper models, or improving Nova MCP search and metadata scores."
+description: "Builds and reviews high-signal `meta.nova` and curated domain references for dbt resources. Use when adding Nova metadata, choosing canonical datasets or indicators, defining model-bound measures or metric templates, annotating columns, de-ranking helper models, authoring domain reference docs, or improving Nova MCP search and metadata scores."
 license: MIT
 allowed-tools: "Bash Read Write mcp__nova__show_metadata mcp__nova__search mcp__nova__search_indicator mcp__nova__indicator_inventory mcp__nova__search_columns mcp__nova__column_inventory mcp__nova__find_by_path mcp__nova__get_entity mcp__nova__get_context mcp__nova__get_columns mcp__nova__get_metadata_score mcp__nova__compare_grains mcp__nova__find_entity_overlap mcp__nova__modelling_consistency_report mcp__nova__get_undocumented"
 metadata:
   owner: "dbt-nova"
   persona: "meta-authoring"
-  version: "0.0.4"
+  version: "0.0.5"
 ---
 
 # Meta Authoring Skill (dbt-nova)
@@ -56,6 +56,13 @@ Use the CLI only when you are validating local file edits or a local manifest bu
 - Keep synonyms concise: 2-8 business terms is usually enough.
 - Verify referenced fields exist: `grain.time_field`, `grain.dimensions`, `measures[].field`, and `recommended_filters[].field`.
 - Treat PII and compliance as first-class governance signals. Prefer entity-level `governance` for dataset sensitivity and column-level governance only where a specific exposed column needs it.
+- Use curated domain references for narrative guidance that does not belong in
+  `meta.nova`: business context, scope and exclusions, standard hygiene filters,
+  canonical-entity rationale, gotchas, and cross-domain handoffs. Domain
+  references must point back to Nova metadata rather than replacing it.
+- Do not use raw query corpora, notebook archives, or dashboard history as the
+  source of authority for domain references. They can be supporting evidence
+  only after the governed metadata and eval evidence are clear.
 
 ## Workflow
 
@@ -63,13 +70,17 @@ Use the CLI only when you are validating local file edits or a local manifest bu
 2. Read one transport reference: `references/transport-mcp.md` for live Nova evidence, or `references/transport-cli.md` for local validation.
 3. Load `references/decision-rules.md` when choosing a Nova surface or canonical placement.
 4. Load `references/patterns.md` only when writing YAML.
-5. Load `references/review-checklist.md` before final handoff.
+5. Load `references/domain-reference-template.md` when authoring or reviewing a
+   domain reference document. Use `references/domain-reference-example.md` only
+   when a concrete synthetic example is useful.
+6. Load `references/review-checklist.md` before final handoff.
 
 ## Output Standard
 
 Final handoffs must include:
 - classification and intended Nova surface
 - metadata added or changed
+- domain reference sections added or changed, if any
 - repeated-concept and canonicality evidence
 - validation result
 - search or score verification result

--- a/.github/skills/meta-authoring/references/domain-reference-example.md
+++ b/.github/skills/meta-authoring/references/domain-reference-example.md
@@ -1,0 +1,135 @@
+# Starter Commerce Domain Reference Example
+
+This synthetic example uses the `starter_eval` fixture naming from dbt-nova. It
+is intentionally small and should not be treated as a production domain model.
+
+## Status
+
+- Owner: analytics enablement
+- Maintainers: dbt-nova example maintainers
+- Last reviewed: 2026-06-23
+- Applies to dbt project: `starter_eval`
+- Applies to Nova domains: `commerce`
+- Related eval suites: `evals/starter.yml`
+
+## Business Context
+
+The starter commerce domain covers synthetic order reporting for examples,
+skills, and evals. Analysts use it to identify the canonical orders model,
+resolve gross revenue, inspect customer geography, and run the weekly revenue
+recipe. The domain is deliberately narrow: it proves Nova discovery, context,
+lineage, recipes, metadata scoring, and agent tool-use behavior without relying
+on a real warehouse or real business data.
+
+Nova metadata links:
+- `meta.nova.domains`: `commerce`
+- `meta.nova.use_cases`: `gross_revenue_reporting`, `order_reporting`
+- `meta.nova.synonyms`: order and revenue vocabulary on `fct_orders`
+- `meta.nova.governance`: low-sensitivity synthetic reporting data
+
+## Canonical Entities
+
+| Purpose | dbt unique_id | Relation | Why canonical | Nova metadata |
+| --- | --- | --- | --- | --- |
+| Primary execution dataset | `model.starter_eval.fct_orders` | `analytics.starter.fct_orders` | Owns order-grain reporting and the canonical gross revenue measure. | `canonical`, `grain`, `measures` |
+| Customer geography dimension | `model.starter_eval.dim_customers` | `analytics.starter.dim_customers` | Supplies customer attributes and geography used by the order fact. | `domains`, `grain` |
+| Raw sparse example | `model.starter_eval.raw_events_sparse` | `analytics.starter.raw_events_sparse` | Demonstrates low-quality sparse metadata and should not be the analyst landing page. | sparse metadata only |
+
+## Grain And Scope
+
+- Primary grain: one row per order
+- Primary key: `order_id`
+- Time field: `order_date`
+- Default dimensions: `country_code`, `status`
+- Supported breakdowns: order date, country code, status
+- Unsupported breakdowns: session, product, shipment, and marketing attribution
+
+Scope rules:
+- Included: synthetic order revenue from the starter fixture.
+- Excluded: real customer behavior, stock, fulfilment, margin, returns, and
+  marketing channel attribution.
+- Known partial coverage: `dim_customers` can support geography examples but is
+  not a full customer analytics domain.
+
+Nova metadata links:
+- `meta.nova.grain.primary_key`: `order_id`
+- `meta.nova.grain.time_field`: `order_date`
+- `meta.nova.grain.dimensions`: `country_code`, `status`
+
+## Standard Hygiene Filters
+
+| Filter purpose | Field | Required values or rule | Applies by default? | Notes |
+| --- | --- | --- | --- | --- |
+| Completed order reporting | `status` | validate accepted fixture values before filtering | no | Use only when the question asks for completed orders. |
+| Geography reporting | `country_code` | exact country code such as `GB` | no | Validate friendly country labels before final SQL. |
+
+## Measures And Metrics
+
+| Business term | Nova indicator | Type | Expression or definition | Parent entity |
+| --- | --- | --- | --- | --- |
+| Gross revenue | `gross_revenue` | measure | Sum of `gross_amount` at order grain. | `model.starter_eval.fct_orders` |
+
+Nova metadata links:
+- `meta.nova.measures[]`: `gross_revenue`
+- `meta.nova.metric` or `meta.nova.metrics[]`: not used in this fixture
+- `recommended_filters`: not used in this fixture
+
+## Dimensions And Filter Values
+
+| Business concept | Field | Semantic type | Common values | Validation requirement |
+| --- | --- | --- | --- | --- |
+| Order date | `order_date` | time | fixture dates | Confirm requested date window exists when executing SQL. |
+| Country | `country_code` | country code | examples include `GB` | Validate friendly labels to exact codes before final SQL. |
+| Order status | `status` | status | fixture-defined accepted values | Use only after confirming the target status value. |
+
+## Common Workflows
+
+| Workflow | Recommended path | Required checks | Output shape |
+| --- | --- | --- | --- |
+| Gross revenue lookup | `search_indicator` for `gross revenue`, then compact context on `model.starter_eval.fct_orders` | Confirm `gross_revenue` and order grain before analysis. | selected model and measure |
+| Weekly revenue report | recipe `commerce/weekly_revenue` | Confirm recipe parameters and date range. | daily gross revenue and country rollup |
+
+## Cross-Domain Handoffs
+
+| When the question asks for... | Stay in this domain when... | Hand off to... | Handoff evidence |
+| --- | --- | --- | --- |
+| Customer geography | The question only needs order revenue by `country_code`. | customer domain reference, if available | `model.starter_eval.dim_customers` lineage |
+| Sessions or conversion | The question asks about visits, checkout, or conversion rate. | ecommerce sessions domain, if available | no session metric exists in the starter fixture |
+| Raw event provenance | The question is about sparse metadata behavior. | governance or metadata-audit workflow | `model.starter_eval.raw_events_sparse` metadata score |
+
+## Gotchas And Anti-Patterns
+
+- Do not use `model.starter_eval.raw_events_sparse` for revenue answers.
+- Do not invent conversion or session KPIs in this fixture; they are outside
+  starter commerce scope.
+- Do not treat `dim_customers` as a full customer analytics mart; it is a
+  supporting dimension for examples.
+- Do not bypass `gross_revenue` with raw SQL against `gross_amount` unless
+  semantic discovery failed and the fallback is documented.
+
+## Freshness, Tests, And Trust
+
+- Freshness signal: fixture manifest timestamp only.
+- Key tests: not-null and uniqueness tests on `fct_orders` identifiers and
+  selected columns.
+- Metadata score target: high enough to serve starter evals.
+- Known caveats: synthetic data, narrow entity set, no live warehouse freshness.
+- Required caveats in final answers: mention fixture scope when a user asks for
+  production interpretation.
+
+## Maintenance
+
+- Review cadence: whenever starter eval fixtures or packaged skills change.
+- Update triggers:
+  - `model.starter_eval.fct_orders` grain changes
+  - `gross_revenue` definition changes
+  - `commerce/weekly_revenue` recipe changes
+  - `evals/starter.yml` changes expected tool order or evidence
+- Required companion updates:
+  - fixture manifest or source YAML
+  - analyst or meta-authoring skill references
+  - starter eval suite
+
+## Evidence Log
+
+- 2026-06-23: Added as the synthetic example for JOE-27 domain reference docs.

--- a/.github/skills/meta-authoring/references/domain-reference-template.md
+++ b/.github/skills/meta-authoring/references/domain-reference-template.md
@@ -1,0 +1,201 @@
+# Domain Reference Template
+
+Use this template when a project needs a curated domain reference document next
+to dbt models, metadata, or project docs. Domain references explain business
+context that is too narrative for `meta.nova`, while still pointing back to the
+canonical Nova metadata fields that agents should verify.
+
+Domain references are curated sources of truth for agents and reviewers. They
+are not raw query dumps, historical notebook archives, or replacements for
+governed metadata. Keep them short, stable, and explicit about the canonical
+entities and filters an analyst should use.
+
+## Placement
+
+Preferred locations:
+- `models/<domain>/domain-reference.md`
+- `models/marts/<domain>/domain-reference.md`
+- `docs/domains/<domain>.md`
+- a colocated path chosen by the downstream project and documented in its skill
+  or agent setup
+
+Use one document per business domain or durable workflow family. Do not create a
+new domain reference for a one-off question.
+
+## Template
+
+Copy the sections below and replace bracketed placeholders. Remove sections only
+when they truly do not apply, and say `Not applicable` when omitting a section
+would hide an important boundary.
+
+```markdown
+# [Domain Name] Domain Reference
+
+## Status
+
+- Owner:
+- Maintainers:
+- Last reviewed:
+- Applies to dbt project:
+- Applies to Nova domains:
+- Related eval suites:
+
+## Business Context
+
+[Explain the domain in 3-6 sentences. Include the business process, the common
+analyst questions, and the decisions this domain supports.]
+
+Nova metadata links:
+- `meta.nova.domains`:
+- `meta.nova.use_cases`:
+- `meta.nova.synonyms`:
+- `meta.nova.governance`:
+
+## Canonical Entities
+
+| Purpose | dbt unique_id | Relation | Why canonical | Nova metadata |
+| --- | --- | --- | --- | --- |
+| Primary execution dataset | `model.pkg.model_name` | `catalog.schema.table` | [Reason] | `canonical`, `grain`, `measures` |
+| Supporting dimension | `model.pkg.dimension_name` | `catalog.schema.table` | [Reason] | `domains`, `grain` |
+
+Guidance:
+- Name the canonical execution model first.
+- Prefer `unique_id` over friendly names.
+- Explain when a source, staging, helper, or intermediate model should not be
+  used directly by analysts.
+
+## Grain And Scope
+
+- Primary grain:
+- Primary key:
+- Time field:
+- Default dimensions:
+- Supported breakdowns:
+- Unsupported breakdowns:
+
+Scope rules:
+- Included:
+- Excluded:
+- Known partial coverage:
+
+Nova metadata links:
+- `meta.nova.grain.primary_key`:
+- `meta.nova.grain.time_field`:
+- `meta.nova.grain.dimensions`:
+
+## Standard Hygiene Filters
+
+| Filter purpose | Field | Required values or rule | Applies by default? | Notes |
+| --- | --- | --- | --- | --- |
+| [valid records] | `[field_name]` | `[rule]` | yes/no | [Reason] |
+| [market] | `[field_name]` | `[value list]` | yes/no | [Validation note] |
+
+Guidance:
+- Include required filters that protect correctness, such as valid statuses,
+  canonical channels, or non-test records.
+- Use exact coded values when known.
+- Say which filter values must be validated in the warehouse before final SQL.
+
+## Measures And Metrics
+
+| Business term | Nova indicator | Type | Expression or definition | Parent entity |
+| --- | --- | --- | --- | --- |
+| [term] | `[measure_or_metric_name]` | measure/metric | `[definition]` | `model.pkg.model_name` |
+
+Nova metadata links:
+- `meta.nova.measures[]`:
+- `meta.nova.metric` or `meta.nova.metrics[]`:
+- `recommended_filters`:
+
+Guidance:
+- Prefer canonical Nova measures or metrics over prose formulas.
+- If the domain reference explains a KPI formula, point to the metadata owner
+  and do not duplicate a divergent expression.
+
+## Dimensions And Filter Values
+
+| Business concept | Field | Semantic type | Common values | Validation requirement |
+| --- | --- | --- | --- | --- |
+| [country] | `[field_name]` | `[semantic_type]` | `[coded values]` | [How to validate] |
+
+Guidance:
+- Include high-signal dimensions only.
+- Map friendly labels to exact warehouse values when stable.
+- Mark values that are examples, not authoritative enumerations.
+
+## Common Workflows
+
+| Workflow | Recommended path | Required checks | Output shape |
+| --- | --- | --- | --- |
+| [weekly report] | [recipe, metric, or entity] | [filters, dates, eval gate] | [tables, KPIs] |
+
+Guidance:
+- Link recurring workflows to Nova recipes or eval suites when available.
+- Keep one-off report logic out of this section unless it is becoming standard.
+
+## Cross-Domain Handoffs
+
+| When the question asks for... | Stay in this domain when... | Hand off to... | Handoff evidence |
+| --- | --- | --- | --- |
+| [concept] | [condition] | [domain/entity] | [metadata, lineage, owner] |
+
+Guidance:
+- Document joins or handoffs that are safe.
+- Document boundaries where analysts should ask a clarifying question.
+- Do not imply that incompatible grains can be joined without caveats.
+
+## Gotchas And Anti-Patterns
+
+- [Do not use `model.pkg.helper_model` for analyst answers because...]
+- [Do not compare X to Y without...]
+- [Raw source tables are for provenance only unless...]
+
+Guidance:
+- Include only pitfalls that materially change answers.
+- Prefer short rules an agent can apply before execution.
+
+## Freshness, Tests, And Trust
+
+- Freshness signal:
+- Key tests:
+- Metadata score target:
+- Known caveats:
+- Required caveats in final answers:
+
+Nova metadata links:
+- `meta.nova.governance`:
+- test coverage:
+- source freshness:
+- eval gate:
+
+## Maintenance
+
+- Review cadence:
+- Update triggers:
+  - canonical model changed
+  - `meta.nova.grain` changed
+  - measure or metric definition changed
+  - standard filter value changed
+  - eval suite changed
+- Required companion updates:
+  - dbt YAML or `meta.nova`
+  - skill/reference docs
+  - eval suite or golden question
+
+## Evidence Log
+
+- [YYYY-MM-DD] [Short note about the evidence, issue, PR, or eval run that
+  changed this reference.]
+```
+
+## Review Checklist
+
+Before handing off a domain reference:
+- Every canonical entity has a `unique_id`.
+- Grain, time field, required filters, gotchas, and handoffs are explicit.
+- The document points back to `meta.nova.domains`, `use_cases`, `grain`,
+  `measures`, `metric(s)`, and `governance` where relevant.
+- No section relies on a raw query corpus as authority.
+- Synthetic examples use synthetic project names only.
+- The document says when to ask for clarification instead of forcing a join or
+  metric proxy.

--- a/.github/skills/meta-authoring/references/review-checklist.md
+++ b/.github/skills/meta-authoring/references/review-checklist.md
@@ -16,6 +16,9 @@ Use this before final handoff.
 - Sources and staging resources stay sparse but include governance when sensitivity or PII is present.
 - Column annotations are limited to identifiers, time fields, high-signal dimensions, measures, and genuine disambiguation.
 - Synonyms are concise and business-facing.
+- Domain references keep narrative guidance out of `meta.nova` while still
+  linking back to `domains`, `use_cases`, `grain`, `measures`, `metric(s)`, and
+  `governance`.
 
 ## Canonicality And Reuse
 
@@ -46,3 +49,5 @@ Use this before final handoff.
 - `search_indicator` or `search` returns the expected canonical result for key terms.
 - `get_entity`, `get_context`, or `get_columns` confirms the final contract.
 - `get_metadata_score` improves or any non-score tradeoff is explained.
+- Domain reference changes were validated with skill installation and docs build
+  when the packaged template or docs changed.

--- a/.github/skills/meta-authoring/references/workflow.md
+++ b/.github/skills/meta-authoring/references/workflow.md
@@ -8,10 +8,12 @@ Use this sequence for both authoring and review. The main failure mode is adding
 2. Classify the target entity.
 3. Inventory repeated concepts before adding new canonical metadata.
 4. Choose the smallest correct Nova surface.
-5. Validate local edits with schema/audit tooling when available.
-6. Rebuild or refresh the manifest through the project workflow.
-7. Verify search, grain, and score behavior against the refreshed manifest.
-8. Widen scope only after the narrow target is clean.
+5. If authoring a domain reference, separate stable metadata facts from
+   narrative guidance before writing the reference.
+6. Validate local edits with schema/audit tooling when available.
+7. Rebuild or refresh the manifest through the project workflow.
+8. Verify search, grain, and score behavior against the refreshed manifest.
+9. Widen scope only after the narrow target is clean.
 
 ## Classification
 
@@ -45,6 +47,27 @@ Use:
 - `search.candidates` for audience-specific de-ranking only
 
 Prefer fewer high-signal fields over exhaustive metadata.
+
+## Domain References
+
+Use `references/domain-reference-template.md` when a team needs curated
+business guidance alongside dbt models or docs. Domain references are the right
+surface for:
+- business context and supported decisions
+- scope and exclusions
+- standard hygiene filters and value validation notes
+- canonical-entity rationale
+- gotchas and anti-patterns
+- cross-domain handoffs
+- maintenance triggers
+
+Keep canonical definitions in `meta.nova`. A domain reference may explain why a
+model or metric is canonical, but it should point to `meta.nova.domains`,
+`use_cases`, `grain`, `measures`, `metric(s)`, and `governance` rather than
+duplicating divergent formulas or free-text metadata.
+
+Do not treat a raw query corpus, dashboard, or notebook as authoritative. Use
+those only as supporting evidence after the governed metadata surface is clear.
 
 ## Verification
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added a reusable domain reference template and synthetic starter commerce
+  example to the meta-authoring skill, plus analyst guidance and docs for using
+  curated domain references as stable context rather than raw query dumps.
 - Tightened the analyst skill around semantic-first KPI discovery, added
   eval-author guidance and starter eval expectations for `search_indicator`
   before context or SQL execution, and added scorer coverage for rejecting SQL

--- a/docs/features/domain-references.md
+++ b/docs/features/domain-references.md
@@ -1,0 +1,182 @@
+# Domain References
+
+Domain references are curated Markdown guides that sit next to dbt models,
+metadata, or project docs. They capture stable business context that is too
+narrative for `meta.nova`: grain, scope, standard filters, canonical entities,
+gotchas, cross-domain handoffs, and maintenance rules.
+
+They are curated sources of truth for domain context. They complement Nova
+metadata, and they do not replace `meta.nova`, eval suites, recipes, lineage,
+tests, or warehouse validation.
+
+## Why They Exist
+
+Raw query corpora are noisy planning material. They often contain stale logic,
+one-off filters, duplicated definitions, and bypasses around governed metrics.
+Domain references give agents a curated layer between compact `meta.nova`
+contracts and verbose project history.
+
+Use a domain reference when a team needs to answer:
+- Which model is canonical for this domain?
+- What grain and time field should analysis use?
+- Which filters are standard hygiene rules?
+- Which measures or metrics are governed?
+- Which gotchas should stop an agent before SQL execution?
+- When should the question hand off to another domain?
+
+## Placement
+
+Recommended locations:
+
+```text
+models/<domain>/domain-reference.md
+models/marts/<domain>/domain-reference.md
+docs/domains/<domain>.md
+```
+
+Pick one convention per project and document it in your agent or skill setup.
+Keep references close enough to model metadata that reviewers notice drift.
+
+## Required Sections
+
+Each domain reference should include:
+
+| Section | Purpose | Nova metadata link |
+| --- | --- | --- |
+| Status | Owner, maintainers, review date, dbt project, related evals | owner, governance |
+| Business context | Stable domain description and supported decisions | `domains`, `use_cases`, `synonyms` |
+| Canonical entities | Preferred execution models, dimensions, and excluded helpers | `canonical`, `tier`, `grain` |
+| Grain and scope | Primary key, time field, dimensions, inclusions, exclusions | `grain` |
+| Standard hygiene filters | Required filters and exact coded values | columns, `recommended_filters` |
+| Measures and metrics | Governed indicators and parent entities | `measures`, `metric`, `metrics` |
+| Dimensions and values | High-signal filters and validation expectations | column `role`, `semantic_type`, `example_values` |
+| Common workflows | Recurring recipes, evals, or output shapes | recipes, eval suites |
+| Cross-domain handoffs | When to stay, ask, split, or hand off | lineage, domains |
+| Gotchas | Rules that materially change answers | metadata, tests, lineage |
+| Freshness and trust | Tests, freshness, caveats, score targets | governance, tests, freshness |
+| Maintenance | Review cadence and companion update rules | PR/eval process |
+
+The installable `meta-authoring` skill includes the copy-ready template at
+`.github/skills/meta-authoring/references/domain-reference-template.md`.
+
+## Authoring Rules
+
+- Prefer `unique_id` over friendly model names.
+- Keep prose short and durable. Put high-churn details in metadata, tests, or
+  evals instead.
+- Tie each canonical recommendation back to `meta.nova.domains`,
+  `use_cases`, `grain`, `measures`, `metric(s)`, or `governance` when possible.
+- Treat standard filter values as claims that need validation unless they are
+  already enforced by metadata, tests, or accepted-values checks.
+- Explain when to ask for clarification instead of joining incompatible grains.
+- Include only gotchas that materially change answers.
+- Do not use raw SQL history, query corpora, dashboards, or notebooks as the
+  source of authority. They can be supporting evidence only.
+
+## Synthetic Example
+
+This example uses the synthetic `starter_eval` fixture names.
+
+```markdown
+# Starter Commerce Domain Reference
+
+## Status
+
+- Owner: analytics enablement
+- Maintainers: dbt-nova example maintainers
+- Last reviewed: 2026-06-23
+- Applies to dbt project: `starter_eval`
+- Applies to Nova domains: `commerce`
+- Related eval suites: `evals/starter.yml`
+
+## Business Context
+
+The starter commerce domain covers synthetic order reporting for examples,
+skills, and evals. Analysts use it to identify the canonical orders model,
+resolve gross revenue, inspect customer geography, and run the weekly revenue
+recipe. The domain is deliberately narrow: it proves Nova discovery, context,
+lineage, recipes, metadata scoring, and agent tool-use behavior without relying
+on a real warehouse or real business data.
+
+## Canonical Entities
+
+| Purpose | dbt unique_id | Relation | Why canonical |
+| --- | --- | --- | --- |
+| Primary execution dataset | `model.starter_eval.fct_orders` | `analytics.starter.fct_orders` | Owns order-grain reporting and the canonical gross revenue measure. |
+| Customer geography dimension | `model.starter_eval.dim_customers` | `analytics.starter.dim_customers` | Supplies customer attributes and geography used by the order fact. |
+| Raw sparse example | `model.starter_eval.raw_events_sparse` | `analytics.starter.raw_events_sparse` | Demonstrates sparse metadata and should not be the analyst landing page. |
+
+## Grain And Scope
+
+- Primary grain: one row per order
+- Primary key: `order_id`
+- Time field: `order_date`
+- Default dimensions: `country_code`, `status`
+- Supported breakdowns: order date, country code, status
+- Unsupported breakdowns: session, product, shipment, and marketing attribution
+
+## Standard Hygiene Filters
+
+| Filter purpose | Field | Required values or rule | Applies by default? |
+| --- | --- | --- | --- |
+| Completed order reporting | `status` | validate accepted fixture values before filtering | no |
+| Geography reporting | `country_code` | exact country code such as `GB` | no |
+
+## Measures And Metrics
+
+| Business term | Nova indicator | Type | Definition | Parent entity |
+| --- | --- | --- | --- | --- |
+| Gross revenue | `gross_revenue` | measure | Sum of `gross_amount` at order grain. | `model.starter_eval.fct_orders` |
+
+## Cross-Domain Handoffs
+
+- Stay in this domain for order revenue by date, status, or country.
+- Hand off when the question asks about sessions, checkout conversion,
+  marketing attribution, stock, margin, or fulfilment.
+- Use `model.starter_eval.raw_events_sparse` only for sparse-metadata examples.
+```
+
+The full synthetic example is packaged with the `meta-authoring` skill at
+`.github/skills/meta-authoring/references/domain-reference-example.md`.
+
+## How Agents Should Use References
+
+Analyst agents should:
+
+1. Resolve governed indicators first with `search_indicator` for KPI-shaped
+   questions.
+2. Use the domain reference to confirm canonical entity, grain, filters,
+   gotchas, and handoff boundaries.
+3. Verify current fields, values, lineage, and trust evidence through Nova tools.
+4. Report material caveats from the reference when they affect interpretation.
+
+If the domain reference conflicts with current Nova tool evidence, treat the
+reference as stale or ambiguous and prefer current manifest evidence.
+
+Meta-authoring agents should:
+
+1. Check repeated concepts with Nova search and indicator tools before writing.
+2. Keep canonical facts in `meta.nova`; keep narrative guidance in the domain
+   reference.
+3. Update the relevant skill, reference doc, or eval when model metadata changes.
+4. Validate docs and skills before handing off.
+
+## Validation
+
+For dbt-nova itself, validate packaged skills and docs:
+
+```bash
+bash scripts/install_skills.sh --all --skills-dir /tmp/dbt-nova-skills-test
+uv run mkdocs build --strict
+```
+
+For downstream projects, add project-specific checks around the chosen reference
+location. A future maintenance check can warn when dbt model or metadata changes
+arrive without a matching skill, reference, or eval update.
+
+## Related Guides
+
+- [Nova Meta Overview](nova-meta-overview.md)
+- [Nova Meta (Models)](nova-meta-models.md)
+- [Nova Meta (Metrics)](nova-meta-metrics.md)
+- [Agent Skills](../getting-started/skills.md)

--- a/docs/features/nova-meta-overview.md
+++ b/docs/features/nova-meta-overview.md
@@ -126,6 +126,9 @@ If you use `pii` as a list, prefer explicit classes (`["email", "phone"]`).
 - **Metadata scoring**: evaluates coverage and quality of key Nova fields.
 - **Governance filters**: enables queries like “show restricted” or “pii”.
 - **Agent workflows**: persona skills rely on Nova meta for reliable outputs.
+- **Domain references**: curated Markdown guides can add stable business
+  context, gotchas, hygiene filters, and cross-domain handoffs while pointing
+  back to the canonical `meta.nova` fields.
 
 `search.candidates` is a ranking hint:
 - Missing keys default to `true`
@@ -201,4 +204,5 @@ behind the same authentication posture used for the rest of the MCP surface.
 
 - [Nova Meta (Models)](nova-meta-models.md)
 - [Nova Meta (Metrics)](nova-meta-metrics.md)
+- [Domain References](domain-references.md)
 - [Search Ranking](search-ranking.md)

--- a/docs/getting-started/skills.md
+++ b/docs/getting-started/skills.md
@@ -32,6 +32,11 @@ The repo also ships deterministic helper scripts for architecture and cleanup wo
 
 These scripts call Nova CLI tools directly and keep their outputs aligned with the tool contracts rather than introducing a second reporting schema.
 
+The `meta-authoring` skill also ships a reusable domain reference template and
+synthetic example. Domain references are curated Markdown guides for business
+context, grain, standard filters, canonical entities, gotchas, and cross-domain
+handoffs; see [Domain References](../features/domain-references.md).
+
 ## Install in common tools
 
 Use the standalone persona skill directly when you want one workflow.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -135,6 +135,7 @@ nav:
     - Nova Meta Overview: features/nova-meta-overview.md
     - Nova Meta (Models): features/nova-meta-models.md
     - Nova Meta (Metrics): features/nova-meta-metrics.md
+    - Domain References: features/domain-references.md
   - Operations:
     - Ops & Troubleshooting: operations/ops.md
     - Hosted Deployment: operations/hosted-deployment.md


### PR DESCRIPTION
## Summary
- add a copy-ready domain reference template and synthetic starter commerce example to the installable meta-authoring skill
- teach the analyst and meta-authoring skills how to consume, author, and review curated domain references
- document domain references in MkDocs, link them from Nova Meta and skills docs, and add the page to the docs nav

## Validation
- git diff --check
- bash scripts/install_skills.sh --all --skills-dir /var/folders/pl/x8lgf0px3_ggrmj305g_x1gw0000gn/T/tmp.DfJS2KacXA
- uv run mkdocs build --strict

Closes JOE-27