### PR TITLE
[codex] Harden production readiness findings

### DIFF
--- a/.github/workflows/nova-build-assets.yml
+++ b/.github/workflows/nova-build-assets.yml
@@ -664,7 +664,7 @@ jobs:
           fi
           if [[ "${allow_mutable_installer_ref}" != "true" ]]; then
             if ! [[ "${installer_ref}" =~ ^[0-9a-fA-F]{40}$ || "${installer_ref}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "installer_ref must be an immutable full commit SHA or release tag (for example v0.0.6)."
+              echo "installer_ref must be an immutable full commit SHA or release tag (for example v0.0.5)."
               echo "Resolved installer_ref='${installer_ref}'. Set allow_mutable_installer_ref=true only for trusted development runs."
               exit 1
             fi

--- a/.github/workflows/nova-metadata-audit.yml
+++ b/.github/workflows/nova-metadata-audit.yml
@@ -485,7 +485,7 @@ jobs:
               if not immutable_ref:
                   fail(
                       "installer_ref must be an immutable full commit SHA or release tag "
-                      f"(for example v0.0.6); resolved installer_ref={installer_ref!r}. "
+                      f"(for example v0.0.5); resolved installer_ref={installer_ref!r}. "
                       "Set allow_mutable_installer_ref=true only for trusted development runs."
                   )
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Hardened production readiness by making installer checksum signature
+  verification fail closed by default, resolving `latest` installs to the
+  immutable release tag before fetching optional support assets, adding
+  cooperative deadlines to synchronous MCP/CLI search scans, accounting
+  semantic timeouts as circuit-breaker failures, and correcting release-tag and
+  config-reference docs without publishing `v0.0.6`.
 - Redacted raw upstream Databricks and BigQuery HTTP error bodies from
   CLI/MCP responses while preserving status and provider error-code context.
 - Safety-gated MCP `reload_manifest` source, refresh, and storage mutations

--- a/README.md
+++ b/README.md
@@ -135,23 +135,29 @@ Minimal MCP client config:
 
 ## Quick Start
 
+Install `cosign` first when using the release installer examples below; they
+require signed checksum verification. For trusted development-only installs
+without `cosign` on `v0.0.5`, omit `DBT_NOVA_VERIFY_SIGNATURE=1`. The next
+installer also accepts `DBT_NOVA_VERIFY_SIGNATURE=auto` for opportunistic
+verification.
+
 ```bash
 # Install (recommended: slim + non-interactive)
 # Public repo (unauthenticated)
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.6 bash -s -- --slim --non-interactive
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --non-interactive
 
 # Private repo (authenticated)
 GH_TOKEN="$(gh auth token)"
 curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
+  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
 
 # Optional: pre-warm model files during install before enabling semantic layers
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
   DBT_NOVA_EMBEDDINGS_CACHE_DIR="$HOME/.dbt-nova/.fastembed_cache" \
   DBT_NOVA_WARMUP_REQUIRED_MODELS=3 \
-  DBT_NOVA_VERSION=v0.0.6 bash -s -- --slim --warm-models --non-interactive
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --warm-models --non-interactive
 
 # Optional: enforce SHA-256 verification during direct HF fallback warmup
 # cp scripts/warm_models.checksums.example /path/to/checksums.txt
@@ -160,11 +166,11 @@ curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scrip
 #   bash scripts/warm_models.sh
 
 # Optional: install all built-in persona skills to ~/.agents/skills
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.6 bash -s -- --slim --install-skills --non-interactive
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --install-skills --non-interactive
 
 # Optional: install a single standalone skill
-# DBT_NOVA_VERSION=v0.0.6 bash -s -- --slim --install-skills --skill analyst --non-interactive
+# DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --install-skills --skill analyst --non-interactive
 
 export DBT_MANIFEST_PATH=/path/to/manifest.json
 export DBT_NOVA_PRUNE_ALLOW_IDS='["model.my_proj.fct_orders","model.my_proj.dim_*"]'
@@ -198,15 +204,20 @@ switch to strict read-only reuse.
 
 Producer (reusable workflow):
 
+Set `<nova-ref>` to a release tag or full commit SHA that includes the workflow
+inputs you use. `v0.0.5` supports the basic producer flow; runner override
+inputs require a newer release or immutable commit SHA until the next release is
+cut.
+
 ```yaml
 jobs:
   build_nova_assets:
     # Pin to a release tag or commit SHA
-    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@v0.0.6
+    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@<nova-ref>
     with:
       manifest_path: target/manifest.json
       storage_instance_id: analytics-prod
-      installer_ref: v0.0.6
+      installer_ref: <nova-ref>
       installer_install_mode: auto
       artifact_name_prefix: analytics-prod
 ```

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -327,6 +327,9 @@ Guardrails:
   vector/sparse, manifest-scoped caches.
 
 - `DBT_NOVA_SEARCH_ENABLE_VECTOR` – enable dense vectors (default: `false`)
+- `DBT_NOVA_SEARCH_COLD_START_POLICY` – semantic cache behavior when
+  manifest-scoped caches are missing: `degrade` skips semantic startup work,
+  `build` creates missing caches during startup (default: `degrade`)
 - `DBT_NOVA_SEARCH_VECTOR_TOP_K` – max vector hits before fusion (default: `200`)
 - `DBT_NOVA_SEARCH_VECTOR_MAX_CHARS` – max chars in embedding text (default: `4000`)
 - `DBT_NOVA_SEARCH_ENABLE_VECTOR_ANN` – enable ANN buckets (default: `true`)
@@ -335,10 +338,15 @@ Guardrails:
 - `DBT_NOVA_SEARCH_VECTOR_ANN_HAMMING` – ANN Hamming radius (default: `1`)
 - `DBT_NOVA_SEARCH_VECTOR_ANN_MAX_CANDIDATES` – max ANN candidates (default: `5000`)
 - `DBT_NOVA_SEARCH_VECTOR_ANN_MIN_CANDIDATES` – min before full scan (default: `200`)
+- `DBT_NOVA_SEARCH_ONNX_THREADS` – ONNX intra-thread count for vector, sparse,
+  and reranker models (default: min available parallelism, capped at `4`)
 - `DBT_NOVA_SEARCH_EMBEDDING_BATCH_SIZE` – embedding batch size (default: `128`)
 - `DBT_NOVA_EMBEDDING_MODEL` – embedding model name (default: `intfloat/multilingual-e5-base`)
 - `DBT_NOVA_SEARCH_ENABLE_SPARSE` – enable sparse vectors (default: `false`)
 - `DBT_NOVA_SEARCH_SPARSE_TOP_K` – max sparse hits before fusion (default: `200`)
+- `DBT_NOVA_SEARCH_SPARSE_EMBEDDING_BATCH_SIZE` – sparse embedding batch size
+  (default: `16`; falls back to `DBT_NOVA_SEARCH_EMBEDDING_BATCH_SIZE` only
+  when the sparse-specific variable is unset)
 - `DBT_NOVA_SEARCH_ENABLE_RERANKER` – enable cross‑encoder reranker (default: `false`)
 - `DBT_NOVA_RERANKER_MODEL` – reranker model (default: `jinaai/jina-reranker-v2-base-multilingual`)
 - `DBT_NOVA_SEARCH_RERANK_TOP_N` – max results reranked (default: `20`)
@@ -441,10 +449,47 @@ Post‑retrieval tuning:
 - `DBT_NOVA_SEARCH_CANONICAL_META_MATCH_BONUS` (default: `2.5`)
 - `DBT_NOVA_SEARCH_ENGINEER_EXACT_MATCH_MULTIPLIER` (default: `2.0`)
 
+Indicator search and grouping:
+- `DBT_NOVA_SEARCH_INDICATOR_ENABLE_PARENT_COHERENCE` (default: `true`)
+- `DBT_NOVA_SEARCH_INDICATOR_PARENT_GROUP_MAX_GROUPS` (default: `5`)
+- `DBT_NOVA_SEARCH_INDICATOR_PARENT_GROUP_MAX_INDICATORS` (default: `4`)
+- `DBT_NOVA_SEARCH_INDICATOR_GENERIC_LABEL_BONUS_ONE_TOKEN` (default: `2.5`)
+- `DBT_NOVA_SEARCH_INDICATOR_GENERIC_LABEL_BONUS_TWO_TOKENS` (default: `1.5`)
+- `DBT_NOVA_SEARCH_INDICATOR_GENERIC_LABEL_BONUS_THREE_PLUS_TOKENS` (default: `0.75`)
+- `DBT_NOVA_SEARCH_INDICATOR_PARENT_SYNONYM_BONUS_ONE_TOKEN` (default: `1.5`)
+- `DBT_NOVA_SEARCH_INDICATOR_PARENT_SYNONYM_BONUS_TWO_TOKENS` (default: `1.0`)
+- `DBT_NOVA_SEARCH_INDICATOR_PARENT_SYNONYM_BONUS_THREE_PLUS_TOKENS` (default: `0.5`)
+- `DBT_NOVA_SEARCH_INDICATOR_SEMANTIC_LABEL_PRECISION_SCALE` (default: `0.14`)
+- `DBT_NOVA_SEARCH_INDICATOR_SEMANTIC_LABEL_PRECISION_CANONICAL_BONUS` (default: `0.12`)
+- `DBT_NOVA_SEARCH_INDICATOR_PARENT_COHERENCE_DIVERSITY_BONUS` (default: `0.28`)
+- `DBT_NOVA_SEARCH_INDICATOR_PARENT_COHERENCE_CANONICAL_BONUS` (default: `0.14`)
+- `DBT_NOVA_SEARCH_INDICATOR_PARENT_COHERENCE_STRONG_MATCH_BONUS` (default: `0.08`)
+- `DBT_NOVA_SEARCH_INDICATOR_PARENT_COHERENCE_SUPPORT_SURFACE_BONUS` (default: `0.06`)
+- `DBT_NOVA_SEARCH_INDICATOR_PARENT_COHERENCE_TIME_FIELD_BONUS` (default: `0.06`)
+- `DBT_NOVA_SEARCH_INDICATOR_PARENT_COHERENCE_DIMENSION_BONUS` (default: `0.06`)
+- `DBT_NOVA_SEARCH_INDICATOR_PARENT_COHERENCE_MAX_BONUS` (default: `0.95`)
+- `DBT_NOVA_SEARCH_INDICATOR_SEARCH_PARENT_BONUS_SCALE` (default: `0.55`)
+- `DBT_NOVA_SEARCH_INDICATOR_SEARCH_MISSING_PARENT_MULTIPLIER` (default: `0.75`)
+- `DBT_NOVA_SEARCH_INDICATOR_SEARCH_PARENT_TOP_K` (default: `3`)
+- `DBT_NOVA_SEARCH_INDICATOR_RRF_SCORE_WEIGHT` (default: `1.0`)
+- `DBT_NOVA_SEARCH_INDICATOR_RERANKER_SCORE_WEIGHT` (default: `1.0`)
+
+Metadata support signals:
+- `DBT_NOVA_SEARCH_METADATA_SUPPORT_PARENT_SYNONYM_WEIGHT` (default: `0.4`)
+- `DBT_NOVA_SEARCH_METADATA_SUPPORT_DOMAIN_WEIGHT` (default: `0.35`)
+- `DBT_NOVA_SEARCH_METADATA_SUPPORT_USE_CASE_WEIGHT` (default: `0.25`)
+- `DBT_NOVA_SEARCH_METADATA_SUPPORT_DIMENSION_WEIGHT` (default: `0.45`)
+- `DBT_NOVA_SEARCH_METADATA_SUPPORT_COLUMN_NAME_WEIGHT` (default: `0.2`)
+- `DBT_NOVA_SEARCH_METADATA_SUPPORT_COLUMN_ROLE_WEIGHT` (default: `0.2`)
+- `DBT_NOVA_SEARCH_METADATA_SUPPORT_SEMANTIC_TYPE_WEIGHT` (default: `0.35`)
+- `DBT_NOVA_SEARCH_METADATA_SUPPORT_EXAMPLE_VALUE_WEIGHT` (default: `0.5`)
+- `DBT_NOVA_SEARCH_METADATA_SUPPORT_MAX_BONUS` (default: `1.25`)
+- `DBT_NOVA_SEARCH_METADATA_SUPPORT_MAX_VALUES_PER_FIELD` (default: `4`)
+
 Staging deboost behavior:
 - `DBT_NOVA_SEARCH_STAGING_DEBOOST_FACTOR` applies when an entity matches a configured
   layer rule with layer name `staging`, `stage`, or `stg` (case-insensitive).
-- Configure layer mapping with `DBT_NOVA_LAYER_RULES_JSON`.
+- Configure layer mapping with `DBT_NOVA_LAYER_RULES`.
 
 Persona candidate behavior:
 - `DBT_NOVA_SEARCH_*_CANDIDATE_FALSE_DEBOOST_FACTOR` applies when

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -87,9 +87,10 @@ For user-owned private repositories, the attestation step is skipped.
 - The OCI image job uploads `dbt-nova-oci-trivy.json` with the release and fails
   on unwaived HIGH/CRITICAL findings in the smoke-tested image.
 
-The installer validates checksum signatures automatically when `cosign` is
-available. Set `DBT_NOVA_VERIFY_SIGNATURE=1` to make signature verification
-strict.
+The next-release installer defaults to strict checksum signature verification:
+`DBT_NOVA_VERIFY_SIGNATURE=1` requires `cosign` plus the released `.sha256.sig`
+and `.sha256.crt` files. Use `DBT_NOVA_VERIFY_SIGNATURE=auto` only for trusted
+development installs where missing `cosign` or signatures may be skipped.
 
 Supported prebuilt binary targets:
 
@@ -191,7 +192,7 @@ Useful overrides:
 - `DBT_NOVA_INSTALL_NONINTERACTIVE=1`
 - `DBT_NOVA_INSTALL_DIR=/custom/path`
 - `DBT_NOVA_VERIFY_CHECKSUM=1|0`
-- `DBT_NOVA_VERIFY_SIGNATURE=auto|1|0`
+- `DBT_NOVA_VERIFY_SIGNATURE=1|auto|0`
 - `DBT_NOVA_COSIGN_BINARY=cosign`
 - `DBT_NOVA_COSIGN_CERT_IDENTITY_REGEXP=...`
 - `DBT_NOVA_COSIGN_CERT_OIDC_ISSUER=https://token.actions.githubusercontent.com`

--- a/docs/features/agent-readiness.md
+++ b/docs/features/agent-readiness.md
@@ -55,7 +55,9 @@ fresh local cache for the manifest under test.
 Run agent readiness after dbt has produced `target/manifest.json`. This example
 starts in advisory mode, writes machine and human reports, always uploads the
 reports as workflow artifacts, and mirrors the Markdown report into the job
-summary.
+summary. Replace `<nova-release-tag>` with a release that includes
+`audit agent-readiness`; until that release exists, install Nova from an
+immutable source commit instead of using the release installer step.
 
 ```yaml
 name: Agent readiness
@@ -68,6 +70,7 @@ jobs:
   agent_readiness:
     runs-on: ubuntu-22.04
     env:
+      DBT_NOVA_RELEASE: <nova-release-tag>
       READINESS_THRESHOLDS: >-
         {"overall":{"min_score":70,"severity":"advisory"},"persona":{"engineer":{"min_score":70,"severity":"advisory"},"analyst":{"min_score":65,"severity":"advisory"},"governance":{"min_score":65,"severity":"advisory"}}}
     steps:
@@ -76,6 +79,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac
+        with:
+          cosign-release: "v2.4.1"
 
       - name: Install dbt project dependencies
         run: |
@@ -89,8 +97,8 @@ jobs:
 
       - name: Install dbt-nova
         run: |
-          curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
-            DBT_NOVA_VERSION=v0.0.6 bash -s -- --slim --non-interactive
+          curl -fsSL "https://raw.githubusercontent.com/joe-broadhead/dbt-nova/${DBT_NOVA_RELEASE}/scripts/install.sh" | \
+            DBT_NOVA_VERSION="${DBT_NOVA_RELEASE}" DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --non-interactive
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Run agent-readiness report

--- a/docs/features/metadata-audit.md
+++ b/docs/features/metadata-audit.md
@@ -119,7 +119,8 @@ pay for full search/model startup during metadata-only audits.
 By default every job runs on `ubuntu-22.04`. Downstream wrappers can pass
 `runner: decathlon` for a single custom runner label, or
 `runner_labels_json: '["self-hosted","linux","x64"]'` when a self-hosted pool
-requires multiple labels.
+requires multiple labels. Those runner override inputs require a release tag or
+immutable commit SHA that includes them.
 
 When `selection_mode: changed` and `changed_files_json` is omitted on
 `pull_request` events, the reusable workflow resolves changed files from the
@@ -139,12 +140,14 @@ emitting the JSON and Markdown audit reports.
 
 When using `dbt_generate_manifest: true`, prefer the same secret-bundle pattern
 as the Nova assets workflow so callers can work consistently across providers
-and across same-owner or cross-owner reusable workflow calls:
+and across same-owner or cross-owner reusable workflow calls. Replace
+`<nova-ref>` with a release tag or full commit SHA that includes the workflow
+inputs you use:
 
 ```yaml
 jobs:
   nova_metadata_audit:
-    uses: joe-broadhead/dbt-nova/.github/workflows/nova-metadata-audit.yml@v0.0.6
+    uses: joe-broadhead/dbt-nova/.github/workflows/nova-metadata-audit.yml@<nova-ref>
     with:
       dbt_generate_manifest: true
       dbt_command_args_json: >-

--- a/docs/features/search-ranking.md
+++ b/docs/features/search-ranking.md
@@ -135,7 +135,7 @@ DBT_NOVA_SEARCH_ENGINEER_EXACT_MATCH_MULTIPLIER=2.0
 3) **Domains/use_cases** provide intent routing but stay below synonyms/measures.
 4) `description`, `columns`, `tags`, `path`, and `code` remain as backstops.
 5) **Staging-layer models** are de‑boosted so curated models rank higher.
