### PR TITLE
Align post-release docs and cross-grain policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,27 +137,26 @@ Minimal MCP client config:
 
 Install `cosign` first when using the release installer examples below; they
 require signed checksum verification. For trusted development-only installs
-without `cosign` on `v0.0.5`, omit `DBT_NOVA_VERIFY_SIGNATURE=1`. The next
-installer also accepts `DBT_NOVA_VERIFY_SIGNATURE=auto` for opportunistic
-verification.
+without `cosign`, use `DBT_NOVA_VERIFY_SIGNATURE=auto` instead of the strict
+`DBT_NOVA_VERIFY_SIGNATURE=1` examples.
 
 ```bash
 # Install (recommended: slim + non-interactive)
 # Public repo (unauthenticated)
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --non-interactive
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --non-interactive
 
 # Private repo (authenticated)
 GH_TOKEN="$(gh auth token)"
 curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
+  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
 
 # Optional: pre-warm model files during install before enabling semantic layers
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
   DBT_NOVA_EMBEDDINGS_CACHE_DIR="$HOME/.dbt-nova/.fastembed_cache" \
   DBT_NOVA_WARMUP_REQUIRED_MODELS=3 \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --warm-models --non-interactive
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --warm-models --non-interactive
 
 # Optional: enforce SHA-256 verification during direct HF fallback warmup
 # cp scripts/warm_models.checksums.example /path/to/checksums.txt
@@ -166,11 +165,11 @@ curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scrip
 #   bash scripts/warm_models.sh
 
 # Optional: install all built-in persona skills to ~/.agents/skills
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --install-skills --non-interactive
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --install-skills --non-interactive
 
 # Optional: install a single standalone skill
-# DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --install-skills --skill analyst --non-interactive
+# DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --install-skills --skill analyst --non-interactive
 
 export DBT_MANIFEST_PATH=/path/to/manifest.json
 export DBT_NOVA_PRUNE_ALLOW_IDS='["model.my_proj.fct_orders","model.my_proj.dim_*"]'
@@ -205,9 +204,8 @@ switch to strict read-only reuse.
 Producer (reusable workflow):
 
 Set `<nova-ref>` to a release tag or full commit SHA that includes the workflow
-inputs you use. `v0.0.5` supports the basic producer flow; runner override
-inputs require a newer release or immutable commit SHA until the next release is
-cut.
+inputs you use. `v0.0.6` includes the runner override inputs; use `v0.0.6`, a
+newer release tag, or an immutable commit SHA when passing them.
 
 ```yaml
 jobs:

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -89,7 +89,7 @@ For user-owned private repositories, the attestation step is skipped.
 - The OCI image job uploads `dbt-nova-oci-trivy.json` with the release and fails
   on unwaived HIGH/CRITICAL findings in the smoke-tested image.
 
-The next-release installer defaults to strict checksum signature verification:
+The installer in v0.0.6 and newer releases defaults to strict checksum signature verification:
 `DBT_NOVA_VERIFY_SIGNATURE=1` requires `cosign` plus the released `.sha256.sig`
 and `.sha256.crt` files. Use `DBT_NOVA_VERIFY_SIGNATURE=auto` only for trusted
 development installs where missing `cosign` or signatures may be skipped.

--- a/docs/features/nova-meta-metrics.md
+++ b/docs/features/nova-meta-metrics.md
@@ -88,6 +88,33 @@ meta:
 - **Deterministic grouping**: group by all grain fields.
 - **No joins/windowing**: keep metrics simple and owned by a single canonical model.
 
