### PR TITLE
Add adversarial reviewer skill

### DIFF
--- a/.github/skills/analyst/SKILL.md
+++ b/.github/skills/analyst/SKILL.md
@@ -88,7 +88,10 @@ Do not mix transports in one answer unless you are explicitly debugging transpor
 6. Validate non-trivial filter values before aggregation.
 7. Escalate trust checks only when useful.
 8. Execute.
-9. Report with explicit evidence.
+9. For high-stakes, leadership-bound, launch-readiness, customer-facing, or
+   recurring production answers, prepare a review packet and run the `reviewer`
+   skill before finalizing when it is available.
+10. Report with explicit evidence.
 
 Rules:
 - Prefer a common parent across requested indicators.
@@ -103,6 +106,14 @@ Rules:
 - Keep validation probes close to the target slice. Do not scan a year-plus range just to confirm one filter member.
 - Do not front-load every trust tool by default. Escalate only when the answer is high-stakes or the entity choice is ambiguous.
 - For high-stakes, launch-readiness, or recurring production workflows, check the relevant eval suite gate with `dbt-nova eval gate <suite_name> --json` when CLI access and suite ownership are known. Treat blocked gates as advisory warnings to surface before final analysis, not as permission to hide the answer.
+- For high-stakes, leadership-bound, launch-readiness, customer-facing, or
+  recurring production answers, pass a draft through the `reviewer` skill before
+  finalizing when the skill is available. Include the user question, draft
+  answer, selected entity/source, semantic discovery or fallback evidence, SQL
+  or recipe summary, and provenance/freshness blocks.
+- If the reviewer returns `fix_required` or `needs_evidence`, resolve that
+  finding or surface it as a final-answer blocker/caveat rather than silently
+  shipping the draft unchanged.
 
 ## Analysis discipline
 

--- a/.github/skills/analyst/references/workflow.md
+++ b/.github/skills/analyst/references/workflow.md
@@ -41,7 +41,10 @@ Use this prompt when needed:
 6. Verify execution fields only after the winning entity is chosen.
 7. Validate filter values with bounded execution before aggregation.
 8. Run the final SQL or recipe.
-9. Report the answer with explicit evidence.
+9. For high-stakes, leadership-bound, launch-readiness, customer-facing, or
+   recurring production answers, build a reviewer packet and run the `reviewer`
+   skill when available.
+10. Report the answer with explicit evidence.
 
 Do not skip filter-value validation when the question includes geography, market, segment, or channel constraints.
 
@@ -198,6 +201,22 @@ Use trust and provenance tools proportionally:
 - metadata score when documenting caveats or choosing between similar entities
 
 Do not front-load every trust tool by default. Escalate only when the answer is high-stakes or the entity choice is ambiguous.
+
+## Reviewer handoff rule
+
+For high-stakes answers, prepare a reviewer packet before the final response:
+
+- user question
+- answer draft
+- selected entity/source and relation
+- selected indicator, metric, measure, recipe, or fallback reason
+- SQL summary or recipe query summary
+- semantic discovery evidence
+- provenance tier and freshness status for evidence used in the answer
+
+If the `reviewer` skill returns `fix_required` or `needs_evidence`, do not ship
+the draft unchanged. Fix the route/caveat, gather the missing evidence, or state
+the blocker clearly in the final answer.
 
 ## Output requirement
 

--- a/.github/skills/eval-author/SKILL.md
+++ b/.github/skills/eval-author/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: "Bash Read Write mcp__nova__show_metadata mcp__nova__health mcp__
 metadata:
   owner: "dbt-nova"
   persona: "eval-author"
-  version: "0.0.5"
+  version: "0.0.6"
 ---
 
 # Eval Author Skill (dbt-nova)
@@ -60,6 +60,10 @@ Eval execution is CLI-only. MCP is for discovering ground truth and debugging ex
 - Prefer stable identifiers such as `unique_id`, `parent_unique_id`, recipe id, and column name.
 - Use bridge evals for search rank, indicator rank, column rank, context fields, lineage edges, metadata score, recipe discovery, and generic tool success.
 - Use agent evals for required tool calls, forbidden tools, ordering, selected entities, ranked entity evidence, safe parameter checks, and final-answer text.
+- Use reviewer agent evals for adversarial judgment over a supplied review
+  packet: semantic-layer bypass, missing stale/unknown freshness caveats, and
+  `needs_evidence` behavior. Keep these cases focused on final-answer verdict
+  terms unless the provider reliably emits tool traces for no-tool reviews.
 - For KPI or metric workflows, assert semantic-first behavior explicitly:
   `search_indicator` before `get_context` for definition/context tasks, and
   `search_indicator` before `execute_sql` for execution tasks.
@@ -81,6 +85,8 @@ When handing off an eval suite or eval fix, include:
 - declared manifest scope and known gaps
 - bridge cases and what each proves
 - agent cases and what each proves
+- reviewer agent cases and which wrong-answer mode each challenges, when the
+  suite covers answer review behavior
 - semantic-first or fallback behavior each agent case proves
 - gate threshold and intended run cadence
 - command lines to validate and run

