### PR TITLE
Add configurable reusable workflow runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,7 @@ jobs:
       id-token: write
     uses: ./.github/workflows/nova-build-assets.yml
     with:
+      runner: ubuntu-22.04
       manifest_path: tests/fixtures/nova_manifest.json
       storage_instance_id: ci-readonly-smoke
       artifact_name_prefix: ci-readonly-smoke
@@ -353,6 +354,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/nova-metadata-audit.yml
     with:
+      runner_labels_json: '["ubuntu-22.04"]'
       manifest_path: tests/fixtures/nova_manifest.json
       storage_instance_id: ci-metadata-audit-project
       artifact_name_prefix: ci-metadata-audit-project

--- a/.github/workflows/nova-build-assets.yml
+++ b/.github/workflows/nova-build-assets.yml
@@ -107,6 +107,16 @@ on:
         required: false
         type: number
         default: 360
+      runner:
+        description: "GitHub Actions runner label for every job in this reusable workflow"
+        required: false
+        type: string
+        default: "ubuntu-22.04"
+      runner_labels_json:
+        description: "Optional JSON array of runner labels (for example [\"self-hosted\",\"linux\",\"x64\"]). Overrides runner when set."
+        required: false
+        type: string
+        default: ""
       publish_targets:
         description: "Comma-separated remote publish targets: s3,gcs,dbfs"
         required: false
@@ -207,7 +217,7 @@ permissions:
 jobs:
   prepare:
     name: Validate inputs and define contract outputs
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner_labels_json != '' && fromJSON(inputs.runner_labels_json) || inputs.runner }}
     timeout-minutes: 20
     outputs:
       artifact_name_storage: ${{ steps.resolve.outputs.artifact_name_storage }}
@@ -727,7 +737,7 @@ jobs:
 
   build:
     name: Build, validate, and publish storage artifact
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner_labels_json != '' && fromJSON(inputs.runner_labels_json) || inputs.runner }}
     timeout-minutes: ${{ fromJSON(needs.prepare.outputs.build_timeout_minutes) }}
     needs: prepare
     concurrency:

--- a/.github/workflows/nova-metadata-audit.yml
+++ b/.github/workflows/nova-metadata-audit.yml
@@ -124,6 +124,16 @@ on:
         required: false
         type: number
         default: 14
+      runner:
+        description: "GitHub Actions runner label for every job in this reusable workflow"
+        required: false
+        type: string
+        default: "ubuntu-22.04"
+      runner_labels_json:
+        description: "Optional JSON array of runner labels (for example [\"self-hosted\",\"linux\",\"x64\"]). Overrides runner when set."
+        required: false
+        type: string
+        default: ""
     secrets:
       DBT_NOVA_SECRET_BUNDLE_JSON:
         description: "Optional JSON object of secret-name -> secret-value pairs used by dbt_secret_env_map_json"
@@ -279,7 +289,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner_labels_json != '' && fromJSON(inputs.runner_labels_json) || inputs.runner }}
     outputs:
       manifest_path: ${{ steps.resolve.outputs.manifest_path }}
       manifest_uri: ${{ steps.resolve.outputs.manifest_uri }}
@@ -506,7 +516,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   audit:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner_labels_json != '' && fromJSON(inputs.runner_labels_json) || inputs.runner }}
     needs: prepare
     timeout-minutes: 60
     concurrency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added configurable runner inputs to the reusable asset and metadata-audit
+  workflows so downstream repositories can run them on self-hosted or
+  organization runner pools while preserving the `ubuntu-22.04` default.
+
 ## [0.0.6] - 2026-06-24
 
 - Hardened hosted HTTP container defaults by removing the baked-in auth-proxy

--- a/README.md
+++ b/README.md
@@ -211,6 +211,11 @@ jobs:
       artifact_name_prefix: analytics-prod
 ```
 
+The reusable asset and metadata-audit workflows default to `ubuntu-22.04`.
+Downstream wrappers can pass `runner: decathlon` for a single custom runner
+label, or `runner_labels_json: '["self-hosted","linux","x64"]'` when a runner
+pool requires multiple labels.
+
 Consumer env (required):
 
 ```bash

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -7,6 +7,9 @@ Operational defaults:
 - Linux x86_64 runners are pinned to `ubuntu-22.04` for consistency; release
   jobs use native ARM and Intel macOS runners where platform artifacts require
   that architecture.
+- Public reusable workflows default to `ubuntu-22.04` but expose `runner` and
+  `runner_labels_json` inputs for downstream self-hosted or organization
+  runner pools.
 - Jobs that execute on local runners set explicit `timeout-minutes` budgets.
 
 ## Workflows
