### PR TITLE
Harden agent audit follow-ups

### DIFF
--- a/.github/skills/analyst/references/transport-cli.md
+++ b/.github/skills/analyst/references/transport-cli.md
@@ -35,7 +35,7 @@ For KPI, metric, measure, rate, funnel, or conversion questions, run
 no relevant governed indicator or no credible semantic parent. Keep the
 `search_indicator` command and rejection reason as final-answer evidence when
 fallback is used. Inspect `indicator_source`, `execution_surface`, `queryable`,
-and `queryable_via` before execution.
+`direct_sql_queryable`, and `queryable_via` before execution.
 
 ## CLI guardrails
 
@@ -77,11 +77,12 @@ dbt-nova tool call search_indicator \
 For rate, conversion, funnel, or ratio questions, request metric indicators
 first and copy any returned metric `expression` exactly into downstream SQL.
 If the compact indicator row is relation-backed (`execution_surface: "relation"`,
-`queryable: true`, `queryable_via: "relation_name"`) and includes
-`relation_name`, `grain`, and `expression`, do not run schema-inspection SQL
-before execution. If the row is Semantic Layer-backed, use the configured
-MetricFlow path. If it is metadata-only or not queryable, report the execution
-blocker instead of writing inferred SQL.
+`queryable: true`, `direct_sql_queryable: true`,
+`queryable_via: "relation_name"`) and includes `relation_name`, `grain`, and
+`expression`, do not run schema-inspection SQL before execution. If the row is
+Semantic Layer-backed, use the configured MetricFlow path. If it is
+metadata-only or not queryable, report the execution blocker instead of writing
+inferred SQL.
 
 Compact entity inspection:
 

--- a/.github/skills/analyst/references/transport-mcp.md
+++ b/.github/skills/analyst/references/transport-mcp.md
@@ -30,8 +30,8 @@ Use this reference when the client exposes `mcp__nova__*` tools directly.
      values such as country, channel, segment, device, or market labels
    - set `include_support_signals: false` only when the top rows already
      provide enough evidence and no filter-value mapping is needed
-   - inspect `indicator_source`, `execution_surface`, `queryable`, and
-     `queryable_via` before execution
+   - inspect `indicator_source`, `execution_surface`, `queryable`,
+     `direct_sql_queryable`, and `queryable_via` before execution
 3. `indicator_inventory` when comparing KPI families
 4. `search` for supporting entity discovery when the ask is not yet KPI-shaped
    or semantic discovery produced an explicit fallback reason.
@@ -109,11 +109,12 @@ KPI resolution:
 For rate, conversion, funnel, or ratio questions, request metric indicators
 first and copy any returned metric `expression` exactly into downstream SQL.
 If the compact indicator row is relation-backed (`execution_surface: "relation"`,
-`queryable: true`, `queryable_via: "relation_name"`) and includes
-`relation_name`, `grain`, and `expression`, do not run schema-inspection SQL
-before execution. If the row is Semantic Layer-backed, use the configured
-MetricFlow path. If it is metadata-only or not queryable, report the execution
-blocker instead of writing inferred SQL.
+`queryable: true`, `direct_sql_queryable: true`,
+`queryable_via: "relation_name"`) and includes `relation_name`, `grain`, and
+`expression`, do not run schema-inspection SQL before execution. If the row is
+Semantic Layer-backed, use the configured MetricFlow path. If it is
+metadata-only or not queryable, report the execution blocker instead of writing
+inferred SQL.
 
 Compact entity inspection:
 

--- a/.github/skills/analyst/references/workflow.md
+++ b/.github/skills/analyst/references/workflow.md
@@ -77,7 +77,7 @@ Semantic discovery evidence must include:
 - whether you searched metrics, measures, or both
 - the top relevant indicator names and parent entities when present
 - the returned `indicator_source`, `execution_surface`, `queryable`, and
-  `queryable_via` values for the accepted row
+  `direct_sql_queryable`, and `queryable_via` values for the accepted row
 - why the top semantic result was accepted or rejected
 
 Fallback to raw model search only when one of these is true:
@@ -140,16 +140,17 @@ for SQL. Do not replace it with a similarly named measure or a guessed
 numerator/denominator.
 
 When compact indicator rows include `execution_surface: "relation"`,
