### PR TITLE
[codex] Prepare v0.0.6 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6] - 2026-07-04
+
 - Hardened Monthly dependency checks by upgrading `anyhow` and `rmcp` past new
   RustSec advisories, retaining streamable HTTP Host validation, and adding
   `DBT_NOVA_HTTP_ALLOWED_HOSTS` for hosted reverse-proxy deployments.
@@ -36,8 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added configurable runner inputs to the reusable asset and metadata-audit
   workflows so downstream repositories can run them on self-hosted or
   organization runner pools while preserving the `ubuntu-22.04` default.
-
-## [0.0.6] - 2026-06-24
 
 - Hardened hosted HTTP container defaults by removing the baked-in auth-proxy
   acknowledgement, defaulting published images to discovery-only SQL tool


### PR DESCRIPTION
## Summary

- Moves the pending v0.0.6 hardening notes out of `[Unreleased]` and into the `0.0.6` release section.
- Updates the v0.0.6 changelog date to `2026-07-04`.
- Leaves `[Unreleased]` empty so `release-prepare.yml` and `release-tag.yml` metadata gates can pass before tagging.

## Pre-release audit

- Latest local `master` and `origin/master` were synced at `bca7c1a04269249d70c84d27b1e77c206db30092` before branching.
- Latest GitHub `master` CI and documentation deploy are green for that commit.
- Latest public GitHub release is `v0.0.5`; the repo is staged for `v0.0.6`, and no `v0.0.6` tag exists yet.
- No open PRs were present before this PR.
- One open GitHub issue remains: #217 composite metrics across model grain boundaries, which looks like future feature work rather than a v0.0.6 release blocker.

## Validation

- `cargo fmt --check`
- `cargo check --locked --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo build --locked --release --all-features`
- `cargo check --locked --no-default-features --all-targets`
- `cargo test --locked --no-default-features`
- `scripts/smoke_release_no_warm.sh --manifest-path tests/fixtures/starter_eval_manifest.json --binary target/release/dbt-nova --skip-build --output-dir target/nova-release-smoke/audit-no-warm --storage-instance-id audit-no-warm-smoke`
- `uv run mkdocs build --strict`
- `cargo deny check`
- `bash scripts/check_dependency_watchlist.sh`
- `scripts/check_advisory_ignores.sh`
- `bash scripts/check_config_reference.sh`
- `actionlint .github/workflows/*.yml`
- Local release metadata check: `[Unreleased]` is empty and `CHANGELOG.md` has a `## [0.0.6]` section matching `Cargo.toml`.

Draft until release sequencing/tag approval.