### PR TITLE
Harden release smoke and agent readiness

### DIFF
--- a/.github/skills/analyst/SKILL.md
+++ b/.github/skills/analyst/SKILL.md
@@ -66,6 +66,18 @@ can state one of these evidence-backed reasons:
 When you fall back to raw model search, say what semantic discovery you tried
 and why it was insufficient.
 
+Metric disambiguation rules:
+- If the ask says "total", "amount", "GMV", "revenue", or another additive
+  business result, prefer the total measure or metric definition. Reject
+  `per_*`, ratio, average, per-teammate, per-business-unit, or normalized
+  indicators unless the user explicitly asks for that grain.
+- If top semantic results include both a total indicator and a per-unit
+  indicator, choose the total indicator when the wording asks for an amount;
+  ask one clarification question before execution only when the wording itself
+  is genuinely ambiguous.
+- Preserve the rejected indicator names in your evidence when the distinction
+  matters to the answer.
+
 ## Transport selection (required)
 
 Choose transport before loading transport-specific references:

--- a/.github/skills/analyst/references/transport-cli.md
+++ b/.github/skills/analyst/references/transport-cli.md
@@ -9,8 +9,12 @@ Use this reference when the client does not expose Nova MCP tools directly and y
 - Always use `--json`.
 - Prefer `--params-file` over long inline JSON when payloads get large.
 - Run `dbt-nova health check` before substantive work.
-- If health is not ready, resolve the readiness problem before trusting search or SQL.
+- If health is not ready or `ready_for_traffic` is false, resolve the readiness
+  problem before trusting search or SQL.
 - `execute_sql` and `run_recipe` require valid warehouse environment variables.
+- Do not run `manifest warm` during analyst work unless the user explicitly
+  approves semantic cache warmup. For large or memory-constrained manifests,
+  keep vector, sparse, and reranker search disabled in the environment.
 
 ## Transport mapping
 
@@ -39,6 +43,8 @@ fallback is used.
 - Prefer `--params-file` or `--params-json` to avoid shell-escaping mistakes.
 - Prefer `--params-file` for `execute_sql` when SQL contains quotes or newlines.
 - Treat warehouse auth failures as execution blockers, not discovery failures.
+- Treat `INDEX_BUILDING` as a readiness state. Poll health until
+  `ready_for_traffic=true` instead of retrying analytical tools immediately.
 
 ## Execution
 

--- a/.github/skills/analyst/references/transport-mcp.md
+++ b/.github/skills/analyst/references/transport-mcp.md
@@ -6,9 +6,15 @@ Use this reference when the client exposes `mcp__nova__*` tools directly.
 
 - Use `show_metadata` for fast project identity and manifest scope checks.
 - Use `health` only when readiness is uncertain or a prior tool suggests startup, refresh, or cache issues.
-- If `health.status` is not `ready` on a shared hosted endpoint, stop and report the readiness state. Do not mutate server state from an analyst workflow.
+- If `health.status` is not `ready` or `health.data.ready_for_traffic` is false
+  on a shared hosted endpoint, stop and report the readiness state. Do not
+  mutate server state from an analyst workflow.
+- Treat `INDEX_BUILDING` as normal startup/readiness evidence, not as a failed
+  analytical result.
 - `run_recipe` uses the same warehouse execution path as `execute_sql`.
 - A warehouse auth or provider failure is an execution blocker, not a discovery failure.
+- Do not call `warm_manifest` from an analyst workflow unless the user
+  explicitly approved semantic cache warmup for the running machine.
 
 ## Discovery order
 

--- a/.github/skills/bi-engineer/references/transport-cli.md
+++ b/.github/skills/bi-engineer/references/transport-cli.md
@@ -9,8 +9,11 @@ Use this reference when you are working through the local `dbt-nova` CLI.
 - Always use `--json`.
 - Prefer `--params-file` for structured payloads.
 - Run `health check` before substantive work.
+- If health is not ready or `ready_for_traffic` is false, wait before using
+  discovery or execution evidence.
 - Keep warehouse validation bounded with explicit time/filter predicates, row/byte limits, and finite timeouts.
 - Do not trigger full manifest warmups or broad warehouse scans unless the user explicitly approves them.
+- Treat `INDEX_BUILDING` as startup readiness evidence, not a BI design result.
 
 ## CLI mapping
 

--- a/.github/skills/bi-engineer/references/transport-mcp.md
+++ b/.github/skills/bi-engineer/references/transport-mcp.md
@@ -6,6 +6,8 @@ Use this reference when the client exposes `mcp__nova__*` tools directly.
 
 - Use MCP first for indicator resolution, contract checks, and filter validation.
 - Use `health` when readiness is uncertain and `show_metadata` when manifest context matters.
+- If `health` reports `ready_for_traffic=false` or a tool returns
+  `INDEX_BUILDING`, wait for readiness before continuing.
 - Use recipe tools when a recurring reporting workflow already exists; otherwise design from the entity contract.
 - Treat warehouse failures as execution blockers, not design proof.
 - Keep SQL bounded with explicit time/filter predicates, `row_limit`, `byte_limit`, small `max_chunks`, and finite timeouts.

--- a/.github/skills/engineer/references/transport-cli.md
+++ b/.github/skills/engineer/references/transport-cli.md
@@ -10,6 +10,11 @@ Use this reference when you are working through the local `dbt-nova` CLI in the 
 - Prefer `--params-file` when payloads become awkward inline.
 - Run `audit nova-meta` when schema YAML or `meta.nova` changes.
 - After local compile/build updates the manifest, refresh the Nova view before trusting new discovery results.
+- For large-manifest validation on constrained machines, do not run
+  `manifest warm`; keep vector, sparse, and reranker search disabled unless the
+  user explicitly asks to test semantic cache behavior.
+- Treat `INDEX_BUILDING` as a startup/readiness state and wait for
+  `ready_for_traffic=true` before drawing conclusions from search tools.
 
 ## CLI mapping
 
@@ -29,3 +34,5 @@ Common mappings:
 - Prefer `tool call` parity with MCP before inventing custom shell parsing.
 - Treat auth failures as execution blockers, not discovery failures.
 - Use CLI JSON output as evidence for ship summaries.
+- Use `scripts/smoke_release_no_warm.sh` when the task is release or local
+  hardening evidence rather than model implementation.

--- a/.github/skills/engineer/references/transport-mcp.md
+++ b/.github/skills/engineer/references/transport-mcp.md
@@ -7,7 +7,12 @@ Use this reference when the client exposes `mcp__nova__*` tools directly.
 - Use `show_metadata` first for a fast scope check when you need project identity or manifest scope.
 - Use MCP first for discovery, inspection, impact, and quality checks.
 - Use `health` only when readiness is uncertain or a prior tool suggests a startup/cache issue.
+- If `health` reports `ready_for_traffic=false` or a tool returns
+  `INDEX_BUILDING`, wait for readiness before continuing tool-based evidence
+  gathering.
 - If the change requires local compile/build or `audit nova-meta`, switch to CLI for that part instead of forcing MCP to do it.
+- Do not call `warm_manifest` on shared or constrained environments unless the
+  task is explicitly about semantic cache lifecycle validation.
 
 ## Discovery order
 

--- a/.github/skills/eval-author/SKILL.md
+++ b/.github/skills/eval-author/SKILL.md
@@ -75,6 +75,13 @@ Eval execution is CLI-only. MCP is for discovering ground truth and debugging ex
 - Freeze relative dates in agent tasks. Do not leave "last week", "this month", or "last 52 weeks" unresolved unless the eval is explicitly testing date interpretation.
 - Keep smoke suites small and strict. Keep broader regression suites larger with realistic `--fail-under` thresholds.
 - Put advisory launch-readiness thresholds in suite YAML as `gate: { threshold: <0.0-1.0> }`, then verify the latest full-suite telemetry with `dbt-nova eval gate <suite_name> --json`. Filtered `--case-id` runs are for iteration and do not satisfy configured gates.
+- For large manifests or constrained machines, keep vector, sparse, and reranker
+  search disabled during smoke/eval validation unless semantic model behavior is
+  the explicit test target. Do not run `manifest warm` or `warm_manifest` as a
+  side effect of eval authoring.
+- MCP eval, trace, and nova-meta file paths are scoped under the server working
+  directory. Put suite files, result directories, traces, and validation
+  fixtures under that root, or run the server from the project root.
 - Never include secrets, credentials, raw SQL parameter maps, or private manifests in public eval artifacts.
 
 ## Output standard