-`queryable: true`, `queryable_via: "relation_name"`, `relation_name`, `grain`,
-and metric `expression`, treat them as sufficient execution evidence. Do not
-spend a tool call on `DESCRIBE`, `information_schema`, or full context unless
-execution actually fails because the contract is incomplete.
+`queryable: true`, `direct_sql_queryable: true`,
+`queryable_via: "relation_name"`, `relation_name`, `grain`, and metric
+`expression`, treat them as sufficient execution evidence. Do not spend a tool
+call on `DESCRIBE`, `information_schema`, or full context unless execution
+actually fails because the contract is incomplete.
 
 When `execution_surface` is `semantic_layer`, use the configured dbt Semantic
 Layer / MetricFlow execution path rather than SQL against `relation_name`. When
-`execution_surface` is `metadata_only` or `queryable` is false, treat the row as
-definition context or a blocker; do not infer joins or write SQL from metric
-names alone.
+`direct_sql_queryable` is false, `execution_surface` is `metadata_only`, or
+`queryable` is false, treat the row as definition context or a blocker for
+direct SQL; do not infer joins or write SQL from metric names alone.
 
 ## Contract check rule
 

--- a/.github/skills/meta-authoring/references/workflow.md
+++ b/.github/skills/meta-authoring/references/workflow.md
@@ -31,8 +31,8 @@ If classification is ambiguous, inspect context and lineage before editing. Do n
 For business terms such as GMV, AOV, sessions, orders, customers, margin, conversion, or product counts:
 - search indicators by term and synonym
 - inventory canonical indicators
-- inspect `execution_surface`, `queryable`, and `queryable_via` before treating
-  an indicator as executable
+- inspect `execution_surface`, `queryable`, `direct_sql_queryable`, and
+  `queryable_via` before treating an indicator as executable
 - inspect candidate entities and grains
 - compare grains when two definitions look equivalent
 - use overlap or consistency reports when the concept appears broadly

--- a/.github/skills/model-architect/references/modelling-antipatterns.md
+++ b/.github/skills/model-architect/references/modelling-antipatterns.md
@@ -46,7 +46,7 @@ Signals:
 
 Signals:
 - `search_indicator` returns `execution_surface: "semantic_layer"` but the plan
-  tries to query `relation_name` directly
+  tries to query `relation_name` directly despite `direct_sql_queryable: false`
 - MetricFlow measure references are not resolved before using the metric
 - the refactor plan mixes Semantic Layer ownership with dbt relation ownership
   without an explicit boundary

--- a/.github/skills/model-architect/references/semantic-layer-boundaries.md
+++ b/.github/skills/model-architect/references/semantic-layer-boundaries.md
@@ -38,12 +38,12 @@ When choosing where semantics live, ask:
 `search_indicator` and `indicator_inventory` return execution metadata that
 must shape architecture decisions:
 
-- `execution_surface: "relation"` with `queryable_via: "relation_name"` means
-  the indicator can be queried through the returned relation after grain and
-  field checks.
-- `execution_surface: "semantic_layer"` with `queryable_via: "metricflow"`
-  belongs to the configured dbt Semantic Layer / MetricFlow execution path, not
-  ad hoc SQL against a relation.
+- `execution_surface: "relation"` with `direct_sql_queryable: true` and
+  `queryable_via: "relation_name"` means the indicator can be queried through
+  the returned relation after grain and field checks.
+- `execution_surface: "semantic_layer"` with `direct_sql_queryable: false` and
+  `queryable_via: "metricflow"` belongs to the configured dbt Semantic Layer /
+  MetricFlow execution path, not ad hoc SQL against a relation.
 - `execution_surface: "metadata_only"` or `queryable: false` is context only.
   Move the KPI to a dbt model, semantic metric, saved query, or recipe before
   calling it executable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added response-only `direct_sql_queryable` metadata to `search_indicator` and
+  `indicator_inventory` so agents can distinguish relation-backed SQL surfaces
+  from Semantic Layer-backed indicators that require MetricFlow/dbt Semantic
+  Layer execution.
 - Added agent modelling audit docs, API guidance, and packaged skill updates so
   agents use relation-backed, Semantic Layer-backed, and metadata-only indicator
   surfaces correctly.

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -154,14 +154,15 @@ hand-authored `meta.nova` block exists.
 Each indicator row includes response-only execution metadata:
 `indicator_source` (`nova_meta`, `dbt_metric`, or `dbt_semantic_model`),
 `execution_surface` (`relation`, `semantic_layer`, or `metadata_only`),