-   This deboost is layer-rule driven (`DBT_NOVA_LAYER_RULES_JSON`) and applies
+   This deboost is layer-rule driven (`DBT_NOVA_LAYER_RULES`) and applies
    when the resolved layer is `staging`, `stage`, or `stg`.
 6) **Persona candidate hints** can de‑boost models that are still useful for
    engineering/governance discovery but should not dominate analyst discovery.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -8,6 +8,7 @@
 | **RAM** | 512 MB | 2 GB+ (4 GB with dense vectors) |
 | **Disk** | 100 MB | 500 MB+ (depends on manifest size) |
 | **Rust** | 1.93+ (edition 2024) | Latest stable |
+| **cosign** | 2.x | Required for signed release checksum verification |
 
 You also need:
 
@@ -17,42 +18,46 @@ Remote manifests are supported via `DBT_NOVA_MANIFEST_URI` (http(s), dbfs, s3, g
 
 ## Quick Install (Recommended)
 
-Use the installer script (defaults to **slim**):
+Use the installer script (defaults to **slim**). The examples below require
+`cosign` and enforce signed checksum verification. For development-only installs
+without `cosign` on `v0.0.5`, omit `DBT_NOVA_VERIFY_SIGNATURE=1`. The next
+installer also accepts `DBT_NOVA_VERIFY_SIGNATURE=auto` for opportunistic
+verification.
 
 ```bash
 # Public repo (unauthenticated)
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.6 bash -s -- --slim --non-interactive
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --non-interactive
 
 # Private repo (authenticated)
 GH_TOKEN="$(gh auth token)"
 curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
+  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
 ```
 
 Non-interactive examples:
 
 ```bash
 # Public repo: default slim in non-interactive mode
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.6 bash -s -- --non-interactive
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --non-interactive
 
 # Public repo: force slim
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.6 bash -s -- --slim --non-interactive
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --non-interactive
 
 # Private repo: default slim in non-interactive mode
 GH_TOKEN="$(gh auth token)"
 curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --non-interactive
+  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --non-interactive
 
 # Private repo: force slim
 GH_TOKEN="$(gh auth token)"
 curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
+  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
 ```
 
 The installer places `dbt-nova` in `~/.local/bin`. For bundled installs, it also
@@ -66,10 +71,10 @@ or remote model hydration? See [Modes & Combinations](modes-and-combinations.md)
 If you want users to enable semantic layers without a later model download, pre-warm during install:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
   DBT_NOVA_EMBEDDINGS_CACHE_DIR="$HOME/.dbt-nova/.fastembed_cache" \
   DBT_NOVA_WARMUP_REQUIRED_MODELS=3 \
-  DBT_NOVA_VERSION=v0.0.6 bash -s -- --slim --warm-models --non-interactive
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --warm-models --non-interactive
 ```
 
 Use the same `DBT_NOVA_EMBEDDINGS_CACHE_DIR` value in your MCP client config so every
@@ -80,23 +85,23 @@ client process reuses that cache.
 Install all built-in standalone persona skills:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.6 bash -s -- --slim --install-skills --non-interactive
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --install-skills --non-interactive
 ```
 
 Install one standalone skill:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.6 bash -s -- --slim --install-skills --skill analyst --non-interactive
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --install-skills --skill analyst --non-interactive
 ```
 
 To choose a different destination:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
   DBT_NOVA_SKILLS_DIR="$HOME/.codex/skills" \
-  DBT_NOVA_VERSION=v0.0.6 bash -s -- --slim --install-skills --non-interactive
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --install-skills --non-interactive
 ```
 
 ## Verify Installation
@@ -118,12 +123,20 @@ find "$HOME/.dbt-nova/.fastembed_cache" -type f \
 ```
 
 The installer verifies SHA-256 checksums for downloaded archives by default.
-Set `DBT_NOVA_VERIFY_CHECKSUM=0` to skip this check.
+Set `DBT_NOVA_VERIFY_CHECKSUM=0` only for trusted development scenarios.
 
-Checksum signature verification defaults to `auto`: if `cosign` is available
-and the release includes a `.sha256.sig` and `.sha256.crt`, the installer
-verifies the signed checksum against the release workflow identity. To require
-signature verification, install `cosign` and set:
+The installer supports three checksum signature modes:
+
+- `DBT_NOVA_VERIFY_SIGNATURE=1` requires `cosign` plus release `.sha256.sig`
+  and `.sha256.crt` files, and fails closed when verification cannot run.
+- `DBT_NOVA_VERIFY_SIGNATURE=auto` verifies when possible and skips when
+  `cosign` or signature files are unavailable.
+- `DBT_NOVA_VERIFY_SIGNATURE=0` disables checksum signature verification.
+
+Current stable examples pass `DBT_NOVA_VERIFY_SIGNATURE=1` explicitly. The
+`v0.0.5` installer supports this strict mode, while the next release installer
+also defaults to required signature verification and adds the explicit `auto`
+mode. To require verification when invoking the installer directly:
 
 ```bash
 export DBT_NOVA_VERIFY_SIGNATURE=1
@@ -221,7 +234,7 @@ The installer defaults to **slim** and supports:
 - `DBT_NOVA_INSTALL_DIR=/custom/path`
 - `--bundled`, `--slim`, `--warm-models`, `--install-skills`, `--skill <name>`, `--skills-dir <path>`, `--non-interactive`, `--install-dir <path>`
 - `DBT_NOVA_VERIFY_CHECKSUM=1|0`
-- `DBT_NOVA_VERIFY_SIGNATURE=auto|1|0`
+- `DBT_NOVA_VERIFY_SIGNATURE=1|auto|0`
 - `DBT_NOVA_COSIGN_BINARY=cosign`
 - `DBT_NOVA_COSIGN_CERT_IDENTITY_REGEXP=...`
 - `DBT_NOVA_COSIGN_CERT_OIDC_ISSUER=https://token.actions.githubusercontent.com`
@@ -315,7 +328,7 @@ by SHA-256 verification when checksum mode is enabled.
 Example (pin fallback seed to a specific release tag):
 
 ```bash
-DBT_NOVA_WARMUP_VERSION=v0.0.6 bash scripts/warm_models.sh
+DBT_NOVA_WARMUP_VERSION=v0.0.5 bash scripts/warm_models.sh
 ```
 
 ---

--- a/docs/getting-started/mcp-clients.md
+++ b/docs/getting-started/mcp-clients.md
@@ -18,13 +18,14 @@ remote artifacts vs model cache strategies), see
 
 For slim installs, set a stable `DBT_NOVA_EMBEDDINGS_CACHE_DIR` (recommended:
 `~/.dbt-nova/.fastembed_cache`) so model downloads are reused across sessions/clients.