@@ -46,7 +49,8 @@ Operational defaults:
   (`DBT_NOVA_SECRET_BUNDLE_JSON`), optional installer source override
   (`installer_repository`, `installer_ref`, `installer_install_mode`), optional models artifact, staged/full semantic warmup
   (`search_warm_strategy`), configurable build timeout
-  (`build_timeout_minutes`), optional remote publish
+  (`build_timeout_minutes`), optional runner selection (`runner` or
+  `runner_labels_json`), optional remote publish
   targets (`s3`, `gcs`, `dbfs`) and `publish_dry_run`; models behavior is
   configured via `models_distribution_mode` (`none|publish_only|publish_and_bootstrap`)
 - **Invocation safety:** structured mode runs
@@ -78,7 +82,8 @@ Operational defaults:
   (`dbt_command`), plus `dbt_env_json`, `dbt_secret_env_map_json`, optional
   workflow_call secret bundle (`DBT_NOVA_SECRET_BUNDLE_JSON`), and optional
   installer source override (`installer_repository`, `installer_ref`,
-  `installer_install_mode`)
+  `installer_install_mode`), plus optional runner selection (`runner` or
+  `runner_labels_json`)
 - **Secret contract:** `dbt_secret_env_map_json` resolves keys from
   `DBT_NOVA_SECRET_BUNDLE_JSON` first, then same-owner inherited workflow
   secrets; downstream wrappers should prefer the bundle pattern for cross-owner

--- a/docs/features/metadata-audit.md
+++ b/docs/features/metadata-audit.md
@@ -116,6 +116,11 @@ It follows the same installer and dbt invocation standards as the reusable
 asset workflow, but disables vector, sparse, and reranker search so CI does not
 pay for full search/model startup during metadata-only audits.
 
+By default every job runs on `ubuntu-22.04`. Downstream wrappers can pass
+`runner: decathlon` for a single custom runner label, or
+`runner_labels_json: '["self-hosted","linux","x64"]'` when a self-hosted pool
+requires multiple labels.
+
 When `selection_mode: changed` and `changed_files_json` is omitted on
 `pull_request` events, the reusable workflow resolves changed files from the
 immutable PR event SHAs (`pull_request.base.sha` and `pull_request.head.sha`)

--- a/docs/operations/prebuilt-assets.md
+++ b/docs/operations/prebuilt-assets.md
@@ -75,6 +75,10 @@ Alternative producer inputs:
 - `models_distribution_mode` (`none`, `publish_only`, `publish_and_bootstrap`)
 - `search_warm_strategy` (`staged` by default, or `full`)
 - `build_timeout_minutes` (integer `1..360`, default `360`)
+- `runner` (single GitHub Actions runner label for all workflow jobs, default
+  `ubuntu-22.04`)
+- `runner_labels_json` (JSON array of runner labels, overriding `runner` when
+  a self-hosted pool requires multiple labels)
 - workflow_call secret `DBT_NOVA_SECRET_BUNDLE_JSON` (optional JSON object of
   `secret-name -> secret-value` entries for cross-owner reusable workflow calls)
 
@@ -179,6 +183,30 @@ Common downstream pattern: keep a repo-local `workflow_dispatch` wrapper and
 call this reusable workflow from it. This lets each repo set its own target
 defaults, storage instance naming, and publish prefixes without forking Nova's
 workflow.
+
+Self-hosted runner example:
+
+```yaml
+jobs:
+  build_nova_assets:
+    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@v0.0.6
+    with:
+      runner: decathlon
+      manifest_path: target/manifest.json
+      storage_instance_id: analytics-prod
+```
+
+Multi-label runner example:
+
+```yaml
+jobs:
+  build_nova_assets:
+    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@v0.0.6
+    with:
+      runner_labels_json: '["self-hosted","linux","x64"]'
+      manifest_path: target/manifest.json
+      storage_instance_id: analytics-prod
+```
 
 The producer emits:
 


### PR DESCRIPTION
## Summary

- add `runner` inputs to the reusable asset and metadata-audit workflows, defaulting to `ubuntu-22.04`
- add optional `runner_labels_json` inputs for self-hosted runner pools that require multiple labels
- exercise both input forms in CI reusable-workflow smoke calls and document downstream usage

Closes #226

## Validation

- `actionlint .github/workflows/nova-build-assets.yml .github/workflows/nova-metadata-audit.yml .github/workflows/ci.yml`
- `uv run mkdocs build --strict`