-`queryable`, `queryable_via` (`relation_name`, `metricflow`, or `none`), and an
-optional `execution_note`.
+`queryable`, `direct_sql_queryable`, `queryable_via` (`relation_name`,
+`metricflow`, or `none`), and an optional `execution_note`.
 
 Use those fields as the execution gate. Relation-backed indicators can be
 queried through the returned `relation_name` after the grain and fields fit the
 question. Semantic Layer-backed indicators require the configured dbt Semantic
-Layer / MetricFlow execution path. Metadata-only indicators are context only;
-they are not safe SQL surfaces and should not trigger inferred joins.
+Layer / MetricFlow execution path and are not directly queryable through Nova
+SQL. Metadata-only indicators are context only; they are not safe SQL surfaces
+and should not trigger inferred joins.
 
 Required:
 - `query`
@@ -204,6 +205,7 @@ Example response shape:
       "indicator_source": "nova_meta",
       "execution_surface": "relation",
       "queryable": true,
+      "direct_sql_queryable": true,
       "queryable_via": "relation_name",
       "domains": ["commerce"],
       "grain": {
@@ -265,6 +267,7 @@ Example response shape:
       "indicator_source": "nova_meta",
       "execution_surface": "relation",
       "queryable": true,
+      "direct_sql_queryable": true,
       "queryable_via": "relation_name",
       "domains": ["commerce"],
       "grain": {

--- a/docs/development/agent-modelling-findings-contract.md
+++ b/docs/development/agent-modelling-findings-contract.md
@@ -61,6 +61,7 @@ Each finding must be deterministic and serializable as:
   "evidence": {
     "execution_surface": "metadata_only",
     "queryable": false,
+    "direct_sql_queryable": false,
     "queryable_via": "none"
   },
   "recommendation": "Move the indicator to a queryable dbt model, expose it through dbt Semantic Layer / MetricFlow, or mark the entity as non-analyst-facing.",

--- a/docs/features/agent-modelling-audits.md
+++ b/docs/features/agent-modelling-audits.md
@@ -64,6 +64,76 @@ The report adds:
 categories. Findings are sorted by severity, category, code, entity, indicator,
 and message so repeated runs are stable.
 
+## Output Examples
+
+A clean project still includes the agent-modelling section so CI and agent
+clients can rely on a stable response shape:
+
+```json
+{
+  "agent_modelling_schema_version": "agent_modelling.v1",
+  "agent_modelling_finding_count": 0,
+  "agent_modelling_findings": [],
+  "summary": {
+    "agent_modelling": {
+      "total": 0,
+      "blockers": 0,
+      "high": 0,
+      "medium": 0,
+      "low": 0,
+      "truncated": false,
+      "top_codes": [],
+      "top_categories": []
+    }
+  }
+}
+```
+
+A problematic metadata-only cross-grain KPI returns deterministic evidence and
+a remediation path instead of asking the agent to infer a raw fact-table join:
+
+```json
+{
+  "agent_modelling_finding_count": 1,
+  "agent_modelling_findings": [
+    {
+      "code": "ratio_like_metric_without_deterministic_surface",
+      "severity": "blocker",
+      "category": "cross_grain",
+      "message": "Ratio-like indicator `revenue_per_session` has no deterministic execution surface.",
+      "evidence": {
+        "execution_surface": "metadata_only",
+        "queryable": false,
+        "queryable_via": "none"
+      },
+      "recommendation": "Move the KPI to a queryable dbt relation, dbt Semantic Layer / MetricFlow metric, saved query, or recipe before agents use it for analysis."
+    }
+  ],
+  "summary": {
+    "agent_modelling": {
+      "total": 1,
+      "blockers": 1,
+      "high": 0,
+      "medium": 0,
+      "low": 0,
+      "truncated": false,
+      "top_codes": [
+        {
+          "code": "ratio_like_metric_without_deterministic_surface",
+          "count": 1
+        }
+      ],
+      "top_categories": [
+        {
+          "category": "cross_grain",
+          "count": 1
+        }
+      ]
+    }
+  }
+}
+```
+
 ## Severity Semantics
 
 - `blocker`: the surface is unsafe or ambiguous for agent execution. Examples

--- a/docs/features/agent-modelling-audits.md
+++ b/docs/features/agent-modelling-audits.md
@@ -23,6 +23,7 @@ response-only execution metadata:
 - `indicator_source`: `nova_meta`, `dbt_metric`, or `dbt_semantic_model`
 - `execution_surface`: `relation`, `semantic_layer`, or `metadata_only`
 - `queryable`: boolean
+- `direct_sql_queryable`: boolean
 - `queryable_via`: `relation_name`, `metricflow`, or `none`
 - `execution_note`: optional guidance
 
@@ -31,7 +32,8 @@ Treat those fields as the first execution gate:
 - Relation-backed indicators can be queried through the returned
   `relation_name` when the grain and fields fit the question.
 - Semantic-layer-backed indicators require the configured dbt Semantic Layer /
-  MetricFlow execution path. Do not pretend they are relation-backed just
+  MetricFlow execution path. They return `queryable: true` and
+  `direct_sql_queryable: false`; do not pretend they are relation-backed just
   because they are discoverable in Nova.
 - Metadata-only indicators are context. They are not safe query surfaces for
   SQL execution or agent-inferred joins.
@@ -104,6 +106,7 @@ a remediation path instead of asking the agent to infer a raw fact-table join:
       "evidence": {
         "execution_surface": "metadata_only",
         "queryable": false,
+        "direct_sql_queryable": false,
         "queryable_via": "none"
       },
       "recommendation": "Move the KPI to a queryable dbt relation, dbt Semantic Layer / MetricFlow metric, saved query, or recipe before agents use it for analysis."

--- a/src/cli/agent_readiness_cmd.rs
+++ b/src/cli/agent_readiness_cmd.rs
@@ -888,6 +888,9 @@ async fn build_agent_modelling_readiness_result(
         .modelling_consistency_report(&ModellingConsistencyReportParams {
             resource_types: Vec::new(),
             pagination: PaginationParams {
+                // Agent modelling findings are bounded independently by
+                // `agent_modelling_audit.max_findings`; keep the legacy
+                // overlap/duplicate report payload minimal for readiness.
                 limit: Some(1),
                 offset: 0,
             },

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -2221,6 +2221,7 @@ struct IndicatorExecutionMetadata {
     indicator_source: &'static str,
     execution_surface: &'static str,
     queryable: bool,
+    direct_sql_queryable: bool,
     queryable_via: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     execution_note: Option<&'static str>,
@@ -2893,6 +2894,7 @@ fn indicator_execution_metadata(entity: &ArchivedEntity) -> IndicatorExecutionMe
             indicator_source: "nova_meta",
             execution_surface: "relation",
             queryable: true,
+            direct_sql_queryable: true,
             queryable_via: "relation_name",
             execution_note: None,
         },
@@ -2900,6 +2902,7 @@ fn indicator_execution_metadata(entity: &ArchivedEntity) -> IndicatorExecutionMe
             indicator_source: "nova_meta",
             execution_surface: "metadata_only",
             queryable: false,
+            direct_sql_queryable: false,
             queryable_via: "none",
             execution_note: Some(
                 "No deterministic relation or Semantic Layer execution surface is available.",
@@ -2913,6 +2916,7 @@ fn semantic_layer_indicator_execution(source: &'static str) -> IndicatorExecutio
         indicator_source: source,
         execution_surface: "semantic_layer",
         queryable: true,
+        direct_sql_queryable: false,
         queryable_via: "metricflow",
         execution_note: Some("Use MetricFlow or the dbt Semantic Layer for execution."),
     }
@@ -4185,6 +4189,7 @@ mod candidate_tests {
             indicator_source: "nova_meta",
             execution_surface: "metadata_only",
             queryable: false,
+            direct_sql_queryable: false,
             queryable_via: "none",
             execution_note: Some(
                 "No deterministic relation or Semantic Layer execution surface is available.",

--- a/tests/metricflow_catalog.rs
+++ b/tests/metricflow_catalog.rs
@@ -144,6 +144,7 @@ async fn metricflow_metrics_are_discoverable_without_nova_meta() {
     assert_eq!(gross_revenue["indicator_source"], "dbt_metric");
     assert_eq!(gross_revenue["execution_surface"], "semantic_layer");
     assert_eq!(gross_revenue["queryable"].as_bool(), Some(true));
+    assert_eq!(gross_revenue["direct_sql_queryable"].as_bool(), Some(false));
     assert_eq!(gross_revenue["queryable_via"], "metricflow");
     assert!(
         gross_revenue["execution_note"]
@@ -162,6 +163,10 @@ async fn metricflow_metrics_are_discoverable_without_nova_meta() {
     assert_eq!(revenue_per_session["indicator_source"], "dbt_metric");
     assert_eq!(revenue_per_session["execution_surface"], "semantic_layer");
     assert_eq!(revenue_per_session["queryable"].as_bool(), Some(true));
+    assert_eq!(
+        revenue_per_session["direct_sql_queryable"].as_bool(),
+        Some(false)
+    );
     assert_eq!(revenue_per_session["queryable_via"], "metricflow");
 
     let order_total = inventory_rows
@@ -171,6 +176,7 @@ async fn metricflow_metrics_are_discoverable_without_nova_meta() {
     assert_eq!(order_total["indicator_source"], "dbt_semantic_model");
     assert_eq!(order_total["execution_surface"], "semantic_layer");
     assert_eq!(order_total["queryable"].as_bool(), Some(true));
+    assert_eq!(order_total["direct_sql_queryable"].as_bool(), Some(false));
     assert_eq!(order_total["queryable_via"], "metricflow");
 
     let relation_metric = inventory_rows
@@ -183,6 +189,10 @@ async fn metricflow_metrics_are_discoverable_without_nova_meta() {
     assert_eq!(relation_metric["indicator_source"], "nova_meta");
     assert_eq!(relation_metric["execution_surface"], "relation");
     assert_eq!(relation_metric["queryable"].as_bool(), Some(true));
+    assert_eq!(
+        relation_metric["direct_sql_queryable"].as_bool(),
+        Some(true)
+    );
     assert_eq!(relation_metric["queryable_via"], "relation_name");
     assert_eq!(
         relation_metric["relation_name"],
@@ -200,6 +210,10 @@ async fn metricflow_metrics_are_discoverable_without_nova_meta() {
     assert_eq!(metadata_only_metric["indicator_source"], "nova_meta");
     assert_eq!(metadata_only_metric["execution_surface"], "metadata_only");
     assert_eq!(metadata_only_metric["queryable"].as_bool(), Some(false));
+    assert_eq!(
+        metadata_only_metric["direct_sql_queryable"].as_bool(),
+        Some(false)
+    );
     assert_eq!(metadata_only_metric["queryable_via"], "none");
     assert!(
         metadata_only_metric["execution_note"]
@@ -230,6 +244,10 @@ async fn metricflow_metrics_are_discoverable_without_nova_meta() {
     assert_eq!(gross_revenue_search["indicator_source"], "dbt_metric");
     assert_eq!(gross_revenue_search["execution_surface"], "semantic_layer");
     assert_eq!(gross_revenue_search["queryable"].as_bool(), Some(true));
+    assert_eq!(
+        gross_revenue_search["direct_sql_queryable"].as_bool(),
+        Some(false)
+    );
     assert_eq!(gross_revenue_search["queryable_via"], "metricflow");
 
     let ratio_search = json(
@@ -260,6 +278,10 @@ async fn metricflow_metrics_are_discoverable_without_nova_meta() {
     assert_eq!(
         revenue_per_session_search["queryable"].as_bool(),
         Some(true)
+    );
+    assert_eq!(
+        revenue_per_session_search["direct_sql_queryable"].as_bool(),
+        Some(false)
     );
     assert_eq!(revenue_per_session_search["queryable_via"], "metricflow");
 


### PR DESCRIPTION
## Summary

- Close the stale metadata-only composite metrics direction in GitHub issue #217 and track the cleanup in Linear (`JOE-601`).
- Clarify why agent readiness calls `modelling_consistency_report` with `limit: Some(1)` and add clean/problematic agent modelling audit output examples (`JOE-602`).
- Add response-only `direct_sql_queryable` metadata to `search_indicator` and `indicator_inventory`, with tests/docs/packaged skill guidance distinguishing relation SQL from MetricFlow/dbt Semantic Layer execution (`JOE-603`).

## Validation

- `cargo fmt --check`
- `cargo test --locked --test metricflow_catalog`
- `uv run mkdocs build --strict`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `git diff --check`

Notes:
- MkDocs emitted the existing upstream Material for MkDocs 2.0 warning, but the strict docs build succeeded.