--- a/.github/skills/eval-author/references/provider-patterns.md
+++ b/.github/skills/eval-author/references/provider-patterns.md
@@ -185,7 +185,16 @@ called_with:
 
 ## Provider Runs
 
-Default provider:
+Default provider presets:
+
+| Provider | Default command shape |
+| --- | --- |
+| `opencode` | `opencode run --format json <prompt>` |
+| `codex` | `codex exec --json --cd <workdir> <prompt>` |
+| `claude` | `claude -p --verbose --output-format stream-json <prompt>` |
+| `goose` | `goose run --text <prompt> --output-format stream-json --no-session` |
+
+Default provider run:
 
 ```bash
 dbt-nova eval agent run \
@@ -195,6 +204,41 @@ dbt-nova eval agent run \
   --case-id metric_lookup_flow \
   --fail-under 1.0
 ```
+
+For a trusted local hardening run where the agent CLIs are already configured
+and noninteractive execution is acceptable, use explicit custom provider args:
+
+```bash
+dbt-nova eval agent run \
+  --suite evals/analyst-agent.yml \
+  --provider custom \
+  --provider-command opencode \
+  --provider-args-json '["run","--format","json","--dangerously-skip-permissions","{prompt}"]' \
+  --manifest-path target/manifest.json \
+  --telemetry \
+  --fail-under 1.0
+
+dbt-nova eval agent run \
+  --suite evals/analyst-agent.yml \
+  --provider custom \
+  --provider-command claude \
+  --provider-args-json '["-p","--dangerously-skip-permissions","--verbose","--output-format","stream-json","{prompt}"]' \
+  --manifest-path target/manifest.json \
+  --telemetry \
+  --fail-under 1.0
+
+dbt-nova eval agent run \
+  --suite evals/analyst-agent.yml \
+  --provider custom \
+  --provider-command codex \
+  --provider-args-json '["exec","--json","--dangerously-bypass-approvals-and-sandbox","--skip-git-repo-check","--cd","{workdir}","{prompt}"]' \
+  --manifest-path target/manifest.json \
+  --telemetry \
+  --fail-under 1.0
+```
+
+Use bypass flags only on trusted local machines or reviewed private runners.
+Keep them out of public default CI.
 
 Custom provider:
 
@@ -213,3 +257,8 @@ dbt-nova eval agent run \
 - If the wrong MCP server alias is used, set `DBT_NOVA_EVAL_MCP_SERVER_ALIASES`.
 - If `selected_entities` fails but `must_call` passes, inspect the tool result shape and prefer `selected_entity_ranks` scoped to the discovery tool.
 - If final-answer checks are brittle, remove broad prose expectations and keep only durable business terms.
+- If a provider chooses a per-unit metric when the task asks for a total
+  business amount, tighten the task wording and assert the intended indicator in
+  `selected_entity_ranks` or final-answer durable terms.
+- If a gate reports missing telemetry, rerun the full suite with `--telemetry`;
+  filtered `--case-id` runs do not satisfy launch-readiness gates.

--- a/.github/skills/eval-author/references/workflow.md
+++ b/.github/skills/eval-author/references/workflow.md
@@ -34,6 +34,14 @@ suite will use. Do not add `--read-only` during first-time discovery unless a
 reusable index is already materialized; otherwise Nova cannot build the index
 needed to answer search tools.
 
+For large manifests or memory-constrained machines, explicitly disable vector,
+sparse, and reranker search when the suite is not testing semantic model
+behavior. Do not run `manifest warm` or `warm_manifest` just to validate bridge
+or provider tool-use behavior.
+
+When using MCP, wait for `health.data.ready_for_traffic=true` before recording
+ground truth. `INDEX_BUILDING` is startup evidence, not a failed assertion.
+
 Freeze relative dates before writing agent tasks. For example, replace "last
 week" with explicit start/end dates and state the comparison basis. If the eval
 targets a recipe, follow that recipe's calendar contract instead of assuming a

--- a/.github/skills/governance/references/transport-cli.md
+++ b/.github/skills/governance/references/transport-cli.md
@@ -10,6 +10,11 @@ Use this reference when you are working through the local `dbt-nova` CLI.
 - Freeze scope before scoring and keep it stable for reruns.
 - Use `audit metadata-score` as the primary gate.
 - Use `audit nova-meta` when schema YAML or Nova metadata is in scope.
+- Do not run `manifest warm` as part of a governance audit unless semantic
+  cache readiness is the audit subject. On constrained machines, keep vector,
+  sparse, and reranker search disabled.
+- Treat `INDEX_BUILDING` as a readiness state. Wait for
+  `ready_for_traffic=true` before freezing audit evidence.
 
 ## CLI mapping
 
@@ -20,3 +25,4 @@ Common mappings:
 - local Nova validation: `audit nova-meta`
 - blocker detail: `tool call get_metadata_score`, `get_test_coverage`, `get_entity`
 - scope inventory: `tool call list_entities`, `find_by_path`
+- release/local hardening: `scripts/smoke_release_no_warm.sh`

--- a/.github/skills/governance/references/transport-mcp.md
+++ b/.github/skills/governance/references/transport-mcp.md
@@ -7,8 +7,13 @@ Use this reference when the client exposes `mcp__nova__*` tools directly.
 - Use `show_metadata` first to capture manifest identity and project scope.
 - Use MCP for scope inventory, metadata scoring, test-coverage review, and entity-level blocker extraction.
 - Use `health` only when readiness is uncertain or a prior tool suggests startup/cache issues.
+- If `health` reports `ready_for_traffic=false` or a tool returns
+  `INDEX_BUILDING`, wait for readiness before freezing audit scope or scoring
+  evidence.
 - Use CLI separately for `audit nova-meta` or other local-only validation.
 - Do not reload or mutate shared hosted MCP servers from a governance audit.
+- Do not call `warm_manifest` from governance audits unless semantic cache
+  readiness is explicitly in scope.
 
 ## Practical order
 

--- a/.github/skills/kpi-debugger/references/transport-cli.md
+++ b/.github/skills/kpi-debugger/references/transport-cli.md
@@ -9,8 +9,12 @@ Use this reference when you are working through the local `dbt-nova` CLI.
 - Always use `--json`.
 - Prefer `--params-file` for structured payloads.
 - Run `health check` before substantive work.
+- If health is not ready or `ready_for_traffic` is false, wait before using
+  discovery or execution evidence.
 - Keep warehouse execution bounded with explicit dates, filters, row/byte limits, and finite timeouts.
 - Do not use CLI workarounds that warm a full manifest or scan a full table unless the user explicitly approves it.
+- Treat `INDEX_BUILDING` as startup readiness evidence, not discrepancy
+  evidence.
 
 ## CLI mapping
 

--- a/.github/skills/kpi-debugger/references/transport-mcp.md
+++ b/.github/skills/kpi-debugger/references/transport-mcp.md
@@ -6,6 +6,8 @@ Use this reference when the client exposes `mcp__nova__*` tools directly.
 
 - Use MCP first for KPI resolution, contract checks, recipe discovery, and bounded reproduction.
 - Use `health` when readiness is uncertain.
+- If `health` reports `ready_for_traffic=false` or a tool returns
+  `INDEX_BUILDING`, wait for readiness before continuing.
 - Use `show_metadata` when the manifest/project context matters.
 - Use recipes only when a recurring reconciliation or debug workflow already exists and its required parameters are clear.
 - Treat warehouse failures as execution blockers, not diagnosis proof.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added no-warm release hardening coverage for CLI and MCP validation,
+  including an all-tool MCP catalog smoke test, a release smoke harness,
+  refreshed provider-eval documentation, and packaged agent-skill readiness
+  guidance for large manifest testing.
 - Hardened production readiness by making installer checksum signature
   verification fail closed by default, resolving `latest` installs to the
   immutable release tag before fetching optional support assets, adding

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -183,12 +183,18 @@ cargo check --locked --no-default-features --all-targets
 cargo check --locked --all-features
 cargo clippy --locked --all-targets --all-features -- -D warnings
 cargo fmt --check