+Install `cosign` first when using the strict release installer example below.
 If you installed with:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
   DBT_NOVA_EMBEDDINGS_CACHE_DIR="$HOME/.dbt-nova/.fastembed_cache" \
   DBT_NOVA_WARMUP_REQUIRED_MODELS=3 \
-  DBT_NOVA_VERSION=v0.0.6 bash -s -- --slim --warm-models --non-interactive
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --warm-models --non-interactive
 ```
 
 use that exact same `DBT_NOVA_EMBEDDINGS_CACHE_DIR` path in your MCP client env.

--- a/docs/getting-started/modes-and-combinations.md
+++ b/docs/getting-started/modes-and-combinations.md
@@ -26,7 +26,7 @@ Installer controls:
 - `DBT_NOVA_SKILL_NAME=<skill>` (optional single standalone skill)
 - `DBT_NOVA_INSTALL_NONINTERACTIVE=1`
 - `DBT_NOVA_INSTALL_DIR`, `DBT_NOVA_SKILLS_DIR`
-- `DBT_NOVA_VERIFY_CHECKSUM=1|0`, `DBT_NOVA_VERIFY_SIGNATURE=auto|1|0`
+- `DBT_NOVA_VERIFY_CHECKSUM=1|0`, `DBT_NOVA_VERIFY_SIGNATURE=1|auto|0`
 
 ## 2) Manifest Source Plane
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -11,28 +11,29 @@ Get dbt-nova running in under 5 minutes.
 
 !!! tip "All-in-one option"
     Use the installer script. It defaults to the **slim** release and
-    starts with lexical search only. Semantic layers are opt-in.
+    starts with lexical search only. Semantic layers are opt-in. Install
+    `cosign` first because these examples require signed checksum verification.
 
 ```bash
 # Public repo (unauthenticated)
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.6 bash -s -- --slim --non-interactive
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --non-interactive
 
 # Private repo (authenticated)
 GH_TOKEN="$(gh auth token)"
 curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