+## Cross-Grain KPIs
+
+Some business KPIs combine measures from different fact tables or natural
+grains, such as revenue per session, cost per acquisition, or return rate. Nova
+should make those KPIs discoverable only when there is a deterministic execution
+surface. Do not encode a cross-grain KPI only as `meta.nova` metadata and expect
+an agent to infer the raw fact-table join.
+
+For cross-grain KPIs, prefer one of these surfaces:
+
+- a dbt model at the intended analysis grain;
+- an existing `meta.nova` measure or metric on a queryable dbt artifact;
+- a dbt Semantic Layer / MetricFlow artifact;
+- an OSI semantic artifact when the artifact is scoped and deterministic;
+- a saved query or Nova recipe for report-shaped outputs.
+
+`composite_metrics` and `NovaMetric.derivation` graphs are not part of the
+current Nova schema. They should not be used as metadata-only substitutes for a
+queryable surface. Nova-native composite metrics may be revisited later only if
+Nova owns a narrow SQL compiler, validation, explainability, and fail-closed
+behavior.
+
+Agent guidance: if a KPI crosses grain boundaries and no deterministic surface
+exists, treat it as non-queryable context. Ask for or propose a dbt model,
+semantic-layer metric, OSI artifact, saved query, or recipe instead of joining
+heterogeneous facts from metric names alone.
+
 ### SQL Example
 
 `models/marts/product/mart__conversion_rate/mart__conversion_rate.sql`

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -20,44 +20,43 @@ Remote manifests are supported via `DBT_NOVA_MANIFEST_URI` (http(s), dbfs, s3, g
 
 Use the installer script (defaults to **slim**). The examples below require
 `cosign` and enforce signed checksum verification. For development-only installs
-without `cosign` on `v0.0.5`, omit `DBT_NOVA_VERIFY_SIGNATURE=1`. The next
-installer also accepts `DBT_NOVA_VERIFY_SIGNATURE=auto` for opportunistic
-verification.
+without `cosign`, use `DBT_NOVA_VERIFY_SIGNATURE=auto` instead of the strict
+`DBT_NOVA_VERIFY_SIGNATURE=1` examples.
 
 ```bash
 # Public repo (unauthenticated)
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --non-interactive
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --non-interactive
 
 # Private repo (authenticated)
 GH_TOKEN="$(gh auth token)"
 curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
+  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
 ```
 
 Non-interactive examples:
 
 ```bash
 # Public repo: default slim in non-interactive mode
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --non-interactive
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --non-interactive
 
 # Public repo: force slim
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --non-interactive
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --non-interactive
 
 # Private repo: default slim in non-interactive mode
 GH_TOKEN="$(gh auth token)"
 curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --non-interactive
+  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --non-interactive
 
 # Private repo: force slim
 GH_TOKEN="$(gh auth token)"
 curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
+  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
 ```
 
 The installer places `dbt-nova` in `~/.local/bin`. For bundled installs, it also
@@ -71,10 +70,10 @@ or remote model hydration? See [Modes & Combinations](modes-and-combinations.md)
 If you want users to enable semantic layers without a later model download, pre-warm during install:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
   DBT_NOVA_EMBEDDINGS_CACHE_DIR="$HOME/.dbt-nova/.fastembed_cache" \
   DBT_NOVA_WARMUP_REQUIRED_MODELS=3 \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --warm-models --non-interactive
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --warm-models --non-interactive
 ```
 
 Use the same `DBT_NOVA_EMBEDDINGS_CACHE_DIR` value in your MCP client config so every
@@ -85,23 +84,23 @@ client process reuses that cache.
 Install all built-in standalone persona skills:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --install-skills --non-interactive
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --install-skills --non-interactive
 ```
 
 Install one standalone skill:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --install-skills --skill analyst --non-interactive
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --install-skills --skill analyst --non-interactive
 ```
 
 To choose a different destination:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
   DBT_NOVA_SKILLS_DIR="$HOME/.codex/skills" \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --install-skills --non-interactive
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --install-skills --non-interactive
 ```
 
 ## Verify Installation
@@ -134,9 +133,9 @@ The installer supports three checksum signature modes:
 - `DBT_NOVA_VERIFY_SIGNATURE=0` disables checksum signature verification.
 
 Current stable examples pass `DBT_NOVA_VERIFY_SIGNATURE=1` explicitly. The
-`v0.0.5` installer supports this strict mode, while the next release installer
-also defaults to required signature verification and adds the explicit `auto`
-mode. To require verification when invoking the installer directly:
+`v0.0.6` installer defaults to required signature verification and also supports
+the explicit `auto` mode for trusted development installs. To require
+verification when invoking the installer directly:
 
 ```bash
 export DBT_NOVA_VERIFY_SIGNATURE=1
@@ -328,7 +327,7 @@ by SHA-256 verification when checksum mode is enabled.
 Example (pin fallback seed to a specific release tag):
 
 ```bash
-DBT_NOVA_WARMUP_VERSION=v0.0.5 bash scripts/warm_models.sh
+DBT_NOVA_WARMUP_VERSION=v0.0.6 bash scripts/warm_models.sh
 ```
 
 ---

--- a/docs/getting-started/mcp-clients.md
+++ b/docs/getting-started/mcp-clients.md
@@ -22,10 +22,10 @@ Install `cosign` first when using the strict release installer example below.
 If you installed with:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
   DBT_NOVA_EMBEDDINGS_CACHE_DIR="$HOME/.dbt-nova/.fastembed_cache" \
   DBT_NOVA_WARMUP_REQUIRED_MODELS=3 \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --warm-models --non-interactive
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --warm-models --non-interactive
 ```
 
 use that exact same `DBT_NOVA_EMBEDDINGS_CACHE_DIR` path in your MCP client env.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -16,24 +16,24 @@ Get dbt-nova running in under 5 minutes.
 
 ```bash
 # Public repo (unauthenticated)
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --non-interactive
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --non-interactive
 
 # Private repo (authenticated)
 GH_TOKEN="$(gh auth token)"
 curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
+  https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 DBT_NOVA_GITHUB_TOKEN="${GH_TOKEN}" bash -s -- --slim --non-interactive
 
 # Optional: pre-warm models during install before enabling semantic layers
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
   DBT_NOVA_EMBEDDINGS_CACHE_DIR="$HOME/.dbt-nova/.fastembed_cache" \
   DBT_NOVA_WARMUP_REQUIRED_MODELS=3 \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --warm-models --non-interactive
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --warm-models --non-interactive
 
 # Optional: install all built-in Agent Skills into ~/.agents/skills
-curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.5/scripts/install.sh | \
-  DBT_NOVA_VERSION=v0.0.5 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --install-skills --non-interactive
+curl -fsSL https://raw.githubusercontent.com/joe-broadhead/dbt-nova/v0.0.6/scripts/install.sh | \
+  DBT_NOVA_VERSION=v0.0.6 DBT_NOVA_VERIFY_SIGNATURE=1 bash -s -- --slim --install-skills --non-interactive
 ```
 
 === "macOS (Apple Silicon)"

--- a/docs/operations/eval-ci-templates.md
+++ b/docs/operations/eval-ci-templates.md
@@ -38,8 +38,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     env:
-      DBT_NOVA_INSTALL_REF: v0.0.5
-      DBT_NOVA_VERSION: v0.0.5
+      DBT_NOVA_INSTALL_REF: v0.0.6
+      DBT_NOVA_VERSION: v0.0.6
       DBT_NOVA_VERIFY_SIGNATURE: "1"
       NOVA_EVAL_SUITE: evals/analyst-smoke.yml
       NOVA_EVAL_NAME: analyst-smoke
@@ -158,8 +158,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     env:
-      DBT_NOVA_INSTALL_REF: v0.0.5
-      DBT_NOVA_VERSION: v0.0.5
+      DBT_NOVA_INSTALL_REF: v0.0.6
+      DBT_NOVA_VERSION: v0.0.6
       DBT_NOVA_VERIFY_SIGNATURE: "1"
       NOVA_AGENT_SUITE: evals/analyst-agent.yml
       NOVA_AGENT_NAME: analyst-agent-smoke

--- a/docs/operations/prebuilt-assets.md
+++ b/docs/operations/prebuilt-assets.md
@@ -43,9 +43,9 @@ Create a workflow in the downstream repo that calls Nova's reusable producer.
 
 The examples below use `<nova-ref>` as a placeholder. For production, replace
 it with either a release tag or an immutable commit SHA and keep `installer_ref`
-aligned with the workflow ref. `v0.0.5` supports the basic producer flow; runner
-override inputs require a newer release or immutable commit SHA until the next
-release is cut. Reusable workflows reject branch-like installer refs unless
+aligned with the workflow ref. `v0.0.6` includes the runner override inputs; use
+`v0.0.6`, a newer release tag, or an immutable commit SHA when passing them.
+Reusable workflows reject branch-like installer refs unless
 `allow_mutable_installer_ref: true` is set for a trusted development run.
 
 ```yaml


### PR DESCRIPTION
## Summary

- Update public install and CI examples from `v0.0.5` to the published `v0.0.6` release.
- Remove stale "next release" wording now that v0.0.6 ships strict signature verification, `auto` verification mode, and reusable workflow runner overrides.
- Document the accepted cross-grain KPI policy in the Nova metric guide: deterministic execution surfaces only; no metadata-only `composite_metrics` or vague derivation graphs.

## Why

The v0.0.6 release is now public, but the user-facing docs still pointed at v0.0.5 and described shipped installer/workflow behavior as future work. Linear and GitHub #217 also settled the cross-grain direction, so the metric guide should make that policy visible before implementation begins.

## Validation

- `uv run mkdocs build --strict`
- `git diff --check`
- `rg -n "v0\.0\.5|next release|next installer|next-release|until the next release" README.md docs`