--- a/.github/skills/eval-author/references/provider-patterns.md
+++ b/.github/skills/eval-author/references/provider-patterns.md
@@ -73,6 +73,68 @@ Fallback cases should be separate. They should still require a
 expected final answer capture why no governed indicator or semantic parent was
 usable.
 
+## Reviewer Agent Eval Pattern
+
+Use reviewer agent evals when the behavior under test is adversarial review of
+a draft answer, not fresh analysis. Set `defaults.persona: reviewer` so the
+provider prompt uses the reviewer contract. Give the task a self-contained
+review packet with the user question, draft answer, selected entity/source,
+semantic discovery evidence, provenance/freshness blocks, and SQL or recipe
+summary when available.
+
+Keep reviewer eval assertions durable. Prefer final-answer verdict terms over
+tool-trace expectations unless the provider reliably emits trace rows for
+no-tool reviews.
+
+Semantic-layer bypass case:
+
+```yaml
+version: 1
+name: reviewer-smoke
+defaults:
+  persona: reviewer
+agent_cases:
+  - id: flags_semantic_layer_bypass
+    task: |
+      Review packet:
+      - user question: What was gross revenue last week?
+      - governed semantic evidence: search_indicator returned measure
+        gross_revenue on model.pkg.orders with provenance.tier semantic_layer.
+      - draft route: draft answer used source.pkg.raw_orders as primary
+        evidence and gave no fallback reason.
+      - draft answer: Gross revenue was 42,000 from raw_orders.
+      Return the reviewer output contract.
+    expected:
+      final_answer:
+        must_contain:
+          - fix_required
+          - semantic-layer bypass
+          - gross_revenue
+          - model.pkg.orders
+```
+
+Stale or unknown freshness case:
+
+```yaml
+agent_cases:
+  - id: flags_unknown_freshness_without_caveat
+    task: |
+      Review packet:
+      - user question: What was gross revenue last week?
+      - selected entity: model.pkg.orders
+      - provenance.freshness.status: unknown
+      - provenance.freshness.reason: no_freshness_timestamp
+      - draft answer: Gross revenue was 42,000.
+      Return the reviewer output contract.
+    expected:
+      final_answer:
+        must_contain:
+          - fix_required
+          - freshness
+          - unknown
+          - caveat
+```
+
 ## Useful Expectations
 
 ```yaml

--- a/.github/skills/reviewer/SKILL.md
+++ b/.github/skills/reviewer/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: reviewer
+description: "Adversarially reviews high-stakes dbt-nova analytics answer drafts for evidence quality, semantic-layer bypass, stale or unknown freshness caveats, and provenance-backed fixes. Use before leadership-bound, launch-readiness, customer-facing, or recurring production answers."
+license: MIT
+allowed-tools: "Read Bash mcp__nova__show_metadata mcp__nova__health mcp__nova__search mcp__nova__search_indicator mcp__nova__indicator_inventory mcp__nova__search_recipes mcp__nova__get_recipe mcp__nova__get_entity mcp__nova__batch_get_entities mcp__nova__get_columns mcp__nova__search_columns mcp__nova__column_inventory mcp__nova__get_lineage mcp__nova__get_column_lineage mcp__nova__get_context mcp__nova__get_test_coverage mcp__nova__get_metadata_score mcp__nova__find_by_path"
+metadata:
+  owner: "dbt-nova"
+  persona: "reviewer"
+  version: "0.0.1"
+---
+
+# Reviewer Skill (dbt-nova)
+
+## Mission
+
+Adversarially review a draft Nova analytics answer before it becomes a final
+answer. The reviewer looks for evidence-backed correctness risks, especially:
+
+- semantic-layer bypass: the draft uses a raw/source table when a governed Nova
+  metric, measure, or semantic parent was available
+- stale or unknown freshness: the draft relies on stale or unknown-freshness
+  evidence without warning the user
+
+This skill reviews the draft; it does not answer the original business question.
+
+## Input Contract
+
+Require a review packet with:
+
+- user question
+- final answer draft
+- selected entity or source, including `unique_id` and relation when available
+- selected indicator, metric, measure, recipe, or raw-search fallback reason
+- SQL summary or recipe query summary when execution was used
+- provenance blocks from search, context, lineage, or entity evidence
+- freshness status, source, timestamp, and stale threshold when available
+- semantic discovery evidence, including rejected governed candidates when the
+  answer used a raw/source table
+
+If the packet is incomplete, do not guess. Return `needs_evidence` and name the
+missing evidence needed to review the draft.
+
+## Output Contract
+
+Every review must return:
+
+- `verdict`: one of `pass`, `fix_required`, or `needs_evidence`
+- `findings`: concise findings with `severity`, `evidence`, and
+  `suggested_fix`
+- `residual_caveats`: any remaining limitations after the suggested fix
+
+Severity values:
+
+- `blocker`: likely wrong or unsafe final answer until fixed
+- `high`: materially weak evidence or caveat gap
+- `medium`: useful correction that does not obviously change the answer
+- `low`: wording, completeness, or auditability improvement
+
+## Rules
+
+- Use evidence from provenance/search/context/lineage/eval context, not vibes.
+- Do not execute SQL. Request the SQL summary or trace evidence instead.
+- Do not mutate files, refresh manifests, warm storage, prune storage, or run
+  provider-backed evals from the review.
+- Do not invent missing metadata, freshness timestamps, owners, tests, or
+  semantic candidates.
+- Flag semantic-layer bypass when a governed source was available and the draft
+  used raw/source table evidence without a documented fallback reason.
+- Flag stale or unknown freshness when the draft omits a caveat that would
+  materially affect interpretation.
+- Treat the review as explicit advisory workflow. Do not create a hidden
+  automatic blocking system or multi-round debate.
+
+## Load Order
+
+- Read `references/workflow.md` first.
+- Read `references/challenge-patterns.md` before deciding the verdict.
+- Read `references/evidence-sources.md` only if the packet lacks evidence and
+  the client can gather read-only Nova context.
+- Load `assets/review-output-template.md` only when producing the formal review.

--- a/.github/skills/reviewer/assets/review-output-template.md
+++ b/.github/skills/reviewer/assets/review-output-template.md
@@ -1,0 +1,18 @@
+# Reviewer Output Template
+
+```text
+verdict: fix_required | needs_evidence | pass
+
+findings:
+- severity: blocker | high | medium | low
+  title:
+  evidence:
+  suggested_fix:
+
+residual_caveats:
+- <caveat or none>
+```
+
+For `pass`, keep findings empty or include only low-severity wording
+improvements. For `needs_evidence`, each finding should name one missing
+evidence field and the exact source that should supply it.

--- a/.github/skills/reviewer/references/challenge-patterns.md
+++ b/.github/skills/reviewer/references/challenge-patterns.md
@@ -1,0 +1,68 @@
+# Challenge Patterns
+
+## Semantic-Layer Bypass
+
+Flag semantic-layer bypass when all of these are true:
+
+- the user question is KPI, metric, measure, rate, funnel, or conversion shaped
+- the evidence packet shows a governed Nova metric, measure, recipe, or semantic
+  parent that covers the question
+- the draft uses a raw/source table, staging model, SQL inspection, or broad
+  model search as its answer basis
+- the draft does not state an evidence-backed fallback reason
+
+Common evidence:
+
+- `search_indicator` returned a relevant metric or measure
+- `provenance.tier` is `semantic_layer` on a candidate parent
+- context includes `meta.nova.measures`, `meta.nova.metrics`, or a recipe with a
+  matching business definition
+- the draft cites a source/staging relation such as `source.*`, `raw_*`, or
+  `stg_*` as the primary answer basis
+
+Acceptable fallback reasons:
+
+- semantic discovery returned no relevant indicator
+- the relevant indicator had no credible execution parent
+- the question was not KPI-shaped after decomposition
+- a recipe fully covered the recurring deliverable and supplied the semantic
+  contract
+
+Suggested fix:
+
+- switch the answer to the governed entity or recipe, or
+- keep the fallback but state the failed semantic-discovery attempt, why the
+  governed source was not usable, and the caveat this creates
+
+## Stale Or Unknown Freshness Without Caveat
+
+Flag missing freshness caveats when:
+
+- `provenance.freshness.status` is `stale` or `unknown`
+- the draft uses that evidence as the basis for a result, conclusion, or
+  recommendation
+- the draft does not warn that freshness is stale or unknown
+
+Common evidence:
+
+- `freshness.status: stale`
+- `freshness.status: unknown`
+- `freshness.reason: no_freshness_timestamp`
+- stale source freshness or manifest-generated timestamp beyond
+  `stale_after_days`
+
+Suggested fix:
+
+- add a caveat with the exact freshness status and source
+- include timestamp, age, and stale threshold when available
+- avoid leadership-ready or launch-ready wording until freshness is resolved
+
+## Non-Finding Cases
+
+Do not flag a semantic bypass when the packet shows semantic discovery was tried
+and no relevant governed source existed.
+
+Do not flag a freshness caveat when the evidence is fresh and the answer does
+not otherwise overstate readiness.
+
+Do not invent a better source from names alone. Require actual Nova evidence.

--- a/.github/skills/reviewer/references/evidence-sources.md
+++ b/.github/skills/reviewer/references/evidence-sources.md
@@ -1,0 +1,40 @@
+# Evidence Sources
+
+Prefer the review packet supplied by the primary agent. Use read-only Nova
+context only when the packet is incomplete and the client can safely gather more
+evidence.
+
+## MCP Evidence
+
+Useful read-only MCP tools:
+
+- `search_indicator` for governed metrics and measures
+- `search` only after semantic evidence is absent or explicitly insufficient
+- `get_entity` or `get_context` for the selected entity contract
+- `get_lineage` or `get_column_lineage` for upstream provenance when relevant
+- `get_metadata_score` and `get_test_coverage` for readiness caveats
+- `search_recipes` and `get_recipe` for recurring deliverables
+
+Do not call `execute_sql`, `run_recipe`, manifest lifecycle tools, storage admin
+tools, or eval write/run tools from a reviewer workflow.
+
+## CLI Evidence
+
+When MCP tools are unavailable and CLI access is explicitly allowed, use
+read-only `dbt-nova tool call` commands only. Examples:
+
+```bash
+dbt-nova tool call search_indicator \
+  --params-json '{"query":"gross revenue","detail":"compact","group_mode":"top","limit":3}' \
+  --json
+```
+
+```bash
+dbt-nova tool call get_context \
+  --params-json '{"id_or_name":"model.pkg.orders","detail":"standard"}' \
+  --json
+```
+
+For review, CLI output is evidence only if it includes the relevant identity,
+semantic contract, provenance tier, and freshness status. If a CLI call cannot
+return those fields, ask for the missing evidence instead of guessing.

--- a/.github/skills/reviewer/references/workflow.md
+++ b/.github/skills/reviewer/references/workflow.md
@@ -1,0 +1,73 @@
+# Reviewer Workflow
+
+Use this workflow to review a high-stakes draft analytics answer with explicit
+Nova evidence.
+
+## Deterministic Sequence
+
+1. Confirm the packet includes the user question, draft answer, selected entity
+   or source, semantic discovery or fallback evidence, provenance blocks, and
+   SQL or recipe summary when applicable.
+2. If evidence is missing, stop with `needs_evidence`.
+3. Identify the evidence route used by the draft:
+   - governed metric, measure, or recipe
+   - curated model without direct indicator coverage
+   - raw/source table fallback
+4. Check whether a governed Nova metric, measure, or semantic parent was
+   available for the same business concept.
+5. Check each cited entity/source provenance block for `tier`, `readiness`, and
+   `freshness.status`.
+6. Compare the answer draft against the evidence:
+   - Does the draft name the selected semantic definition?
+   - Does it disclose raw-source fallback when used?
+   - Does it caveat stale or unknown freshness?
+   - Does it avoid overstating causality, precision, or readiness?
+7. Return a verdict with findings, severity, evidence, suggested fix, and
+   residual caveats.
+
+## Evidence Completeness Rule
+
+The minimum evidence for a pass is:
+
+- selected entity/source identity
+- semantic discovery result or explicit fallback reason
+- provenance tier for the selected entity/source
+- freshness status for evidence used in the answer, or explicit evidence that
+  freshness is unavailable
+- answer draft text
+
+If any of those are missing, return:
+
+```text
+verdict: needs_evidence
+findings:
+- severity: high
+  evidence: <missing field>
+  suggested_fix: Provide <specific evidence> before finalizing.
+```
+
+## Review Boundaries
+
+Do not rewrite the whole analysis. Give the smallest fix that lets the original
+agent repair the final answer.
+
+Do not replace reviewer evidence with intuition. If the draft feels wrong but
+the evidence packet cannot prove it, ask for the missing search, context,
+lineage, metadata-score, or freshness evidence.
+
+Do not run `execute_sql`. If the result looks suspicious, ask for the executed
+SQL summary, result rows, and filter validation evidence.
+
+## Verdict Rule
+
+Use `fix_required` when:
+
+- a governed semantic candidate exists and the draft used raw/source table
+  evidence without a fallback reason
+- evidence freshness is `stale` or `unknown` and the draft omits a caveat
+- the draft's selected entity, grain, time field, filter field, or indicator
+  differs from the cited evidence
+
+Use `needs_evidence` when the packet cannot prove pass or fail.
+
+Use `pass` only when the draft's route, caveats, and evidence are consistent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a reusable domain reference template and synthetic starter commerce
   example to the meta-authoring skill, plus analyst guidance and docs for using
   curated domain references as stable context rather than raw query dumps.
+- Added an adversarial `reviewer` skill and provider-backed reviewer eval
+  coverage for semantic-layer bypass and stale/unknown freshness caveats, plus
+  analyst and eval-author guidance for high-stakes answer review.
 - Tightened the analyst skill around semantic-first KPI discovery, added
   eval-author guidance and starter eval expectations for `search_indicator`
   before context or SQL execution, and added scorer coverage for rejecting SQL

--- a/docs/development/opencode-reference-pack.md
+++ b/docs/development/opencode-reference-pack.md
@@ -70,6 +70,7 @@ The shared skill packages in `.github/skills/` remain canonical:
 - `meta-authoring`
 - `model-architect`
 - `project-cleanup`
+- `reviewer`
 
 The OpenCode pack should copy those directories into `.opencode/skills/` during
 installation. The copied skill folders are generated artifacts from Nova's
@@ -112,6 +113,7 @@ opencode.json
     meta-authoring/
     model-architect/
     project-cleanup/
+    reviewer/
 ```
 
 Ownership:
@@ -125,6 +127,7 @@ Ownership:
 | `evals/starter.yml` | repo eval suite | Nova evals | Baseline bridge and agent smoke coverage. |
 | `evals/agent-tokenomics-opencode.yml` | repo eval suite | Nova evals | Provider-backed OpenCode agent smoke coverage. |
 | `evals/agent-tokenomics-bridge.yml` | repo eval suite | Nova evals | Deterministic bridge coverage for compact tool contracts. |
+| `evals/reviewer.yml` | repo eval suite | Nova evals | Provider-backed reviewer coverage for semantic bypass and freshness caveat checks. |
 
 ## MCP Config Examples
 
@@ -231,7 +234,8 @@ The generated global config should start from:
       "kpi-debugger": "allow",
       "meta-authoring": "allow",
       "model-architect": "allow",
-      "project-cleanup": "allow"
+      "project-cleanup": "allow",
+      "reviewer": "allow"
     }
   }
 }
@@ -269,8 +273,8 @@ expose deployment posture. Roles may allow them explicitly when needed.
 | `nova-metadata-steward` | `primary` | `meta-authoring`, `model-architect`, `governance` | `discovery`, `metadata-audit`, `structure` | `edit`; `bash` for dbt compile/test and Nova validation; `nova_reload_manifest` after local manifest rebuild | `execution` by default, `eval-write`, `trace-write`, storage pruning/cleanup; all unlisted `nova_*` | `dbt-nova audit nova-meta` against fixture metadata; `evals/starter.yml` metadata score cases; planned `.opencode` pack validator in JOE-28 |
 | `nova-eval-author` | `primary` | `eval-author` | `discovery`, `eval-read`, selected `metadata-audit` (`nova_get_metadata_score`, `nova_get_test_coverage`) | `edit`; `bash`; `eval-write`; `trace-write`; `execution` only when an eval case explicitly requires SQL | `admin-mutation` except config validation; all unrelated `nova_*` | `dbt-nova eval validate --suite evals/starter.yml`; `dbt-nova eval validate --suite evals/agent-tokenomics-opencode.yml`; provider smoke for one OpenCode case when credentials are available |
 | `nova-source-scout` | `subagent` | `analyst` | read-only subset of `discovery`: `nova_health`, `nova_show_metadata`, `nova_search`, `nova_search_indicator`, `nova_indicator_inventory`, `nova_search_columns`, `nova_column_inventory`, `nova_get_entity`, `nova_list_entities`, `nova_find_by_path`, `nova_get_columns`, `nova_get_context` | none | `structure` that reveals SQL, `execution`, `metadata-audit`, `eval-write`, `trace-write`, `admin-mutation`, `edit`, `bash`; all unlisted `nova_*` | `evals/starter.yml` cases `canonical_revenue_discovery`, `recipe_discovery` without executing recipes |