+  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
 
 # Optional: pre-warm models during install before enabling semantic layers
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
   DBT_NOVA_EMBEDDINGS_CACHE_DIR="$HOME/.dbt-nova/.fastembed_cache" \
   DBT_NOVA_WARMUP_REQUIRED_MODELS=3 \
-  DBT_NOVA_VERSION=v0.0.6 bash -s -- --slim --warm-models --non-interactive
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --warm-models --non-interactive
 
 # Optional: install all built-in Agent Skills into ~/.agents/skills
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.6 bash -s -- --slim --install-skills --non-interactive
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --install-skills --non-interactive
 ```
 
 === "macOS (Apple Silicon)"

--- a/docs/operations/eval-ci-templates.md
+++ b/docs/operations/eval-ci-templates.md
@@ -38,8 +38,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     env:
-      DBT_NOVA_INSTALL_REF: v0.0.6
-      DBT_NOVA_VERSION: v0.0.6
+      DBT_NOVA_INSTALL_REF: v0.0.5
+      DBT_NOVA_VERSION: v0.0.5
+      DBT_NOVA_VERIFY_SIGNATURE: "1"
       NOVA_EVAL_SUITE: evals/analyst-smoke.yml
       NOVA_EVAL_NAME: analyst-smoke
       NOVA_EVAL_OUTPUT: out/nova-bridge-evals
@@ -49,6 +50,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac
+        with:
+          cosign-release: "v2.4.1"
 
       - name: Install dbt project dependencies
         run: |
@@ -63,7 +69,7 @@ jobs:
       - name: Install dbt-nova
         run: |
           curl -fsSL "https://raw.githubusercontent.com/joe-broadhead/dbt-nova/${DBT_NOVA_INSTALL_REF}/scripts/install.sh" | \
-            DBT_NOVA_VERSION="${DBT_NOVA_VERSION}" bash -s -- --slim --non-interactive
+            DBT_NOVA_VERSION="${DBT_NOVA_VERSION}" DBT_NOVA_VERIFY_SIGNATURE="${DBT_NOVA_VERIFY_SIGNATURE}" bash -s -- --slim --non-interactive
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Validate eval suite
@@ -152,8 +158,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     env:
-      DBT_NOVA_INSTALL_REF: v0.0.6
-      DBT_NOVA_VERSION: v0.0.6
+      DBT_NOVA_INSTALL_REF: v0.0.5
+      DBT_NOVA_VERSION: v0.0.5
+      DBT_NOVA_VERIFY_SIGNATURE: "1"
       NOVA_AGENT_SUITE: evals/analyst-agent.yml
       NOVA_AGENT_NAME: analyst-agent-smoke
       NOVA_AGENT_OUTPUT: out/nova-agent-evals
@@ -164,6 +171,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac
+        with:
+          cosign-release: "v2.4.1"
 
       - name: Install dbt project dependencies
         run: |
@@ -178,7 +190,7 @@ jobs:
       - name: Install dbt-nova
         run: |
           curl -fsSL "https://raw.githubusercontent.com/joe-broadhead/dbt-nova/${DBT_NOVA_INSTALL_REF}/scripts/install.sh" | \
-            DBT_NOVA_VERSION="${DBT_NOVA_VERSION}" bash -s -- --slim --non-interactive
+            DBT_NOVA_VERSION="${DBT_NOVA_VERSION}" DBT_NOVA_VERIFY_SIGNATURE="${DBT_NOVA_VERIFY_SIGNATURE}" bash -s -- --slim --non-interactive
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Validate agent eval suite

--- a/docs/operations/prebuilt-assets.md
+++ b/docs/operations/prebuilt-assets.md
@@ -41,9 +41,11 @@ read-only reuse after local materialization.
 
 Create a workflow in the downstream repo that calls Nova's reusable producer.
 
-The examples below pin `v0.0.6`. For production, pin either a release tag or an
-immutable commit SHA and keep `installer_ref` aligned with the workflow ref.
-Reusable workflows reject branch-like installer refs unless
+The examples below use `<nova-ref>` as a placeholder. For production, replace
+it with either a release tag or an immutable commit SHA and keep `installer_ref`
+aligned with the workflow ref. `v0.0.5` supports the basic producer flow; runner
+override inputs require a newer release or immutable commit SHA until the next
+release is cut. Reusable workflows reject branch-like installer refs unless
 `allow_mutable_installer_ref: true` is set for a trusted development run.
 
 ```yaml