+scripts/smoke_release_no_warm.sh --manifest-path tests/fixtures/starter_eval_manifest.json
 scripts/check_config_reference.sh
 scripts/check_dependency_watchlist.sh
 pip install -r docs/requirements.txt
 mkdocs build --strict
 cargo deny check advisories licenses sources
 ```
+
+For private production-manifest hardening, point the no-warm smoke script at the
+generated `target/manifest.json` and pass private bridge/provider suites
+explicitly. Do not run semantic warmup on memory-constrained machines unless
+the test is specifically about vector, sparse, or reranker cache behavior.
 
 For ranking, retrieval, skill, or eval experiments, include before/after eval
 evidence where possible. If the change does not improve accuracy, latency,

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -29,6 +29,8 @@ Before tagging:
 - [ ] `cargo clippy --locked --all-targets --all-features -- -D warnings` passes
 - [ ] `cargo fmt --check` passes
 - [ ] Docs build clean (`mkdocs build --strict`)
+- [ ] No-warm release smoke passes against the intended manifest or fixture:
+      `scripts/smoke_release_no_warm.sh --manifest-path <manifest.json>`
 - [ ] Release PR approved and merged to `master`
 
 After merge to `master`:

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -561,6 +561,53 @@ wrapped into one of the supported event shapes.
 from provider JSON event streams. For custom providers that do not emit JSON
 events, dbt-nova falls back to the provider stdout.
 
+Default provider preset commands are intentionally conservative:
+
+| Provider | Default command shape |
+| --- | --- |
+| `opencode` | `opencode run --format json <prompt>` |
+| `codex` | `codex exec --json --cd <workdir> <prompt>` |
+| `claude` | `claude -p --verbose --output-format stream-json <prompt>` |
+| `goose` | `goose run --text <prompt> --output-format stream-json --no-session` |
+
+For a trusted local hardening run where the CLIs are already configured and
+noninteractive execution is acceptable, use explicit custom args so the command
+line is auditable:
+
+```bash
+dbt-nova eval agent run \
+  --suite evals/analyst-agent.yml \
+  --provider custom \
+  --provider-command opencode \
+  --provider-args-json '["run","--format","json","--dangerously-skip-permissions","{prompt}"]' \
+  --manifest-path /path/to/target/manifest.json \
+  --telemetry \
+  --fail-under 1.0
+
+dbt-nova eval agent run \
+  --suite evals/analyst-agent.yml \
+  --provider custom \
+  --provider-command claude \
+  --provider-args-json '["-p","--dangerously-skip-permissions","--verbose","--output-format","stream-json","{prompt}"]' \
+  --manifest-path /path/to/target/manifest.json \
+  --telemetry \
+  --fail-under 1.0
+
+dbt-nova eval agent run \
+  --suite evals/analyst-agent.yml \
+  --provider custom \
+  --provider-command codex \
+  --provider-args-json '["exec","--json","--dangerously-bypass-approvals-and-sandbox","--skip-git-repo-check","--cd","{workdir}","{prompt}"]' \
+  --manifest-path /path/to/target/manifest.json \
+  --telemetry \
+  --fail-under 1.0
+```
+
+Keep these bypass flags out of shared CI unless the runner, credentials, and
+artifact policy have been reviewed. For launch-readiness claims, run the full
+suite with `--telemetry`, then check `dbt-nova eval gate <suite-name> --json`;
+filtered `--case-id` runs are for debugging only.
+
 For another provider or a custom local wrapper, pass an explicit command:
 
 ```bash

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -122,6 +122,12 @@ dbt-nova manifest warm \
   --json
 ```
 
+If no component flag is supplied, `manifest warm` requests vector and sparse
+warmup. On constrained machines or very large manifests, skip this command and
+leave `DBT_NOVA_SEARCH_ENABLE_VECTOR=false`,
+`DBT_NOVA_SEARCH_ENABLE_SPARSE=false`, and
+`DBT_NOVA_SEARCH_ENABLE_RERANKER=false` for smoke tests.
+
 ### One-shot tool execution
 
 ```bash
@@ -326,6 +332,9 @@ dbt-nova tool call warm_manifest \
 
 The tool-call form uses the manifest source loaded for the tool call. The MCP
 server form uses the currently configured live-server manifest source.
+When no component flag is supplied, the tool requests vector and sparse warmup,
+matching `manifest warm`; keep the safety gate unset for no-warm release or
+large-manifest smoke tests.
 
 ## Operator admin tools via `tool call`
 

--- a/docs/getting-started/mcp-clients.md
+++ b/docs/getting-started/mcp-clients.md
@@ -37,6 +37,29 @@ or reranking in your MCP client, enable them explicitly with:
 - `DBT_NOVA_SEARCH_ENABLE_SPARSE=true`
 - `DBT_NOVA_SEARCH_ENABLE_RERANKER=true`
 
+For large manifests or memory-constrained machines, keep those three variables
+unset or explicitly set them to `false`, and do not call `warm_manifest` unless
+you have intentionally provisioned the machine for semantic cache writes.
+
+## Readiness Polling
+
+MCP clients may receive `INDEX_BUILDING` while the manifest is still loading or
+indexes are still materializing. Treat that as a startup state, not as a failed
+tool contract.
+
+Automation should wait for one of:
+
+- MCP `health` with `data.ready_for_traffic=true`
+- HTTP `/readyz` returning ready when using streamable HTTP
+
+Do not treat `tools/list` or MCP `initialize` as readiness proof; those can
+succeed before search and metadata tools are safe to call. For local release or
+large-manifest checks, use:
+
+```bash
+scripts/smoke_release_no_warm.sh --manifest-path target/manifest.json
+```
+
 Optional manifest pruning (applies to MCP server startup and reloads):
 - `DBT_NOVA_PRUNE_ALLOW_IDS` (JSON array of dbt `unique_id` patterns)
 - `DBT_NOVA_PRUNE_DENY_IDS` (JSON array of dbt `unique_id` patterns; deny wins)

--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -12,6 +12,61 @@ cargo test -- --nocapture
 - `src/tests/` – in‑crate unit tests
 - `tests/` – integration/property tests and fixtures
 
+## No-Warm Release Smoke
+
+Use the release smoke harness when you need to prove the built binary, CLI
+surface, MCP stdio readiness, and a small set of agent-readiness checks against
+a real manifest without building dense, sparse, or reranker semantic caches:
+
+```bash
+scripts/smoke_release_no_warm.sh \
+  --manifest-path target/manifest.json \
+  --output-dir out/nova-release-smoke \
+  --storage-instance-id release-no-warm-smoke
+```
+
+The harness runs `cargo build --release --locked` unless `--skip-build` is
+passed. It exports:
+
+- `DBT_NOVA_SEARCH_ENABLE_VECTOR=false`
+- `DBT_NOVA_SEARCH_ENABLE_SPARSE=false`
+- `DBT_NOVA_SEARCH_ENABLE_RERANKER=false`
+
+It intentionally does not run `dbt-nova manifest warm`. It also verifies that
+`warm_manifest` remains disabled without
+`DBT_NOVA_MCP_ENABLE_MANIFEST_WARM=1`, polls MCP `health` until
+`ready_for_traffic=true`, checks `tools/list`, and writes `summary.json` plus
+`report.md`.
+
+Bridge and provider-backed evals are opt-in because production manifests,
+provider credentials, and artifact policies differ by environment:
+
+```bash
+scripts/smoke_release_no_warm.sh \
+  --manifest-path tests/fixtures/starter_eval_manifest.json \
+  --bridge-suite evals/starter.yml \
+  --agent-suite evals/starter.yml \
+  --agent-providers opencode,claude,codex \
+  --fail-under 1.0
+```
+
+Keep private manifests, provider stdout/stderr, raw traces, and credentials out
+of public artifacts. The script captures only the Nova artifacts needed for a
+local hardening or release review.
+
+## MCP File Path Policy
+
+MCP file tools resolve local paths under the server working directory. This
+applies to eval suites, eval result comparisons, trace inspection/redaction, and
+`validate_nova_meta` project scans. If a path is outside the server cwd, the
+tool should reject it instead of reading arbitrary local files.
+
+For local testing, start `dbt-nova server start` from the dbt project root when
+you need `validate_nova_meta` to scan project YAML. For eval and trace tests,
+write suites, result directories, and trace JSONL files under the server cwd and
+pass relative paths where possible. Avoid symlink workarounds; they make audit
+evidence harder to reproduce.
+
 ## Nova Metadata and Agent Evals
 
 Use `dbt-nova eval run` to test that a manifest exposes the right search,

