### PR TITLE
[codex] Harden release OCI package refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.6] - 2026-07-04
 
+- Hardened OCI release images to upgrade pinned Debian runtime packages during
+  image builds so fixed base-image vulnerabilities are remediated before the
+  Trivy release gate runs.
 - Hardened Monthly dependency checks by upgrading `anyhow` and `rmcp` past new
   RustSec advisories, retaining streamable HTTP Host validation, and adding
   `DBT_NOVA_HTTP_ALLOWED_HOSTS` for hosted reverse-proxy deployments.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN cargo build --locked --release --bin dbt-nova
 FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3 AS runtime
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
       ca-certificates \
       curl \

--- a/Dockerfile.oci
+++ b/Dockerfile.oci
@@ -5,6 +5,7 @@ FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5
 ARG TARGETARCH
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
       ca-certificates \
       curl \


### PR DESCRIPTION
## Summary

- Upgrades pinned Debian runtime packages during Docker image builds before installing runtime dependencies.
- Applies the same runtime package refresh to `Dockerfile` and `Dockerfile.oci`.
- Adds the v0.0.6 changelog note for this release-blocking OCI hardening.

## Why

The v0.0.6 release workflow published the platform binary assets successfully, but failed in `Publish OCI image` at the Trivy HIGH/CRITICAL gate. The smoke-tested image still had fixed Debian packages from the pinned `bookworm-slim` base:

- `libcap2` `1:2.66-4+deb12u2+b2`, fixed in `1:2.66-4+deb12u3`
- `libgnutls30` `3.7.9-2+deb12u6`, fixed in `3.7.9-2+deb12u7`

Keeping the digest pin is good for rebuild stability, but the image build also needs to pull current fixed Debian packages from bookworm before the release scan runs.

## Validation

- `git diff --check`
- `cargo fmt --check`
- Local release metadata check: Cargo version is `0.0.6`, `CHANGELOG.md` has `## [0.0.6]`, and `[Unreleased]` is empty.

Skipped locally:

- Docker build / Trivy scan, because the local Docker daemon is not running in this workspace. GitHub CI will verify the container build, and the release workflow rerun will verify the Trivy gate.