@@ -55,11 +57,11 @@ on:
 jobs:
   build_nova_assets:
     # Pin to a release tag or commit SHA
-    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@v0.0.6
+    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@<nova-ref>
     with:
       manifest_path: target/manifest.json
       storage_instance_id: analytics-prod
-      installer_ref: v0.0.6
+      installer_ref: <nova-ref>
       installer_install_mode: auto
       artifact_name_prefix: analytics-prod
       retention_days: 14
@@ -104,7 +106,7 @@ workflow works across Databricks, BigQuery, Snowflake, DuckDB, and mixed profile
 ```yaml
 jobs:
   build_nova_assets:
-    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@v0.0.6
+    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@<nova-ref>
     with:
       dbt_generate_manifest: true
       dbt_command_args_json: >-
@@ -123,7 +125,7 @@ DBFS publish wrapper example:
 ```yaml
 jobs:
   build_nova_assets:
-    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@v0.0.6
+    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@<nova-ref>
     with:
       dbt_generate_manifest: true
       dbt_command_args_json: >-
@@ -133,7 +135,7 @@ jobs:
       dbt_secret_env_map_json: >-
         {"DBT_ACCESS_TOKEN":"DBT_ACCESS_TOKEN","DATABRICKS_ACCESS_TOKEN":"DBT_ACCESS_TOKEN"}
       storage_instance_id: analytics-prod
-      installer_ref: v0.0.6
+      installer_ref: <nova-ref>
       installer_install_mode: source
       publish_targets: dbfs
       publish_dbfs_prefix: dbfs:/FileStore/projects/my-project/nova-assets/prod
@@ -191,7 +193,7 @@ Self-hosted runner example:
 ```yaml
 jobs:
   build_nova_assets:
-    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@v0.0.6
+    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@<nova-ref>
     with:
       runner: decathlon
       manifest_path: target/manifest.json
@@ -203,7 +205,7 @@ Multi-label runner example:
 ```yaml
 jobs:
   build_nova_assets:
-    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@v0.0.6
+    uses: joe-broadhead/dbt-nova/.github/workflows/nova-build-assets.yml@<nova-ref>
     with:
       runner_labels_json: '["self-hosted","linux","x64"]'
       manifest_path: target/manifest.json
@@ -279,8 +281,8 @@ GitHub OIDC notes for GCS:
 Installer mode guidance:
 
 - Keep `installer_install_mode: auto` as the default.
-- Use `installer_install_mode: release` with a release tag ref (for example
-  `installer_ref: v0.0.6` or newer) to minimize runtime on compatible runners.
+- Use `installer_install_mode: release` with a release tag ref to minimize
+  runtime on compatible runners.
 - Use `installer_install_mode: source` when you need an unreleased commit SHA
   or your runner image is incompatible with the prebuilt binary (for example
   older glibc environments).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,7 +12,7 @@ SKILL_NAME="${DBT_NOVA_SKILL_NAME:-}"
 NON_INTERACTIVE="${DBT_NOVA_INSTALL_NONINTERACTIVE:-0}"
 INSTALL_WARM_MODELS="${DBT_NOVA_INSTALL_WARM_MODELS:-0}"
 VERIFY_CHECKSUM="${DBT_NOVA_VERIFY_CHECKSUM:-1}"
-VERIFY_SIGNATURE="${DBT_NOVA_VERIFY_SIGNATURE:-auto}"
+VERIFY_SIGNATURE="${DBT_NOVA_VERIFY_SIGNATURE:-1}"
 COSIGN_BINARY="${DBT_NOVA_COSIGN_BINARY:-cosign}"
 COSIGN_CERT_IDENTITY_REGEXP="${DBT_NOVA_COSIGN_CERT_IDENTITY_REGEXP:-https://github.com/${REPO_SLUG}/.github/workflows/release.yml@refs/tags/v.*}"
 COSIGN_CERT_OIDC_ISSUER="${DBT_NOVA_COSIGN_CERT_OIDC_ISSUER:-https://token.actions.githubusercontent.com}"
@@ -41,7 +41,7 @@ Environment overrides:
   DBT_NOVA_INSTALL_WARM_MODELS     1 to pre-warm model files after install (default: 0)
   DBT_NOVA_INSTALL_NONINTERACTIVE  1 to skip prompts (defaults to slim)
   DBT_NOVA_VERIFY_CHECKSUM         1 to verify artifact checksum (default: 1)
-  DBT_NOVA_VERIFY_SIGNATURE        auto|1|0 checksum signature verification (default: auto)
+  DBT_NOVA_VERIFY_SIGNATURE        1|auto|0 checksum signature verification (default: 1)
   DBT_NOVA_COSIGN_BINARY           Path to cosign executable (default: cosign)
   DBT_NOVA_COSIGN_CERT_IDENTITY_REGEXP  Expected signing identity regexp
   DBT_NOVA_COSIGN_CERT_OIDC_ISSUER      Expected signing OIDC issuer