--- a/scripts/smoke_release_no_warm.sh
+++ b/scripts/smoke_release_no_warm.sh
@@ -1,0 +1,443 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/smoke_release_no_warm.sh --manifest-path PATH [options]
+
+Build and smoke-test the release binary against a manifest without vector,
+sparse, or reranker warmup. The script writes JSON artifacts and a compact
+Markdown report under --output-dir.
+
+Required:
+  --manifest-path PATH          Local dbt manifest.json to load.
+
+Options:
+  --binary PATH                 dbt-nova binary to test. Defaults to target/release/dbt-nova.
+  --skip-build                  Do not run cargo build --release --locked.
+  --output-dir PATH             Artifact directory. Defaults to target/nova-release-smoke/no-warm.
+  --storage-dir PATH            Nova storage root. Defaults to <output-dir>/storage.
+  --storage-instance-id ID      Storage instance id. Defaults to release-no-warm-smoke.
+  --bridge-suite PATH           Optional bridge eval suite to validate/run.
+  --agent-suite PATH            Optional agent eval suite to validate/run.
+  --agent-providers CSV         Optional provider presets to run, for example opencode,claude,codex.
+  --agent-timeout SECONDS       Provider eval timeout. Defaults to 600.
+  --fail-under RATE             Eval fail-under threshold. Defaults to 1.0.
+  -h, --help                    Show this help.
+
+The script intentionally does not run `dbt-nova manifest warm` or enable the
+MCP `warm_manifest` safety gate. `warm_manifest` is checked only as an expected
+disabled tool-call response.
+EOF
+}
+
+manifest_path=""
+binary="target/release/dbt-nova"
+binary_explicit=0
+skip_build=0
+output_dir="target/nova-release-smoke/no-warm"
+storage_dir=""
+storage_instance_id="release-no-warm-smoke"
+bridge_suite=""
+agent_suite=""
+agent_providers=""
+agent_timeout=600
+fail_under="1.0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --manifest-path)
+      manifest_path="${2:-}"
+      [[ -n "$manifest_path" ]] || { echo "--manifest-path requires a path" >&2; exit 2; }
+      shift 2
+      ;;
+    --binary)
+      binary="${2:-}"
+      [[ -n "$binary" ]] || { echo "--binary requires a path" >&2; exit 2; }
+      binary_explicit=1
+      shift 2
+      ;;
+    --skip-build)
+      skip_build=1
+      shift
+      ;;
+    --output-dir)
+      output_dir="${2:-}"
+      [[ -n "$output_dir" ]] || { echo "--output-dir requires a path" >&2; exit 2; }
+      shift 2
+      ;;
+    --storage-dir)
+      storage_dir="${2:-}"
+      [[ -n "$storage_dir" ]] || { echo "--storage-dir requires a path" >&2; exit 2; }
+      shift 2
+      ;;
+    --storage-instance-id)
+      storage_instance_id="${2:-}"
+      [[ -n "$storage_instance_id" ]] || { echo "--storage-instance-id requires a value" >&2; exit 2; }
+      shift 2
+      ;;
+    --bridge-suite)
+      bridge_suite="${2:-}"
+      [[ -n "$bridge_suite" ]] || { echo "--bridge-suite requires a path" >&2; exit 2; }
+      shift 2
+      ;;
+    --agent-suite)
+      agent_suite="${2:-}"
+      [[ -n "$agent_suite" ]] || { echo "--agent-suite requires a path" >&2; exit 2; }
+      shift 2
+      ;;
+    --agent-providers)
+      agent_providers="${2:-}"
+      [[ -n "$agent_providers" ]] || { echo "--agent-providers requires a CSV list" >&2; exit 2; }
+      shift 2
+      ;;
+    --agent-timeout)
+      agent_timeout="${2:-}"
+      [[ "$agent_timeout" =~ ^[0-9]+$ ]] || { echo "--agent-timeout requires an integer" >&2; exit 2; }
+      shift 2
+      ;;
+    --fail-under)
+      fail_under="${2:-}"
+      [[ -n "$fail_under" ]] || { echo "--fail-under requires a rate" >&2; exit 2; }
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[[ -n "$manifest_path" ]] || { echo "--manifest-path is required" >&2; usage >&2; exit 2; }
+[[ -f "$manifest_path" ]] || { echo "manifest not found: $manifest_path" >&2; exit 2; }
+
+mkdir -p "$output_dir"
+manifest_path="$(python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$manifest_path")"
+output_dir="$(python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$output_dir")"
+storage_dir="${storage_dir:-${output_dir}/storage}"
+mkdir -p "$storage_dir"
+storage_dir="$(python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$storage_dir")"
+
+if [[ "$binary_explicit" -eq 0 ]]; then
+  binary="$(
+    cargo metadata --locked --format-version=1 --no-deps \
+      | python3 -c 'import json,pathlib,sys; print(pathlib.Path(json.load(sys.stdin)["target_directory"]) / "release" / "dbt-nova")'
+  )"
+fi
+
+smoke_env_remove=(
+  DBT_NOVA_MANIFEST_URI
+  DBT_NOVA_BOOTSTRAP_URI
+  DBT_NOVA_STORAGE_ARTIFACT_URI
+  DBT_NOVA_METADATA_ARTIFACT_URI
+  DBT_NOVA_MODELS_ARTIFACT_URI
+  DBT_NOVA_PRUNE_ALLOW_IDS
+  DBT_NOVA_PRUNE_DENY_IDS
+  DBT_NOVA_SERVER_TRANSPORT
+  DBT_NOVA_TOOL_ALLOWLIST
+  DBT_NOVA_TOOL_DENYLIST
+  DBT_NOVA_TRACE_TOOL_CALLS_PATH
+  DBT_NOVA_STORAGE_READ_ONLY
+  DBT_NOVA_TOOL_RATE_LIMITS
+  DBT_NOVA_TOOL_RATE_LIMIT_WINDOW_SECS
+  DBT_NOVA_RESULT_PROFILE
+  DBT_NOVA_MCP_RESULT_PROFILE
+  DBT_NOVA_MCP_MAX_RESPONSE_BYTES
+  DBT_NOVA_MCP_ENABLE_EVAL_RUN
+  DBT_NOVA_MCP_ENABLE_EVAL_WRITES
+  DBT_NOVA_MCP_ENABLE_AGENT_EVAL
+  DBT_NOVA_MCP_ENABLE_CUSTOM_AGENT_PROVIDER
+  DBT_NOVA_MCP_ENABLE_TRACE_WRITES
+  DBT_NOVA_MCP_ENABLE_MANIFEST_RELOAD
+  DBT_NOVA_MCP_ENABLE_MANIFEST_WARM
+  DBT_NOVA_MCP_ENABLE_STORAGE_ADMIN
+)
+unset "${smoke_env_remove[@]}"
+
+export DBT_NOVA_SEARCH_ENABLE_VECTOR=false
+export DBT_NOVA_SEARCH_ENABLE_SPARSE=false
+export DBT_NOVA_SEARCH_ENABLE_RERANKER=false
+export DBT_NOVA_SERVER_TRANSPORT=stdio
+export DBT_NOVA_STORAGE_READ_ONLY=false
+export DBT_NOVA_STORAGE_DIR="$storage_dir"
+export DBT_NOVA_STORAGE_INSTANCE_ID="$storage_instance_id"
+
+if [[ "$skip_build" -eq 0 ]]; then
+  cargo build --release --locked
+fi
+
+[[ -x "$binary" ]] || { echo "binary is not executable: $binary" >&2; exit 2; }
+binary="$(python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$binary")"
+
+"$binary" --version >"${output_dir}/version.txt"
+
+"$binary" health check \
+  --manifest-path "$manifest_path" \
+  --json >"${output_dir}/health.json"
+
+python3 - "${output_dir}/health.json" <<'PY'
+import json, sys
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+data = payload.get("data", {})
+if payload.get("status") != "success" or data.get("ready_for_traffic") is not True:
+    raise SystemExit(f"health check did not reach ready_for_traffic=true: {payload}")
+PY
+
+"$binary" tool call show_metadata \
+  --manifest-path "$manifest_path" \
+  --storage-instance-id "$storage_instance_id" \
+  --params-json '{}' \
+  --json >"${output_dir}/tool-show-metadata.json"
+
+"$binary" tool call search \
+  --manifest-path "$manifest_path" \
+  --storage-instance-id "$storage_instance_id" \
+  --params-json '{"query":"orders","resource_types":["model"],"limit":3}' \
+  --json >"${output_dir}/tool-search.json"
+
+"$binary" tool call get_agent_readiness \
+  --manifest-path "$manifest_path" \
+  --storage-instance-id "$storage_instance_id" \
+  --params-json '{"personas_json":"[\"analyst\"]"}' \
+  --json >"${output_dir}/tool-agent-readiness.json"
+
+warm_manifest_status=0
+if env -u DBT_NOVA_MCP_ENABLE_MANIFEST_WARM "$binary" tool call warm_manifest \
+  --manifest-path "$manifest_path" \
+  --storage-instance-id "$storage_instance_id" \
+  --params-json '{}' \
+  --json >"${output_dir}/tool-warm-manifest-disabled.json" \
+  2>"${output_dir}/tool-warm-manifest-disabled.stderr.log"; then
+  echo "warm_manifest unexpectedly succeeded without DBT_NOVA_MCP_ENABLE_MANIFEST_WARM" >&2
+  exit 1
+else
+  warm_manifest_status=$?
+fi
+
+python3 - "${output_dir}/tool-warm-manifest-disabled.json" "$warm_manifest_status" <<'PY'
+import json, sys
+path, status = sys.argv[1], int(sys.argv[2])
+if status == 0:
+    raise SystemExit("warm_manifest unexpectedly exited successfully")
+payload = json.load(open(path, encoding="utf-8"))
+error = payload.get("error") or {}
+if payload.get("status") != "error" or error.get("error_code") != "INVALID_PARAMS":
+    raise SystemExit(f"warm_manifest did not return the expected disabled-tool error: {payload}")
+if "warm_manifest is disabled" not in str(error.get("error", "")):
+    raise SystemExit(f"warm_manifest error did not mention the safety gate: {payload}")
+PY
+
+python3 - "$binary" "$manifest_path" "$storage_dir" "$storage_instance_id" "$output_dir/mcp-stdio.json" <<'PY'
+import json
+import os
+import select
+import subprocess
+import sys
+import time
+
+binary, manifest_path, storage_dir, storage_instance_id, out_path = sys.argv[1:]
+env = os.environ.copy()
+for key in [
+    "DBT_NOVA_MANIFEST_URI",
+    "DBT_NOVA_BOOTSTRAP_URI",
+    "DBT_NOVA_STORAGE_ARTIFACT_URI",
+    "DBT_NOVA_METADATA_ARTIFACT_URI",
+    "DBT_NOVA_MODELS_ARTIFACT_URI",
+    "DBT_NOVA_PRUNE_ALLOW_IDS",
+    "DBT_NOVA_PRUNE_DENY_IDS",
+    "DBT_NOVA_SERVER_TRANSPORT",
+    "DBT_NOVA_TOOL_ALLOWLIST",
+    "DBT_NOVA_TOOL_DENYLIST",
+    "DBT_NOVA_TRACE_TOOL_CALLS_PATH",
+    "DBT_NOVA_STORAGE_READ_ONLY",
+    "DBT_NOVA_TOOL_RATE_LIMITS",
+    "DBT_NOVA_TOOL_RATE_LIMIT_WINDOW_SECS",
+    "DBT_NOVA_RESULT_PROFILE",
+    "DBT_NOVA_MCP_RESULT_PROFILE",
+    "DBT_NOVA_MCP_MAX_RESPONSE_BYTES",
+    "DBT_NOVA_MCP_ENABLE_EVAL_RUN",
+    "DBT_NOVA_MCP_ENABLE_EVAL_WRITES",
+    "DBT_NOVA_MCP_ENABLE_AGENT_EVAL",
+    "DBT_NOVA_MCP_ENABLE_CUSTOM_AGENT_PROVIDER",
+    "DBT_NOVA_MCP_ENABLE_TRACE_WRITES",
+    "DBT_NOVA_MCP_ENABLE_MANIFEST_RELOAD",
+    "DBT_NOVA_MCP_ENABLE_MANIFEST_WARM",
+    "DBT_NOVA_MCP_ENABLE_STORAGE_ADMIN",
+]:
+    env.pop(key, None)
+env.update({
+    "DBT_MANIFEST_PATH": manifest_path,
+    "DBT_NOVA_STORAGE_DIR": storage_dir,
+    "DBT_NOVA_STORAGE_INSTANCE_ID": storage_instance_id,
+    "DBT_NOVA_SEARCH_ENABLE_VECTOR": "false",
+    "DBT_NOVA_SEARCH_ENABLE_SPARSE": "false",
+    "DBT_NOVA_SEARCH_ENABLE_RERANKER": "false",
+    "DBT_NOVA_SERVER_TRANSPORT": "stdio",
+    "DBT_NOVA_STORAGE_READ_ONLY": "false",
+})
+stderr_path = out_path.rsplit(".", 1)[0] + ".stderr.log"
+stderr_handle = open(stderr_path, "w", encoding="utf-8")
+try:
+    proc = subprocess.Popen(
+        [binary, "server", "start"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=stderr_handle,
+        text=True,
+        env=env,
+    )
+except Exception:
+    stderr_handle.close()
+    raise
+
+next_id = 1
+
+def send(payload):
+    proc.stdin.write(json.dumps(payload) + "\n")
+    proc.stdin.flush()
+
+def read_response(request_id, timeout=60):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        ready, _, _ = select.select([proc.stdout], [], [], 0.5)
+        if not ready:
+            continue
+        line = proc.stdout.readline()
+        if not line:
+            break
+        message = json.loads(line)
+        if str(message.get("id")) == str(request_id):
+            return message
+    raise TimeoutError(f"timed out waiting for MCP response id={request_id}")
+
+def request(method, params=None):
+    global next_id
+    request_id = next_id
+    next_id += 1
+    payload = {"jsonrpc": "2.0", "id": request_id, "method": method}
+    if params is not None:
+        payload["params"] = params
+    send(payload)
+    return read_response(request_id)
+
+def call_tool(name, arguments):
+    response = request("tools/call", {"name": name, "arguments": arguments})
+    if "error" in response:
+        raise RuntimeError(f"{name} returned JSON-RPC error: {response}")
+    text = response["result"]["content"][0]["text"]
+    return json.loads(text)
+
+summary = {"checks": [], "tool_count": None, "ready_for_traffic": False}
+try:
+    request("initialize", {
+        "protocolVersion": "2025-11-25",
+        "capabilities": {},
+        "clientInfo": {"name": "dbt-nova-release-smoke", "version": "1.0.0"},
+    })
+    send({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+
+    tools = request("tools/list", {})["result"]["tools"]
+    summary["tool_count"] = len(tools)
+    if len(tools) != 53:
+        raise RuntimeError(f"expected 53 MCP tools, got {len(tools)}")
+    summary["checks"].append({"name": "tools/list", "ok": True})
+
+    for _ in range(120):
+        health = call_tool("health", {})
+        if health.get("data", {}).get("ready_for_traffic") is True:
+            summary["ready_for_traffic"] = True
+            break
+        time.sleep(0.25)
+    if not summary["ready_for_traffic"]:
+        raise RuntimeError("MCP health never reached ready_for_traffic=true")
+    summary["checks"].append({"name": "health-ready", "ok": True})
+
+    for name, arguments in [
+        ("show_metadata", {}),
+        ("search", {"query": "orders", "resource_types": ["model"], "limit": 3}),
+        ("get_agent_readiness", {"personas_json": "[\"analyst\"]"}),
+    ]:
+        payload = call_tool(name, arguments)
+        if payload.get("success") is not True:
+            raise RuntimeError(f"{name} failed: {payload}")
+        summary["checks"].append({"name": name, "ok": True})
+
+    warm = call_tool("warm_manifest", {})
+    if warm.get("success") is not False or warm.get("error_code") != "INVALID_PARAMS":
+        raise RuntimeError(f"warm_manifest safety gate did not reject as expected: {warm}")
+    summary["checks"].append({"name": "warm_manifest-disabled", "ok": True})
+finally:
+    proc.kill()
+    proc.wait(timeout=10)
+    stderr_handle.close()
+
+with open(out_path, "w", encoding="utf-8") as handle:
+    json.dump(summary, handle, indent=2, sort_keys=True)
+PY
+
+if [[ -n "$bridge_suite" ]]; then
+  "$binary" eval validate --suite "$bridge_suite" >"${output_dir}/bridge-validate.txt"
+  "$binary" eval run \
+    --suite "$bridge_suite" \
+    --manifest-path "$manifest_path" \
+    --storage-instance-id "$storage_instance_id" \
+    --output-dir "${output_dir}/bridge-eval" \
+    --telemetry \
+    --telemetry-retention 1000 \
+    --fail-under "$fail_under" \
+    --json >"${output_dir}/bridge-eval.json"
+fi
+
+if [[ -n "$agent_providers" ]]; then
+  [[ -n "$agent_suite" ]] || { echo "--agent-suite is required with --agent-providers" >&2; exit 2; }
+  "$binary" eval validate --suite "$agent_suite" >"${output_dir}/agent-validate.txt"
+  IFS=',' read -r -a providers <<<"$agent_providers"
+  for provider in "${providers[@]}"; do
+    provider="${provider//[[:space:]]/}"
+    [[ -n "$provider" ]] || continue
+    "$binary" eval agent run \
+      --suite "$agent_suite" \
+      --provider "$provider" \
+      --manifest-path "$manifest_path" \
+      --storage-instance-id "${storage_instance_id}-${provider}" \
+      --output-dir "${output_dir}/agent-${provider}" \
+      --telemetry \
+      --telemetry-retention 1000 \
+      --timeout-secs "$agent_timeout" \
+      --fail-under "$fail_under" \
+      --json >"${output_dir}/agent-${provider}.json"
+  done
+fi
+
+python3 - "$output_dir" "$manifest_path" "$storage_instance_id" <<'PY'
+import json
+import pathlib
+import sys
+
+output_dir = pathlib.Path(sys.argv[1])
+manifest_path = sys.argv[2]
+storage_instance_id = sys.argv[3]
+health = json.load(open(output_dir / "health.json", encoding="utf-8"))
+mcp = json.load(open(output_dir / "mcp-stdio.json", encoding="utf-8"))
+summary = {
+    "manifest_path": manifest_path,
+    "storage_instance_id": storage_instance_id,
+    "semantic_warmup": "not_run",
+    "ready_for_traffic": health.get("data", {}).get("ready_for_traffic"),
+    "mcp_tool_count": mcp.get("tool_count"),
+    "artifacts_dir": str(output_dir),
+}
+with open(output_dir / "summary.json", "w", encoding="utf-8") as handle:
+    json.dump(summary, handle, indent=2, sort_keys=True)
+with open(output_dir / "report.md", "w", encoding="utf-8") as handle:
+    handle.write("# dbt-nova no-warm release smoke\n\n")
+    for key, value in summary.items():
+        handle.write(f"- `{key}`: `{value}`\n")
+PY
+
+echo "No-warm release smoke passed. Artifacts: ${output_dir}"

--- a/src/cli/agent_readiness_cmd.rs
+++ b/src/cli/agent_readiness_cmd.rs
@@ -3054,7 +3054,7 @@ fn append_suggested_meta_patches_table(out: &mut String, patches: &[SuggestedMet
                 .column_name
                 .as_deref()
                 .or(patch.indicator_name.as_deref())
-                .map_or_else(|| patch.unique_id.as_str(), |name| name);
+                .unwrap_or(patch.unique_id.as_str());
             let _ = writeln!(
                 out,
                 "| `{}` | `{}` | `{}` | {} |",

--- a/tests/mcp_protocol.rs
+++ b/tests/mcp_protocol.rs
@@ -1,14 +1,42 @@
 //! Protocol-level MCP smoke test over stdio transport.
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::{ChildStdout, Command};
-use tokio::time::timeout;
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::time::{sleep, timeout};
 
-use dbt_nova::tools::catalog::MCP_TOOL_COUNT;
+use dbt_nova::tools::catalog::{MCP_TOOL_COUNT, MCP_TOOL_NAMES};
+
+const MCP_SMOKE_ENV_REMOVE: &[&str] = &[
+    "DBT_NOVA_MANIFEST_URI",
+    "DBT_NOVA_BOOTSTRAP_URI",
+    "DBT_NOVA_STORAGE_ARTIFACT_URI",
+    "DBT_NOVA_METADATA_ARTIFACT_URI",
+    "DBT_NOVA_MODELS_ARTIFACT_URI",
+    "DBT_NOVA_PRUNE_ALLOW_IDS",
+    "DBT_NOVA_PRUNE_DENY_IDS",
+    "DBT_NOVA_SERVER_TRANSPORT",
+    "DBT_NOVA_TOOL_ALLOWLIST",
+    "DBT_NOVA_TOOL_DENYLIST",
+    "DBT_NOVA_TRACE_TOOL_CALLS_PATH",
+    "DBT_NOVA_STORAGE_READ_ONLY",
+    "DBT_NOVA_TOOL_RATE_LIMITS",
+    "DBT_NOVA_TOOL_RATE_LIMIT_WINDOW_SECS",
+    "DBT_NOVA_RESULT_PROFILE",
+    "DBT_NOVA_MCP_RESULT_PROFILE",
+    "DBT_NOVA_MCP_MAX_RESPONSE_BYTES",
+    "DBT_NOVA_MCP_ENABLE_EVAL_RUN",
+    "DBT_NOVA_MCP_ENABLE_EVAL_WRITES",
+    "DBT_NOVA_MCP_ENABLE_AGENT_EVAL",
+    "DBT_NOVA_MCP_ENABLE_CUSTOM_AGENT_PROVIDER",
+    "DBT_NOVA_MCP_ENABLE_TRACE_WRITES",
+    "DBT_NOVA_MCP_ENABLE_MANIFEST_RELOAD",
+    "DBT_NOVA_MCP_ENABLE_MANIFEST_WARM",
+    "DBT_NOVA_MCP_ENABLE_STORAGE_ADMIN",
+];
 
 async fn write_json_line(
     stdin: &mut tokio::process::ChildStdin,
@@ -55,10 +83,7 @@ async fn read_response(stdout: &mut BufReader<ChildStdout>, request_id: i64) -> 
     }
 }
 
-async fn initialize_stdio_session(
-    stdin: &mut tokio::process::ChildStdin,
-    stdout: &mut BufReader<ChildStdout>,
-) {
+async fn initialize_stdio_session(stdin: &mut ChildStdin, stdout: &mut BufReader<ChildStdout>) {
     write_json_line(
         stdin,
         &json!({
@@ -93,38 +118,333 @@ async fn initialize_stdio_session(
     .expect("failed to write initialized notification");
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn mcp_stdio_round_trip_supports_initialize_and_tools_list() {
+fn fixture_manifest_path(file_name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(file_name)
+}
+
+fn relative_to_repo(path: &Path) -> String {
+    path.strip_prefix(env!("CARGO_MANIFEST_DIR"))
+        .expect("test artifact should be under repo root")
+        .to_string_lossy()
+        .to_string()
+}
+
+fn scrub_mcp_smoke_env(command: &mut Command) {
+    for env_key in MCP_SMOKE_ENV_REMOVE {
+        command.env_remove(env_key);
+    }
+    command.env("DBT_NOVA_SERVER_TRANSPORT", "stdio");
+    command.env("DBT_NOVA_STORAGE_READ_ONLY", "false");
+}
+
+async fn spawn_stdio_server(
+    manifest_path: &Path,
+    storage_dir: &Path,
+    storage_instance_id: &str,
+) -> (Child, ChildStdin, BufReader<ChildStdout>) {
     let binary = PathBuf::from(env!("CARGO_BIN_EXE_dbt-nova"));
     assert!(
         binary.exists(),
         "dbt-nova binary not found at {}",
         binary.display()
     );
-    let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests")
-        .join("fixtures")
-        .join("nova_manifest.json");
-    let storage_dir = tempfile::tempdir().expect("tempdir for protocol smoke storage");
 
-    let mut child = Command::new(&binary)
+    let duckdb_path = storage_dir.join("catalog-smoke.duckdb");
+    drop(duckdb::Connection::open(&duckdb_path).expect("create DuckDB smoke database file"));
+    let mut command = Command::new(&binary);
+    command
         .arg("server")
         .arg("start")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
-        .env("DBT_MANIFEST_PATH", &manifest_path)
-        .env("DBT_NOVA_STORAGE_DIR", storage_dir.path())
-        .env("DBT_NOVA_STORAGE_INSTANCE_ID", "tests-mcp-protocol")
+        .env("DBT_MANIFEST_PATH", manifest_path)
+        .env("DBT_NOVA_STORAGE_DIR", storage_dir)
+        .env("DBT_NOVA_STORAGE_INSTANCE_ID", storage_instance_id)
         .env("DBT_NOVA_SEARCH_ENABLE_VECTOR", "false")
         .env("DBT_NOVA_SEARCH_ENABLE_SPARSE", "false")
         .env("DBT_NOVA_SEARCH_ENABLE_RERANKER", "false")
+        .env("DBT_NOVA_SQL_PROVIDER", "duckdb")
+        .env("DBT_NOVA_DUCKDB_PATH", duckdb_path);
+    scrub_mcp_smoke_env(&mut command);
+    let mut child = command
         .spawn()
         .expect("failed to spawn dbt-nova MCP server");
 
-    let mut stdin = child.stdin.take().expect("child stdin unavailable");
+    let stdin = child.stdin.take().expect("child stdin unavailable");
     let stdout = child.stdout.take().expect("child stdout unavailable");
-    let mut stdout = BufReader::new(stdout);
+    (child, stdin, BufReader::new(stdout))
+}
+
+async fn call_tool(
+    stdin: &mut ChildStdin,
+    stdout: &mut BufReader<ChildStdout>,
+    request_id: i64,
+    name: &str,
+    arguments: Value,
+) -> Value {
+    write_json_line(
+        stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tools/call",
+            "params": {
+                "name": name,
+                "arguments": arguments
+            }
+        }),
+    )
+    .await
+    .unwrap_or_else(|error| panic!("failed to write tools/call for {name}: {error}"));
+
+    let response = read_response(stdout, request_id).await;
+    assert!(
+        response.get("error").is_none(),
+        "{name} returned JSON-RPC error: {response}"
+    );
+    let text = response
+        .get("result")
+        .and_then(|result| result.get("content"))
+        .and_then(Value::as_array)
+        .and_then(|content| content.first())
+        .and_then(|entry| entry.get("text"))
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("{name} response missing result.content[0].text: {response}"));
+    serde_json::from_str(text)
+        .unwrap_or_else(|error| panic!("{name} response text was not JSON ({error}): {text}"))
+}
+
+async fn wait_for_ready(
+    stdin: &mut ChildStdin,
+    stdout: &mut BufReader<ChildStdout>,
+    next_request_id: &mut i64,
+) {
+    for _ in 0..60 {
+        let payload = call_tool(stdin, stdout, *next_request_id, "health", json!({})).await;
+        *next_request_id += 1;
+        if payload["data"]["ready_for_traffic"] == json!(true) {
+            return;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    panic!("MCP server did not report ready_for_traffic=true");
+}
+
+fn write_eval_results(dir: &Path, status: &str, pass_rate: f64) {
+    std::fs::create_dir_all(dir).expect("create eval result dir");
+    let passed = status == "pass";
+    let payload = json!({
+        "suite_name": "mcp-protocol-smoke",
+        "version": 1,
+        "mode": "bridge",
+        "output_dir": dir.display().to_string(),
+        "assertion_count": 1,
+        "pass_count": usize::from(passed),
+        "fail_count": usize::from(!passed),
+        "error_count": 0,
+        "pass_rate": pass_rate,
+        "gate_status": status,
+        "cases": [{
+            "id": "case",
+            "pass_count": usize::from(passed),
+            "fail_count": usize::from(!passed),
+            "error_count": 0,
+            "assertions": [{"name": "tool_success", "status": status}]
+        }]
+    });
+    std::fs::write(
+        dir.join("results.json"),
+        serde_json::to_string_pretty(&payload).expect("serialize eval results"),
+    )
+    .expect("write eval results");
+}
+
+fn success_tool_cases(workspace: &Path) -> Vec<(&'static str, Value)> {
+    let fct_orders = "model.starter_eval.fct_orders";
+    let stg_orders = "model.starter_eval.stg_orders";
+    let dim_customers = "model.starter_eval.dim_customers";
+    let trace_path = relative_to_repo(&workspace.join("trace.jsonl"));
+    let before_dir = relative_to_repo(&workspace.join("before"));
+    let after_dir = relative_to_repo(&workspace.join("after"));
+    vec![
+        (
+            "search",
+            json!({"query":"gross revenue orders","resource_types":["model"],"limit":3}),
+        ),
+        (
+            "search_indicator",
+            json!({"query":"gross revenue","indicator_types":["measure"],"resource_types":["model"],"limit":3,"detail":"compact","group_mode":"top"}),
+        ),
+        (
+            "indicator_inventory",
+            json!({"resource_types":["model"],"limit":3}),
+        ),
+        (
+            "search_columns",
+            json!({"query":"order date","resource_types":["model"],"limit":3}),
+        ),
+        (
+            "column_inventory",
+            json!({"resource_types":["model"],"limit":3}),
+        ),
+        (
+            "compare_grains",
+            json!({"entity1":fct_orders,"entity2":dim_customers}),
+        ),
+        (
+            "find_entity_overlap",
+            json!({"id_or_name":fct_orders,"resource_types":["model"],"limit":3}),
+        ),
+        (
+            "modelling_consistency_report",
+            json!({"resource_types":["model"],"limit":3}),
+        ),
+        (
+            "get_entity",
+            json!({"id_or_name":fct_orders,"detail":"compact"}),
+        ),
+        (
+            "list_entities",
+            json!({"resource_type":"model","limit":3,"detail":"compact"}),
+        ),
+        (
+            "get_lineage",
+            json!({"id_or_name":fct_orders,"direction":"upstream","depth":1,"detail":"compact"}),
+        ),
+        ("get_sql", json!({"id_or_name":fct_orders,"compiled":true})),
+        ("get_columns", json!({"id_or_name":fct_orders})),
+        (
+            "diff_entities",
+            json!({"entity1":stg_orders,"entity2":fct_orders}),
+        ),
+        ("get_impact", json!({"id_or_name":stg_orders})),
+        ("validate_dag", json!({"detail":"summary"})),
+        (
+            "validate_nova_meta",
+            json!({"project_dir":"tests/fixtures"}),
+        ),
+        ("validate_eval_suite", json!({"suite":"evals/starter.yml"})),
+        ("get_eval_gate", json!({"suite":"starter"})),
+        (
+            "get_eval_history",
+            json!({"suite":"starter","since":"2026-01-01"}),
+        ),
+        (
+            "compare_eval_runs",
+            json!({"before":before_dir,"after":after_dir}),
+        ),
+        ("inspect_tool_trace", json!({"path":trace_path})),
+        ("summarize_tool_trace", json!({"path":trace_path})),
+        ("replay_tool_trace", json!({"path":trace_path})),
+        ("show_metadata", json!({})),
+        ("health", json!({})),
+        ("show_config", json!({"defaults":false})),
+        ("validate_config", json!({})),
+        ("inspect_storage", json!({})),
+        ("list_tags", json!({})),
+        ("list_packages", json!({})),
+        ("list_databases", json!({})),
+        (
+            "get_column_lineage",
+            json!({"id_or_name":fct_orders,"column_name":"customer_id","direction":"upstream","depth":1}),
+        ),
+        (
+            "get_test_coverage",
+            json!({"id_or_name":fct_orders,"include_full":false,"columns_limit":5}),
+        ),
+        (
+            "get_metadata_score",
+            json!({"id_or_name":fct_orders,"persona":"analyst","include_breakdown":false,"include_recommendations":false}),
+        ),
+        (
+            "get_metadata_audit",
+            json!({"selection_mode":"entities","entity_ids_json":"[\"model.starter_eval.fct_orders\"]","resource_types_json":"[\"model\"]","personas_json":"[\"analyst\"]","include_breakdown":false,"include_recommendations":false}),
+        ),
+        (
+            "get_agent_readiness",
+            json!({"personas_json":"[\"analyst\"]"}),
+        ),
+        (
+            "batch_get_entities",
+            json!({"unique_ids":[fct_orders,dim_customers],"detail":"compact"}),
+        ),
+        (
+            "find_by_path",
+            json!({"path_pattern":"models/marts/*.sql","resource_types":["model"],"limit":3,"detail":"compact"}),
+        ),
+        (
+            "search_recipes",
+            json!({"query":"weekly revenue","include_queries":true,"limit":3}),
+        ),
+        (
+            "get_recipe",
+            json!({"recipe_id":"commerce/weekly_revenue","include_queries":true,"include_sql":false}),
+        ),
+        (
+            "get_undocumented",
+            json!({"resource_type":"model","id_or_name":"model.starter_eval.raw_events_sparse","include_columns":true,"include_full":false,"limit":3}),
+        ),
+        (
+            "get_context",
+            json!({"id_or_name":fct_orders,"include_columns":true,"include_upstream":true,"include_downstream":false,"include_tests":true,"include_docs":false,"include_sql":false,"lineage_depth":1}),
+        ),
+        (
+            "execute_sql",
+            json!({"statement":"select 1 as ok","row_limit":1,"fetch_all_chunks":false}),
+        ),
+    ]
+}
+
+fn expected_error_tool_cases(workspace: &Path) -> Vec<(&'static str, Value, &'static str)> {
+    let trace_path = relative_to_repo(&workspace.join("trace.jsonl"));
+    vec![
+        (
+            "reload_manifest",
+            json!({"manifest_path":"tests/fixtures/starter_eval_manifest.json"}),
+            "INVALID_PARAMS",
+        ),
+        ("warm_manifest", json!({}), "INVALID_PARAMS"),
+        (
+            "run_eval",
+            json!({"suite":"evals/starter.yml","case_ids":["canonical_revenue_discovery"]}),
+            "INVALID_PARAMS",
+        ),
+        (
+            "init_eval_suite",
+            json!({"persona":"analyst","out":relative_to_repo(&workspace.join("generated.yml"))}),
+            "INVALID_PARAMS",
+        ),
+        (
+            "run_agent_eval",
+            json!({"suite":"evals/starter.yml","provider":"opencode","case_ids":["analyst_revenue_lookup_flow"],"timeout_secs":1}),
+            "INVALID_PARAMS",
+        ),
+        (
+            "redact_tool_trace",
+            json!({"path":trace_path,"out":relative_to_repo(&workspace.join("redacted.jsonl"))}),
+            "INVALID_PARAMS",
+        ),
+        ("prune_storage", json!({"max_keep":1}), "INVALID_PARAMS"),
+        ("cleanup_storage", json!({}), "INVALID_PARAMS"),
+        (
+            "run_recipe",
+            json!({"recipe_id":"missing/recipe","query_indexes":[1],"row_limit":1}),
+            "INVALID_PARAMS",
+        ),
+    ]
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_round_trip_supports_initialize_and_tools_list() {
+    let manifest_path = fixture_manifest_path("nova_manifest.json");
+    let storage_dir = tempfile::tempdir().expect("tempdir for protocol smoke storage");
+
+    let (mut child, mut stdin, mut stdout) =
+        spawn_stdio_server(&manifest_path, storage_dir.path(), "tests-mcp-protocol").await;
 
     initialize_stdio_session(&mut stdin, &mut stdout).await;
 
@@ -159,13 +479,11 @@ async fn mcp_stdio_round_trip_supports_initialize_and_tools_list() {
 #[tokio::test(flavor = "multi_thread")]
 async fn mcp_stdio_honors_tool_allowlist_and_denylist() {
     let binary = PathBuf::from(env!("CARGO_BIN_EXE_dbt-nova"));
-    let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests")
-        .join("fixtures")
-        .join("nova_manifest.json");
+    let manifest_path = fixture_manifest_path("nova_manifest.json");
     let storage_dir = tempfile::tempdir().expect("tempdir for protocol smoke storage");
 
-    let mut child = Command::new(&binary)
+    let mut command = Command::new(&binary);
+    command
         .arg("server")
         .arg("start")
         .stdin(Stdio::piped())
@@ -176,9 +494,12 @@ async fn mcp_stdio_honors_tool_allowlist_and_denylist() {
         .env("DBT_NOVA_STORAGE_INSTANCE_ID", "tests-mcp-tool-filtering")
         .env("DBT_NOVA_SEARCH_ENABLE_VECTOR", "false")
         .env("DBT_NOVA_SEARCH_ENABLE_SPARSE", "false")
-        .env("DBT_NOVA_SEARCH_ENABLE_RERANKER", "false")
+        .env("DBT_NOVA_SEARCH_ENABLE_RERANKER", "false");
+    scrub_mcp_smoke_env(&mut command);
+    command
         .env("DBT_NOVA_TOOL_ALLOWLIST", "search,execute_sql")
-        .env("DBT_NOVA_TOOL_DENYLIST", "execute_sql")
+        .env("DBT_NOVA_TOOL_DENYLIST", "execute_sql");
+    let mut child = command
         .spawn()
         .expect("failed to spawn dbt-nova MCP server");
 
@@ -232,6 +553,83 @@ async fn mcp_stdio_honors_tool_allowlist_and_denylist() {
     assert!(
         call_response.get("error").is_some(),
         "filtered tool call should fail: {call_response}"
+    );
+
+    child.start_kill().expect("failed to terminate MCP child");
+    let _ = child.wait().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_no_warm_catalog_smoke_calls_every_tool_after_readiness() {
+    let manifest_path = fixture_manifest_path("starter_eval_manifest.json");
+    let storage_dir = tempfile::tempdir().expect("tempdir for protocol smoke storage");
+    let workspace = tempfile::tempdir_in(env!("CARGO_MANIFEST_DIR"))
+        .expect("temp workspace under repo root for scoped MCP paths");
+    let trace_path = workspace.path().join("trace.jsonl");
+    std::fs::write(
+        &trace_path,
+        r#"{"tool":"search","success":true,"response_bytes":42,"response_truncated":false,"params_summary":{"query":"gross revenue","resource_types":["model"],"limit":3}}"#,
+    )
+    .expect("write trace fixture");
+    write_eval_results(&workspace.path().join("before"), "pass", 1.0);
+    write_eval_results(&workspace.path().join("after"), "fail", 0.0);
+
+    let (mut child, mut stdin, mut stdout) = spawn_stdio_server(
+        &manifest_path,
+        storage_dir.path(),
+        "tests-mcp-catalog-smoke",
+    )
+    .await;
+
+    initialize_stdio_session(&mut stdin, &mut stdout).await;
+
+    let mut next_request_id = 2;
+    wait_for_ready(&mut stdin, &mut stdout, &mut next_request_id).await;
+
+    let mut called = Vec::new();
+    for (name, arguments) in success_tool_cases(workspace.path()) {
+        let payload = call_tool(&mut stdin, &mut stdout, next_request_id, name, arguments).await;
+        next_request_id += 1;
+        assert_ne!(
+            payload.get("error_code").and_then(Value::as_str),
+            Some("INDEX_BUILDING"),
+            "{name} returned INDEX_BUILDING after readiness: {payload}"
+        );
+        assert_eq!(
+            payload.get("success"),
+            Some(&json!(true)),
+            "{name} should succeed: {payload}"
+        );
+        called.push(name);
+    }
+
+    for (name, arguments, expected_error_code) in expected_error_tool_cases(workspace.path()) {
+        let payload = call_tool(&mut stdin, &mut stdout, next_request_id, name, arguments).await;
+        next_request_id += 1;
+        assert_ne!(
+            payload.get("error_code").and_then(Value::as_str),
+            Some("INDEX_BUILDING"),
+            "{name} returned INDEX_BUILDING after readiness: {payload}"
+        );
+        assert_eq!(
+            payload.get("success"),
+            Some(&json!(false)),
+            "{name} should return a tool error payload: {payload}"
+        );
+        assert_eq!(
+            payload.get("error_code").and_then(Value::as_str),
+            Some(expected_error_code),
+            "{name} returned unexpected error payload: {payload}"
+        );
+        called.push(name);
+    }
+
+    called.sort_unstable();
+    let mut expected = MCP_TOOL_NAMES.to_vec();
+    expected.sort_unstable();
+    assert_eq!(
+        called, expected,
+        "catalog smoke must exercise every MCP tool exactly once"
     );
 
     child.start_kill().expect("failed to terminate MCP child");


### PR DESCRIPTION
## Summary

- Add a no-warm release smoke harness for CLI and MCP readiness checks without vector, sparse, or reranker warmup.
- Add an MCP stdio all-tool catalog smoke test that calls every canonical tool after `ready_for_traffic` and verifies safety gates stay closed.
- Refresh testing, eval, MCP readiness, release, and CLI docs, plus packaged agent skills for large-manifest no-warm validation and provider-backed evals.
- Include the existing local agent-readiness clippy cleanup.

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --test mcp_protocol`
- `DBT_NOVA_SEARCH_ENABLE_VECTOR=false DBT_NOVA_SEARCH_ENABLE_SPARSE=false DBT_NOVA_SEARCH_ENABLE_RERANKER=false cargo test --locked --all-features`
- `uv run mkdocs build --strict`
- `scripts/smoke_release_no_warm.sh --manifest-path tests/fixtures/starter_eval_manifest.json --skip-build --output-dir target/nova-release-smoke/dev-no-warm --storage-instance-id dev-no-warm-smoke`
- `scripts/smoke_release_no_warm.sh --manifest-path tests/fixtures/starter_eval_manifest.json --output-dir target/nova-release-smoke/release-no-warm --storage-instance-id release-no-warm-smoke --bridge-suite evals/starter.yml --fail-under 1.0`
- `bash scripts/check_dependency_watchlist.sh`
- `bash scripts/check_config_reference.sh`
- `cargo deny check` (passed with existing duplicate-version warnings)
- `cargo test --locked --test tokenomics_fixture -- --ignored`
- `target/release/dbt-nova eval validate --suite evals/starter.yml`
- `target/release/dbt-nova eval validate --suite evals/agent-tokenomics-bridge.yml`
- `target/release/dbt-nova eval validate --suite evals/agent-tokenomics-opencode.yml`
- `target/release/dbt-nova eval validate --suite evals/reviewer.yml`
- `git diff --check`
- `bash -n scripts/smoke_release_no_warm.sh`