-| `nova-sql-reviewer` | `subagent` | `engineer`, `kpi-debugger` | selected `discovery`; selected `structure` (`nova_get_sql`, `nova_get_lineage`, `nova_get_column_lineage`, `nova_compare_grains`, `nova_get_test_coverage`, `nova_validate_dag`) | `bash` only for read-only local inspection if the primary agent requests it | `execution`, `eval-write`, `trace-write`, `admin-mutation`, `edit`; all unlisted `nova_*` | `evals/starter.yml` case `column_context_and_lineage`; planned adversarial reviewer suite from JOE-15 |
-| `nova-provenance-reviewer` | `subagent` | `governance`, planned reviewer skill from JOE-15 | `discovery`, `metadata-audit`, `eval-read`, selected `structure` (`nova_get_lineage`, `nova_get_column_lineage`, `nova_get_impact`) | `trace-write` only when producing redacted artifacts; `bash` only for local artifact inspection | `execution`, `eval-write`, storage pruning/cleanup, `edit`; all unlisted `nova_*` | `evals/agent-tokenomics-bridge.yml` trace/budget cases; planned JOE-15 stale-source and semantic-bypass reviewer suite |
+| `nova-sql-reviewer` | `subagent` | `engineer`, `kpi-debugger` | selected `discovery`; selected `structure` (`nova_get_sql`, `nova_get_lineage`, `nova_get_column_lineage`, `nova_compare_grains`, `nova_get_test_coverage`, `nova_validate_dag`) | `bash` only for read-only local inspection if the primary agent requests it | `execution`, `eval-write`, `trace-write`, `admin-mutation`, `edit`; all unlisted `nova_*` | `evals/starter.yml` case `column_context_and_lineage`; `evals/reviewer.yml` semantic-bypass case when delegated to the reviewer workflow |
+| `nova-provenance-reviewer` | `subagent` | `governance`, `reviewer` | `discovery`, `metadata-audit`, `eval-read`, selected `structure` (`nova_get_lineage`, `nova_get_column_lineage`, `nova_get_impact`) | `trace-write` only when producing redacted artifacts; `bash` only for local artifact inspection | `execution`, `eval-write`, storage pruning/cleanup, `edit`; all unlisted `nova_*` | `evals/agent-tokenomics-bridge.yml` trace/budget cases; `evals/reviewer.yml` stale-source and semantic-bypass reviewer cases |
 
 ## Agent Template Pattern
 