@@ -186,11 +186,7 @@ download_file() {
 
   if command -v gh >/dev/null 2>&1; then
     echo "Direct download failed for ${file_name}; trying gh release download"
-    if [[ "${VERSION}" == "latest" ]]; then
-      gh release download --repo "${REPO_SLUG}" --pattern "${file_name}" --output "${out}"
-    else
-      gh release download "${VERSION}" --repo "${REPO_SLUG}" --pattern "${file_name}" --output "${out}"
-    fi
+    gh release download "${VERSION}" --repo "${REPO_SLUG}" --pattern "${file_name}" --output "${out}"
     return 0
   fi
 
@@ -226,8 +222,8 @@ download_repo_archive() {
   fi
 }
 
-repo_default_branch() {
-  local api_url="https://api.github.com/repos/${REPO_SLUG}"
+latest_release_tag() {
+  local api_url="https://api.github.com/repos/${REPO_SLUG}/releases/latest"
   local response=""
 
   if [[ -n "${DOWNLOAD_TOKEN}" ]]; then
@@ -236,13 +232,32 @@ repo_default_branch() {
     response="$(curl -fsSL "${api_url}" 2>/dev/null || true)"
   fi
 
-  if [[ -z "${response}" ]]; then
+  if [[ -n "${response}" ]]; then
+    printf '%s' "${response}" \
+      | tr -d '\n' \
+      | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
     return 0
   fi
 
-  printf '%s' "${response}" \
-    | tr -d '\n' \
-    | sed -n 's/.*"default_branch"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
+  if command -v gh >/dev/null 2>&1; then
+    gh release view --repo "${REPO_SLUG}" --json tagName --jq '.tagName' 2>/dev/null || true
+  fi
+}
+
+resolve_latest_version() {
+  if [[ "${VERSION}" != "latest" ]]; then
+    return 0
+  fi
+
+  local tag
+  tag="$(latest_release_tag)"
+  if [[ -z "${tag}" ]]; then
+    echo "Could not resolve the latest release tag for ${REPO_SLUG}." >&2
+    echo "Set DBT_NOVA_VERSION to an explicit release tag." >&2
+    exit 1
+  fi
+  VERSION="${tag}"
+  echo "Resolved latest release to ${VERSION}"
 }
 
 normalize_model_layout() {
@@ -507,6 +522,14 @@ done
 
 resolve_skill_install_selection
 
+case "${VERIFY_SIGNATURE}" in
+  1|auto|0) ;;
+  *)
+    echo "Invalid DBT_NOVA_VERIFY_SIGNATURE='${VERIFY_SIGNATURE}'. Use 1, auto, or 0." >&2
+    exit 1
+    ;;
+esac
+
 OS="$(uname -s)"
 ARCH="$(uname -m)"
 
@@ -558,19 +581,13 @@ set_artifact_urls() {
   checksum_file="dbt-nova-${asset_os}-${asset_arch}.sha256"
   signature_file="${checksum_file}.sig"
   certificate_file="${checksum_file}.crt"
-  if [[ "${VERSION}" == "latest" ]]; then
-    url="https://github.com/${REPO_SLUG}/releases/latest/download/${asset}"
-    checksum_url="https://github.com/${REPO_SLUG}/releases/latest/download/${checksum_file}"
-    signature_url="https://github.com/${REPO_SLUG}/releases/latest/download/${signature_file}"
-    certificate_url="https://github.com/${REPO_SLUG}/releases/latest/download/${certificate_file}"
-  else
-    url="https://github.com/${REPO_SLUG}/releases/download/${VERSION}/${asset}"
-    checksum_url="https://github.com/${REPO_SLUG}/releases/download/${VERSION}/${checksum_file}"
-    signature_url="https://github.com/${REPO_SLUG}/releases/download/${VERSION}/${signature_file}"
-    certificate_url="https://github.com/${REPO_SLUG}/releases/download/${VERSION}/${certificate_file}"
-  fi
+  url="https://github.com/${REPO_SLUG}/releases/download/${VERSION}/${asset}"
+  checksum_url="https://github.com/${REPO_SLUG}/releases/download/${VERSION}/${checksum_file}"
+  signature_url="https://github.com/${REPO_SLUG}/releases/download/${VERSION}/${signature_file}"
+  certificate_url="https://github.com/${REPO_SLUG}/releases/download/${VERSION}/${certificate_file}"
 }
 
+resolve_latest_version
 set_artifact_urls
 
 tmp_dir="$(mktemp -d)"
@@ -659,15 +676,7 @@ if [[ "${INSTALL_WARM_MODELS}" == "1" && "${INSTALL_FLAVOR}" == "slim" ]]; then
   warm_script_url=""
 
   warm_script_refs=()
-  if [[ "${VERSION}" != "latest" ]]; then
-    warm_script_refs+=("${VERSION}")
-  else
-    detected_default_branch="$(repo_default_branch)"
-    if [[ -n "${detected_default_branch}" ]]; then
-      warm_script_refs+=("${detected_default_branch}")
-    fi
-    warm_script_refs+=("main" "master")
-  fi
+  warm_script_refs+=("${VERSION}")
 
   for warm_script_ref in "${warm_script_refs[@]}"; do
     [[ -n "${warm_script_ref}" ]] || continue
@@ -696,15 +705,7 @@ if [[ "${INSTALL_SKILLS}" == "1" ]]; then
   skills_refs=()
   skills_installed="0"
 
-  if [[ "${VERSION}" != "latest" ]]; then
-    skills_refs+=("${VERSION}")
-  else
-    detected_default_branch="$(repo_default_branch)"
-    if [[ -n "${detected_default_branch}" ]]; then
-      skills_refs+=("${detected_default_branch}")
-    fi
-    skills_refs+=("main" "master")
-  fi
+  skills_refs+=("${VERSION}")
 
   for skills_ref in "${skills_refs[@]}"; do
     [[ -n "${skills_ref}" ]] || continue

--- a/src/manifest/search/core.rs
+++ b/src/manifest/search/core.rs
@@ -762,10 +762,15 @@ impl ManifestSearchHandle {
     /// Returns the underlying initialization error if the manifest fails to load.
     pub async fn wait_ready(&self) -> Result<Arc<ManifestSearch>> {
         loop {
+            let notified = self.notify.notified();
+            tokio::pin!(notified);
+            // Register before checking state so a one-shot readiness notification
+            // cannot land between the check and the wait.
+            notified.as_mut().enable();
             match self.get().await {
                 Ok(searcher) => return Ok(searcher),
                 Err(DbtNovaError::IndexBuildInProgress { .. }) => {
-                    self.notify.notified().await;
+                    notified.await;
                 }
                 Err(err) => return Err(err),
             }

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -30,6 +30,7 @@ use crate::utils::{SearchPersona, has_query_syntax, tokenize_alnum_lowercase};
 use tracing::{debug, instrument, warn};
 
 const SEMANTIC_TIMEOUT_RESERVE_MS: u64 = 10;
+const SCAN_DEADLINE_CHECK_INTERVAL: usize = 64;
 
 #[derive(Debug, Clone, Copy)]
 struct SearchDeadline {
@@ -60,6 +61,34 @@ impl SearchDeadline {
     fn has_timeout(self) -> bool {
         self.timeout_ms > 0
     }
+
+    fn check(self) -> Result<()> {
+        if !self.has_timeout() {
+            return Ok(());
+        }
+        let elapsed_ms = u64::try_from(self.started_at.elapsed().as_millis()).unwrap_or(u64::MAX);
+        if elapsed_ms >= self.timeout_ms {
+            return Err(DbtNovaError::ServerError(format!(
+                "Search timed out after {}ms",
+                self.timeout_ms
+            )));
+        }
+        Ok(())
+    }
+}
+
+enum SemanticWorkResult<T> {
+    Completed(Result<T>),
+    SkippedDeadline,
+    TimedOut,
+}
+
+fn check_scan_deadline(deadline: SearchDeadline, scanned: &mut usize) -> Result<()> {
+    *scanned = scanned.wrapping_add(1);
+    if *scanned == 1 || (*scanned).is_multiple_of(SCAN_DEADLINE_CHECK_INTERVAL) {
+        deadline.check()?;
+    }
+    Ok(())
 }
 
 async fn run_semantic_blocking<T, F>(
@@ -67,7 +96,7 @@ async fn run_semantic_blocking<T, F>(
     component: &'static str,
     operation: &'static str,
     f: F,
-) -> Result<Option<Result<T>>>
+) -> Result<SemanticWorkResult<T>>
 where
     T: Send + 'static,
     F: FnOnce() -> Result<T> + Send + 'static,
@@ -78,14 +107,14 @@ where
             component,
             operation, "semantic operation skipped because request deadline is exhausted"
         );
-        return Ok(None);
+        return Ok(SemanticWorkResult::SkippedDeadline);
     }
 
     let mut handle = tokio::task::spawn_blocking(f);
     if let Some(remaining) = remaining {
         if let Ok(joined) = tokio::time::timeout(remaining, &mut handle).await {
             joined
-                .map(Some)
+                .map(SemanticWorkResult::Completed)
                 .map_err(|error| DbtNovaError::ServerError(error.to_string()))
         } else {
             handle.abort();
@@ -95,12 +124,12 @@ where
                 timeout_ms = remaining.as_millis(),
                 "semantic operation timed out before request deadline"
             );
-            Ok(None)
+            Ok(SemanticWorkResult::TimedOut)
         }
     } else {
         handle
             .await
-            .map(Some)
+            .map(SemanticWorkResult::Completed)
             .map_err(|error| DbtNovaError::ServerError(error.to_string()))
     }
 }
@@ -236,7 +265,7 @@ impl ManifestSearch {
                         )
                         .await?
                         {
-                            Some(Ok(reranked_hits)) => {
+                            SemanticWorkResult::Completed(Ok(reranked_hits)) => {
                                 self.reranker_breaker.on_success().await;
                                 let mut reordered: Vec<(String, f32)> = Vec::new();
                                 let mut seen: HashSet<String> = HashSet::new();
@@ -256,12 +285,16 @@ impl ManifestSearch {
                                 fused_hits = reordered;
                                 reranker_applied = true;
                             }
-                            Some(Err(err)) => {
+                            SemanticWorkResult::Completed(Err(err)) => {
                                 self.reranker_breaker.on_failure().await;
                                 warn!(error = %err, "reranker failed; using fused ranking");
                             }
-                            None => {
+                            SemanticWorkResult::SkippedDeadline => {
                                 debug!("reranker skipped because request deadline was exhausted");
+                            }
+                            SemanticWorkResult::TimedOut => {
+                                self.reranker_breaker.on_failure().await;
+                                warn!("reranker timed out; using fused ranking");
                             }
                         }
                     }
@@ -538,6 +571,7 @@ impl ManifestSearch {
             resource_filter.as_ref(),
             indicator_filter.as_ref(),
             params.explain,
+            deadline,
         )?;
         rows = self
             .rank_indicator_rows(params, query_has_syntax, persona, rows, deadline)
@@ -561,12 +595,14 @@ impl ManifestSearch {
             )));
         }
 
+        let deadline = SearchDeadline::from_config(&self.config.search);
         let resource_filter = normalized_resource_type_filter(&params.resource_types);
         let indicator_filter = normalized_indicator_type_filter(&params.indicator_types)?;
         let rows = self.indicator_inventory_rows(
             resource_filter.as_ref(),
             indicator_filter.as_ref(),
             params.canonical_only,
+            deadline,
         )?;
         let total = rows.len();
         let limit = self.page_limit(params.pagination.limit);
@@ -615,6 +651,7 @@ impl ManifestSearch {
             ));
         }
 
+        let deadline = SearchDeadline::from_config(&self.config.search);
         let resource_filter = normalized_resource_type_filter(&params.resource_types);
         let role_filter = normalized_value_filter(&params.roles);
         let semantic_type_filter = normalized_value_filter(&params.semantic_types);
@@ -625,6 +662,7 @@ impl ManifestSearch {
             resource_filter.as_ref(),
             role_filter.as_ref(),
             semantic_type_filter.as_ref(),
+            deadline,
         )?;
         if let Some(min_score) = params.min_score {
             rows.retain(|row| row.score >= min_score);
@@ -662,6 +700,7 @@ impl ManifestSearch {
             )));
         }
 
+        let deadline = SearchDeadline::from_config(&self.config.search);
         let resource_filter = normalized_resource_type_filter(&params.resource_types);
         let role_filter = normalized_value_filter(&params.roles);
         let semantic_type_filter = normalized_value_filter(&params.semantic_types);
@@ -670,6 +709,7 @@ impl ManifestSearch {
             role_filter.as_ref(),
             semantic_type_filter.as_ref(),
             params.annotated_only,
+            deadline,
         )?;
         let total = rows.len();
         let limit = self.page_limit(params.pagination.limit);
@@ -772,7 +812,7 @@ impl ManifestSearch {
                     )
                     .await?
                     {
-                        Some(Ok(reranked_hits)) => {
+                        SemanticWorkResult::Completed(Ok(reranked_hits)) => {
                             self.reranker_breaker.on_success().await;
                             rows = reorder_indicator_rows_with_reranker(
                                 rows,
@@ -781,17 +821,21 @@ impl ManifestSearch {
                                 &self.config.search.indicator_ranking,
                             );
                         }
-                        Some(Err(err)) => {
+                        SemanticWorkResult::Completed(Err(err)) => {
                             self.reranker_breaker.on_failure().await;
                             warn!(
                                 error = %err,
                                 "indicator reranker failed; using existing indicator ranking"
                             );
                         }
-                        None => {
+                        SemanticWorkResult::SkippedDeadline => {
                             debug!(
                                 "indicator reranker skipped because request deadline was exhausted"
                             );
+                        }
+                        SemanticWorkResult::TimedOut => {
+                            self.reranker_breaker.on_failure().await;
+                            warn!("indicator reranker timed out; using existing indicator ranking");
                         }
                     }
                 }
@@ -962,13 +1006,16 @@ impl ManifestSearch {
         resource_filter: Option<&HashSet<String>>,
         indicator_filter: Option<&HashSet<String>>,
         include_explain: bool,
+        deadline: SearchDeadline,
     ) -> Result<Vec<IndicatorSearchRow>> {
         let min_word_len = self.config.search.min_word_length.max(1);
         let token_set: HashSet<&str> = tokens.iter().map(String::as_str).collect();
         let query_token_count = token_set.len();
         let mut rows: Vec<IndicatorSearchRow> = Vec::new();
+        let mut scanned = 0usize;
 
         for unique_id in self.entities.ids() {
+            check_scan_deadline(deadline, &mut scanned)?;
             let Some(entity) = self.get_entity_archived(unique_id)? else {
                 continue;
             };
@@ -1050,10 +1097,13 @@ impl ManifestSearch {
         resource_filter: Option<&HashSet<String>>,
         indicator_filter: Option<&HashSet<String>>,
         canonical_only: bool,
+        deadline: SearchDeadline,
     ) -> Result<Vec<IndicatorInventoryRow>> {
         let mut rows = Vec::new();
+        let mut scanned = 0usize;
 
         for unique_id in self.entities.ids() {
+            check_scan_deadline(deadline, &mut scanned)?;
             let Some(entity) = self.get_entity_archived(unique_id)? else {
                 continue;
             };
@@ -1113,10 +1163,13 @@ impl ManifestSearch {
         resource_filter: Option<&HashSet<String>>,
         role_filter: Option<&HashSet<String>>,
         semantic_type_filter: Option<&HashSet<String>>,
+        deadline: SearchDeadline,
     ) -> Result<Vec<ColumnSearchRow>> {
         let mut rows = Vec::new();
+        let mut scanned = 0usize;
 
         for unique_id in self.entities.ids() {
+            check_scan_deadline(deadline, &mut scanned)?;
             let Some(entity) = self.get_entity_archived(unique_id)? else {
                 continue;
             };
@@ -1127,6 +1180,7 @@ impl ManifestSearch {
             let column_meta = entity_column_meta_lookup(entity);
 
             for column_name in entity.column_names_iter() {
+                check_scan_deadline(deadline, &mut scanned)?;
                 let summary = column_meta.get(column_name).copied();
                 if !column_matches_filters(summary, role_filter, semantic_type_filter, false) {
                     continue;
@@ -1159,10 +1213,13 @@ impl ManifestSearch {
         role_filter: Option<&HashSet<String>>,
         semantic_type_filter: Option<&HashSet<String>>,
         annotated_only: bool,
+        deadline: SearchDeadline,
     ) -> Result<Vec<ColumnInventoryRow>> {
         let mut rows = Vec::new();
+        let mut scanned = 0usize;
 
         for unique_id in self.entities.ids() {
+            check_scan_deadline(deadline, &mut scanned)?;
             let Some(entity) = self.get_entity_archived(unique_id)? else {
                 continue;
             };
@@ -1173,6 +1230,7 @@ impl ManifestSearch {
             let column_meta = entity_column_meta_lookup(entity);
 
             for column_name in entity.column_names_iter() {
+                check_scan_deadline(deadline, &mut scanned)?;
                 let summary = column_meta.get(column_name).copied();
                 if !column_matches_filters(
                     summary,
@@ -1320,16 +1378,20 @@ impl ManifestSearch {
                 )
                 .await?
                 {
-                    Some(Ok(vector_hits)) => {
+                    SemanticWorkResult::Completed(Ok(vector_hits)) => {
                         self.vector_breaker.on_success().await;
                         rankings.push(("vector", scores_to_ids(&vector_hits)));
                     }
-                    Some(Err(err)) => {
+                    SemanticWorkResult::Completed(Err(err)) => {
                         self.vector_breaker.on_failure().await;
                         warn!(error = %err, "vector search failed; skipping vector results");
                     }
-                    None => {
+                    SemanticWorkResult::SkippedDeadline => {
                         debug!("vector retriever skipped because request deadline was exhausted");
+                    }
+                    SemanticWorkResult::TimedOut => {
+                        self.vector_breaker.on_failure().await;
+                        warn!("vector search timed out; skipping vector results");
                     }
                 }
             } else {
@@ -1352,16 +1414,20 @@ impl ManifestSearch {
                 )
                 .await?
                 {
-                    Some(Ok(sparse_hits)) => {
+                    SemanticWorkResult::Completed(Ok(sparse_hits)) => {
                         self.sparse_breaker.on_success().await;
                         rankings.push(("sparse", scores_to_ids(&sparse_hits)));
                     }
-                    Some(Err(err)) => {
+                    SemanticWorkResult::Completed(Err(err)) => {
                         self.sparse_breaker.on_failure().await;
                         warn!(error = %err, "sparse search failed; skipping sparse results");
                     }
-                    None => {
+                    SemanticWorkResult::SkippedDeadline => {
                         debug!("sparse retriever skipped because request deadline was exhausted");
+                    }
+                    SemanticWorkResult::TimedOut => {
+                        self.sparse_breaker.on_failure().await;
+                        warn!("sparse search timed out; skipping sparse results");
                     }
                 }
             } else {
@@ -1378,6 +1444,7 @@ impl ManifestSearch {
                 resource_filter.as_ref(),
                 None,
                 false,
+                deadline,
             )?;
             if self.config.search.indicator_ranking.enable_parent_coherence
                 && indicator_rows.len() > 1
@@ -4630,8 +4697,8 @@ mod tests {
     use crate::error::DbtNovaError;
 
     use super::{
-        SearchCandidate, SearchDeadline, analyst_near_tie_hint, resource_type_allowed_for_search,
-        run_semantic_blocking,
+        SEMANTIC_TIMEOUT_RESERVE_MS, SearchCandidate, SearchDeadline, SemanticWorkResult,
+        analyst_near_tie_hint, resource_type_allowed_for_search, run_semantic_blocking,
     };
 
     #[test]
@@ -4734,7 +4801,24 @@ mod tests {
         .await
         .expect("deadline helper should not fail");
 
-        assert!(result.is_none());
+        assert!(matches!(result, SemanticWorkResult::SkippedDeadline));
         assert!(!ran.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn semantic_blocking_reports_timeout_after_start() {
+        let deadline = SearchDeadline {
+            started_at: Instant::now(),
+            timeout_ms: SEMANTIC_TIMEOUT_RESERVE_MS + 5,
+        };
+
+        let result = run_semantic_blocking(deadline, "vector search", "test", move || {
+            std::thread::sleep(Duration::from_millis(50));
+            Ok::<_, DbtNovaError>(())
+        })
+        .await
+        .expect("deadline helper should not fail");
+
+        assert!(matches!(result, SemanticWorkResult::TimedOut));
     }
 }


### PR DESCRIPTION
## Summary

- Harden installer provenance by making checksum signature verification fail closed by default and resolving `latest` to the immutable release tag before fetching optional warm-model or skill assets.
- Add cooperative deadline checks to synchronous indicator/column scan paths, account semantic timeouts as circuit-breaker failures, and close the readiness missed-notification window.
- Keep `v0.0.6` unreleased by using the existing `v0.0.5` tag only for currently released install paths, switching next-release workflow/agent-readiness examples to explicit placeholders, requiring strict signature verification in install snippets, and filling the missing config-reference knobs.

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked semantic_blocking --all-features`
- `cargo test --locked --all-features`
- `cargo check --locked --no-default-features --all-targets`
- `uv run mkdocs build --strict`
- `bash scripts/check_config_reference.sh`
- `bash scripts/check_dependency_watchlist.sh`
- `bash -n scripts/install.sh && bash -n scripts/warm_models.sh`
- `actionlint .github/workflows/*.yml`
- `cargo deny check` (passes with existing duplicate-crate warnings)

## Notes

- This PR intentionally does not publish or tag `v0.0.6`.
- Public docs now avoid concrete non-existent `v0.0.6` install/workflow refs until the release is cut.