@@ -331,6 +335,7 @@ uv run mkdocs build --strict
 dbt-nova eval validate --suite evals/starter.yml
 dbt-nova eval validate --suite evals/agent-tokenomics-bridge.yml
 dbt-nova eval validate --suite evals/agent-tokenomics-opencode.yml
+dbt-nova eval validate --suite evals/reviewer.yml
 ```
 
 Bridge smoke for deterministic tool contracts:
@@ -371,6 +376,8 @@ Manual pack checklist:
 - SQL execution remains approval-gated.
 - File edits and eval/provider runs remain approval-gated.
 - Generated `.opencode/skills/*` directories match `.github/skills/*`.
+- Reviewer agents can load the `reviewer` skill and validate
+  `evals/reviewer.yml`.
 - No secrets, manifest URIs with credentials, or local customer paths are
   committed.
 
@@ -419,7 +426,5 @@ directly into those clients.
   workflow.
 - JOE-27: add a domain reference skeleton that the OpenCode pack can point to
   without embedding customer-specific context.
-- JOE-15: implement the adversarial reviewer skill and stale-source checks used
-  by `nova-provenance-reviewer`.
 - JOE-28: add generated-skill/reference maintenance checks for `.opencode`
   outputs and dbt model changes.

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -495,6 +495,36 @@ Fallback evals should be separate cases. They should still require a
 answer or trace evidence explains why no governed indicator or semantic parent
 could cover the ask.
 
+### Reviewer Agent Evals
+
+Reviewer evals test answer-review behavior rather than fresh analysis. Set
+`defaults.persona: reviewer` and give the task a self-contained review packet:
+user question, draft answer, selected entity/source, semantic discovery or
+fallback evidence, provenance/freshness blocks, and SQL or recipe summary when
+available.
+
+The packaged `evals/reviewer.yml` suite covers two reviewer failure modes:
+semantic-layer bypass and missing stale/unknown freshness caveats.
+
+```bash
+dbt-nova eval validate --suite evals/reviewer.yml
+```
+
+When a provider is configured:
+
+```bash
+dbt-nova eval agent run \
+  --suite evals/reviewer.yml \
+  --provider opencode \
+  --case-id reviewer_flags_semantic_layer_bypass \
+  --fail-under 1.0
+```
+
+Prefer durable `final_answer.must_contain` verdict terms such as
+`fix_required`, `semantic-layer bypass`, `freshness`, `unknown`, and `caveat`.
+Use tool-trace expectations only when the provider reliably emits trace rows for
+reviewer evidence gathering.
+
 Run against the default `opencode` adapter:
 
 ```bash

--- a/docs/getting-started/skills.md
+++ b/docs/getting-started/skills.md
@@ -15,6 +15,7 @@ The repo now uses one standalone, persona-first skill package per workflow:
 - `meta-authoring`
 - `model-architect`
 - `project-cleanup`
+- `reviewer`
 
 Each skill now has:
 - one canonical skill name
@@ -50,6 +51,7 @@ For one skill:
 bash scripts/install_skills.sh --skill analyst --skills-dir "$HOME/.agents/skills"
 bash scripts/install_skills.sh --skill engineer --skills-dir "$HOME/.agents/skills"
 bash scripts/install_skills.sh --skill eval-author --skills-dir "$HOME/.agents/skills"
+bash scripts/install_skills.sh --skill reviewer --skills-dir "$HOME/.agents/skills"
 ```
 
 For all dbt-nova skills:
@@ -74,6 +76,7 @@ Codex supports Agent Skills for both the CLI and IDE extensions. You can install
 bash scripts/install_skills.sh --skill analyst --skills-dir .codex/skills
 bash scripts/install_skills.sh --skill engineer --skills-dir .codex/skills
 bash scripts/install_skills.sh --skill eval-author --skills-dir .codex/skills
+bash scripts/install_skills.sh --skill reviewer --skills-dir .codex/skills
 ```
 
 If you already use another generic persona skill in a user-level directory, prefer repo scope so this skill overrides it only for the current project.
@@ -100,6 +103,7 @@ zip -r engineer.skill.zip engineer
 bash /path/to/repo/scripts/install_skills.sh --skill analyst --skills-dir "$HOME/.claude/skills"
 bash /path/to/repo/scripts/install_skills.sh --skill engineer --skills-dir "$HOME/.claude/skills"
 bash /path/to/repo/scripts/install_skills.sh --skill eval-author --skills-dir "$HOME/.claude/skills"
+bash /path/to/repo/scripts/install_skills.sh --skill reviewer --skills-dir "$HOME/.claude/skills"
 ```
 
 ### Gemini CLI
@@ -112,6 +116,7 @@ Gemini CLI discovers skills from three tiers: workspace (`.gemini/skills/`), use
 bash scripts/install_skills.sh --skill analyst --skills-dir .gemini/skills
 bash scripts/install_skills.sh --skill engineer --skills-dir .gemini/skills
 bash scripts/install_skills.sh --skill eval-author --skills-dir .gemini/skills
+bash scripts/install_skills.sh --skill reviewer --skills-dir .gemini/skills
 ```
 
 Then reload skills:
@@ -149,6 +154,7 @@ skills-ref validate .github/skills/kpi-debugger
 skills-ref validate .github/skills/meta-authoring
 skills-ref validate .github/skills/model-architect
 skills-ref validate .github/skills/project-cleanup
+skills-ref validate .github/skills/reviewer
 ```
 
 ## Further reading

--- a/evals/reviewer.yml
+++ b/evals/reviewer.yml
@@ -1,0 +1,104 @@
+version: 1
+name: reviewer
+purpose: Prove that a provider-backed reviewer agent challenges draft answers for semantic-layer bypass and missing stale/unknown freshness caveats using supplied Nova evidence.
+manifest_scope: Synthetic reviewer packets based on dbt-nova provenance contracts; no live warehouse SQL.
+known_gaps:
+  - Provider-backed suite; validate checks shape, while a configured provider is required to score reviewer behavior.
+  - Uses synthetic review packets and should be paired with bridge evals for real manifest metadata health.
+defaults:
+  persona: reviewer
+  top_k: 5
+
+agent_cases:
+  - id: reviewer_flags_semantic_layer_bypass
+    task: |
+      Review packet:
+
+      User question:
+      - What was gross revenue for completed orders last week?
+
+      Governed semantic evidence:
+      - `search_indicator` returned measure `gross_revenue`.
+      - Parent execution entity: `model.starter_eval.fct_orders`.
+      - Parent relation: `analytics_reporting.fct_orders`.
+      - Parent provenance.tier: `semantic_layer`.
+      - Parent freshness.status: `fresh`.
+
+      Draft route:
+      - The draft answer used `source.starter_eval.raw.orders` as the primary
+        evidence source.
+      - The draft did not state that semantic discovery failed.
+      - The draft did not give a fallback reason for ignoring
+        `model.starter_eval.fct_orders`.
+
+      Draft final answer:
+      - Gross revenue was 42,000 from `source.starter_eval.raw.orders`.
+
+      Return the reviewer output contract.
+    expected:
+      final_answer:
+        must_contain:
+          - fix_required
+          - semantic-layer bypass
+          - source.starter_eval.raw.orders
+          - model.starter_eval.fct_orders
+          - gross_revenue
+
+  - id: reviewer_flags_unknown_freshness_without_caveat
+    task: |
+      Review packet:
+
+      User question:
+      - What was gross revenue for completed orders last week?
+
+      Selected evidence:
+      - Selected entity: `model.starter_eval.fct_orders`.
+      - Selected measure: `gross_revenue`.
+      - provenance.tier: `semantic_layer`.
+      - provenance.freshness.status: `unknown`.
+      - provenance.freshness.reason: `no_freshness_timestamp`.
+
+      Draft final answer:
+      - Gross revenue was 42,000. The answer presents the figure as ready to
+        share and does not mention freshness.
+
+      Return the reviewer output contract.
+    expected:
+      final_answer:
+        must_contain:
+          - fix_required
+          - freshness
+          - unknown
+          - caveat
+          - model.starter_eval.fct_orders
+
+  - id: reviewer_flags_stale_freshness_without_caveat
+    task: |
+      Review packet:
+
+      User question:
+      - What was gross revenue for completed orders last week?
+
+      Selected evidence:
+      - Selected entity: `model.starter_eval.fct_orders`.
+      - Selected measure: `gross_revenue`.
+      - provenance.tier: `semantic_layer`.
+      - provenance.freshness.status: `stale`.
+      - provenance.freshness.source: `source_freshness`.
+      - provenance.freshness.timestamp: `2026-04-01T00:00:00Z`.
+      - provenance.freshness.age_days: `83`.
+      - provenance.freshness.stale_after_days: `30`.
+
+      Draft final answer:
+      - Gross revenue was 42,000. The answer presents the figure as ready to
+        share and does not mention freshness.
+
+      Return the reviewer output contract.
+    expected:
+      final_answer:
+        must_contain:
+          - fix_required
+          - freshness
+          - stale
+          - caveat
+          - source_freshness

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -1450,7 +1450,11 @@ async fn run_agent_case(
         )
         .with_date_anchor(date_anchor);
     }
-    let prompt = agent_prompt(case, date_anchor.as_ref());
+    let prompt = agent_prompt(
+        case,
+        date_anchor.as_ref(),
+        suite.defaults.persona.as_deref(),
+    );
     let invocation = match provider::provider_invocation(args, &prompt, &trace_path) {
         Ok(invocation) => invocation,
         Err(error) => {
@@ -5544,7 +5548,11 @@ fn validate_selected_cases<'a>(
     )))
 }
 
-fn agent_prompt(case: &AgentCase, date_anchor: Option<&DateAnchor>) -> String {
+fn agent_prompt(
+    case: &AgentCase,
+    date_anchor: Option<&DateAnchor>,
+    persona: Option<&str>,
+) -> String {
     let date_anchor_section = date_anchor.map_or_else(String::new, |anchor| {
         let mut section = String::from("\nDate anchor:\n");
         for line in anchor.prompt_lines() {
@@ -5553,6 +5561,15 @@ fn agent_prompt(case: &AgentCase, date_anchor: Option<&DateAnchor>) -> String {
         section.push_str("- Treat these dates as ground truth for relative time phrases in the task. Do not reinterpret them using today's date.\n");
         section
     });
+    if persona
+        .map(str::trim)
+        .is_some_and(|value| value.eq_ignore_ascii_case("reviewer"))
+    {
+        return format!(
+            "You are running a dbt-nova reviewer-agent eval.\n\nTask:\n{}\n{}\nRules:\n- Review the supplied draft answer and evidence packet. Do not execute SQL, mutate files, inspect repository source, or invent missing evidence.\n- Use only evidence from the task packet or read-only Nova provenance/search/context evidence explicitly requested by the task.\n- If the packet lacks evidence needed for the review, return verdict `needs_evidence` and name the missing evidence.\n- Challenge semantic-layer bypass: if a governed Nova metric, measure, or semantic parent is available but the draft relies on raw/source table evidence without an evidence-backed fallback reason, require a fix.\n- Challenge stale or unknown freshness: if the draft uses stale or unknown-freshness evidence without an explicit caveat, require a fix.\n- Output a concise review with `verdict`, `findings`, `severity`, `evidence`, and `suggested_fix`.\n- Valid verdicts are `pass`, `fix_required`, and `needs_evidence`. Use `fix_required` for any semantic-layer bypass or missing freshness caveat that could change the answer.\n\nFinish with the review only; do not answer the original analytics question.",
+            case.task, date_anchor_section
+        );
+    }
     format!(
         "You are running a dbt-nova analytics-agent eval.\n\nTask:\n{}\n{}\nRules:\n- Use Nova discovery and execution tools directly. Do not inspect repository files, source code, fixtures, or Rust params unless a Nova command fails and you cannot recover from the error message.\n- For KPI, metric, conversion, funnel, checkout, or business-concept questions, start with search_indicator using compact results: detail=\"compact\", group_mode=\"top\", include_support_signals=true, limit=3, persona=\"analyst\".\n- For rate, conversion, or funnel questions, include the requested metric names literally in the query and set indicator_types=[\"metric\"] unless you are explicitly searching for raw measures.\n- When a metric row returns an expression, copy that expression exactly into SQL; do not substitute similarly named measures or invent a numerator/denominator.\n- Use support_signals, grain dimensions, and relation_name from search_indicator to apply every requested filter before SQL. Do not aggregate across a grain dimension named in the task, such as country, market, channel, segment, or device.\n- Treat relation_name, grain, and expression fields returned by search_indicator as the execution contract. Do not run schema inspection SQL such as DESCRIBE or information_schema when those fields are present.\n- Use execute_sql only after Nova discovery identifies the canonical execution entity or relation. Use one aggregate SQL statement for current and comparison periods when possible. Skip get_entity when search_indicator already returns the relation, grain, measures, and metric expressions you need; otherwise use get_entity with id_or_name and detail=\"compact\".\n- Keep Nova calls to the minimum needed: usually search_indicator plus one execute_sql for calculations, and only search_indicator for model or metric lookup tasks. Avoid get_context, get_lineage, get_sql, and full-detail responses unless blocked.\n- If using the CLI, assume $DBT_NOVA_EVAL_BIN is set. For search/get calls, use --params-json. For execute_sql with quotes or newlines, write a JSON params file like {{\"statement\":\"select ...\",\"row_limit\":50}} and call $DBT_NOVA_EVAL_BIN tool call execute_sql --params-file <file> --json; do not inline multiline SQL in --params-json. Parameter reminders: get_entity uses id_or_name; execute_sql uses statement. Do not run echo, grep, read, or source inspection for normal tool usage.\n\nFinish with a concise answer that cites the Nova evidence, the SQL result, and the explicit filter values used.",
         case.task, date_anchor_section

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -1328,12 +1328,31 @@ fn agent_prompt_includes_date_anchor_section() {
         date_field: Some("order_date".to_string()),
     };
 
-    let prompt = agent_prompt(&case, Some(&anchor));
+    let prompt = agent_prompt(&case, Some(&anchor), None);
     assert!(prompt.contains("Date anchor:"));
     assert!(prompt.contains("snapshot_date: 2026-03-31"));
     assert!(prompt.contains("date_range: 2026-03-01 to 2026-03-31"));
     assert!(prompt.contains("date_field: order_date"));
     assert!(prompt.contains("Do not reinterpret them using today's date"));
+}
+
+#[test]
+fn reviewer_agent_prompt_uses_review_contract() {
+    let case = super::AgentCase {
+        id: "reviewer".to_string(),
+        task: "Review this draft for semantic bypass.".to_string(),
+        date_anchor: DateAnchor::default(),
+        expected: AgentExpected::default(),
+    };
+
+    let prompt = agent_prompt(&case, None, Some("reviewer"));
+
+    assert!(prompt.contains("dbt-nova reviewer-agent eval"));
+    assert!(prompt.contains("Do not execute SQL"));
+    assert!(prompt.contains("semantic-layer bypass"));
+    assert!(prompt.contains("stale or unknown freshness"));
+    assert!(prompt.contains("verdict"));
+    assert!(!prompt.contains("Use Nova discovery and execution tools directly"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add a standalone `reviewer` Agent Skill with explicit input/output contracts, evidence-only review rules, semantic-layer bypass checks, and stale/unknown freshness caveat checks.
- Add reviewer-aware provider eval prompting plus tests, and ship `evals/reviewer.yml` with semantic bypass, unknown freshness, and stale freshness reviewer cases.
- Update analyst, eval-author, skills, evals, OpenCode reference pack, and changelog docs so high-stakes answer review is discoverable and installable.

Closes JOE-15

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --locked agent_prompt`
- `cargo run --locked -- eval validate --suite evals/reviewer.yml --json`
- `bash scripts/install_skills.sh --skill reviewer --skills-dir /tmp/dbt-nova-skills-test`
- `bash scripts/install_skills.sh --all --skills-dir /tmp/dbt-nova-skills-all-test`
- `uv run mkdocs build --strict`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo deny check` (passed; emitted existing duplicate-crate warnings only)
- `bash scripts/check_dependency_watchlist.sh`

## Notes

- A live provider-backed `eval agent run` was not executed locally; `evals/reviewer.yml` validates and is ready to run where an OpenCode/Codex/Claude provider is configured.
