### PR TITLE
Harden production contracts and release gates

### DIFF
--- a/.github/skills/analyst/assets/evidence-block.md
+++ b/.github/skills/analyst/assets/evidence-block.md
@@ -17,6 +17,7 @@
 
 - Indicator definition source:
 - Indicator execution surface / queryable via:
+- Direct SQL queryable:
 - Semantic discovery:
 - Raw-search fallback reason:
 - Execution method:

--- a/.github/skills/analyst/assets/report-template.md
+++ b/.github/skills/analyst/assets/report-template.md
@@ -22,6 +22,7 @@
 - Validated filter values:
 - Metric definition source:
 - Indicator execution surface / queryable via:
+- Direct SQL queryable:
 - Semantic discovery:
 - Raw-search fallback reason:
 - Execution method:

--- a/.github/skills/governance/SKILL.md
+++ b/.github/skills/governance/SKILL.md
@@ -2,7 +2,7 @@
 name: governance
 description: "Runs deterministic governance audits with Nova using frozen scope, repeatable scoring, explicit blocker extraction, and remediation planning. Use when enforcing metadata standards, testing and documentation gates, ownership and compliance requirements, and rerunnable audit evidence through MCP or the dbt-nova CLI."
 license: MIT
-allowed-tools: "Bash Read Write mcp__nova__show_metadata mcp__nova__health mcp__nova__list_entities mcp__nova__list_tags mcp__nova__list_packages mcp__nova__batch_get_entities mcp__nova__find_by_path mcp__nova__search mcp__nova__search_columns mcp__nova__column_inventory mcp__nova__get_entity mcp__nova__get_columns mcp__nova__get_metadata_score mcp__nova__get_test_coverage"
+allowed-tools: "Bash Read Write mcp__nova__show_metadata mcp__nova__health mcp__nova__list_entities mcp__nova__list_tags mcp__nova__list_packages mcp__nova__batch_get_entities mcp__nova__find_by_path mcp__nova__search mcp__nova__search_columns mcp__nova__column_inventory mcp__nova__get_entity mcp__nova__get_columns mcp__nova__get_metadata_audit mcp__nova__get_agent_readiness mcp__nova__get_metadata_score mcp__nova__get_test_coverage"
 metadata:
   owner: "dbt-nova"
   persona: "governance"

--- a/.github/skills/governance/references/transport-mcp.md
+++ b/.github/skills/governance/references/transport-mcp.md
@@ -19,17 +19,19 @@ Use this reference when the client exposes `mcp__nova__*` tools directly.
 
 1. `show_metadata` for manifest identity
 2. `find_by_path`, `list_tags`, `list_packages`, or bounded `list_entities` to freeze scope
-3. `get_metadata_score` for baseline scoring
-4. `get_test_coverage`, `get_entity`, and `get_columns` for blocker detail
-5. `search_columns` or `column_inventory` for PII/compliance and repeated-field audits
-6. `batch_get_entities` for compact review of a small failing set
-7. `search` only as a triage helper when the scope definition is still unclear
+3. `get_metadata_audit` for baseline governance gates and blocker extraction
+4. `get_agent_readiness` when MCP/agent-readiness gates are in scope
+5. `get_metadata_score` for entity-level drill-down
+6. `get_test_coverage`, `get_entity`, and `get_columns` for blocker detail
+7. `search_columns` or `column_inventory` for PII/compliance and repeated-field audits
+8. `batch_get_entities` for compact review of a small failing set
+9. `search` only as a triage helper when the scope definition is still unclear
 
 Scope discipline:
 - for exact entity audits, skip inventory and score the entity directly
 - for path audits, use `find_by_path` before `list_entities`
-- for small path/tag scopes, call `get_metadata_score` on each frozen entity; `scope=project` pages are project baselines, not path-scoped gates
-- for project baselines, use bounded pages and report the page/scope limit
+- for small path/tag scopes, call `get_metadata_score` on each frozen entity
+- for project baselines, use `get_metadata_audit` or `get_metadata_score scope=project`; the latter returns aggregate scoring plus a bounded entity sample
 - keep the rerun scope identical to the baseline scope
 
 Compliance scan pattern:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,8 +157,12 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
-      - name: Validate Tokenomics Bridge Eval
-        run: cargo run --locked --no-default-features -- eval validate --suite evals/agent-tokenomics-bridge.yml
+      - name: Validate Packaged Eval Suites
+        run: |
+          set -euo pipefail
+          for suite in evals/*.yml; do
+            cargo run --locked --no-default-features -- eval validate --suite "$suite"
+          done
 
       - name: Run Tokenomics Bridge Eval
         run: |

--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 45
     env:
       DBT_NOVA_STRICT_SCHEMA: "1"
-      DBT_NOVA_BENCH_LARGE_ENTITY_COUNT: "1000"
+      DBT_NOVA_BENCH_LARGE_ENTITY_COUNT: "10000"
       CARGO_BUILD_JOBS: "1"
       RUSTFLAGS: "-C debuginfo=0"
     steps:

--- a/.github/workflows/nova-build-assets.yml
+++ b/.github/workflows/nova-build-assets.yml
@@ -217,7 +217,6 @@ on:
         value: ${{ jobs.build.outputs.published_models_uris }}
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   prepare:
@@ -754,6 +753,9 @@ jobs:
     runs-on: ${{ inputs.runner_labels_json != '' && fromJSON(inputs.runner_labels_json) || inputs.runner }}
     timeout-minutes: ${{ fromJSON(needs.prepare.outputs.build_timeout_minutes) }}
     needs: prepare
+    permissions:
+      contents: read
+      id-token: write
     concurrency:
       group: nova-assets-${{ github.repository }}-${{ needs.prepare.outputs.storage_instance_id }}
       cancel-in-progress: false

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -10,6 +10,7 @@ jobs:
   tag:
     if: >
       github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       (startsWith(github.event.pull_request.head.ref, 'release/') ||
        startsWith(github.event.pull_request.head.ref, 'hotfix/'))
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,13 +303,26 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf dist/oci
-          rm -f dbt-nova-linux-x86_64.tar.gz dbt-nova-linux-arm64.tar.gz
+          rm -f dbt-nova-linux-x86_64.tar.gz* dbt-nova-linux-x86_64.sha256 \
+            dbt-nova-linux-arm64.tar.gz* dbt-nova-linux-arm64.sha256
           mkdir -p dist/oci/linux-amd64 dist/oci/linux-arm64
 
           gh release download "${RELEASE_TAG}" \
             --repo "${GITHUB_REPOSITORY}" \
-            --pattern "dbt-nova-linux-x86_64.tar.gz" \
-            --pattern "dbt-nova-linux-arm64.tar.gz"
+            --pattern "dbt-nova-linux-x86_64.tar.gz*" \
+            --pattern "dbt-nova-linux-x86_64.sha256" \
+            --pattern "dbt-nova-linux-arm64.tar.gz*" \
+            --pattern "dbt-nova-linux-arm64.sha256"
+
+          for asset in dbt-nova-linux-x86_64 dbt-nova-linux-arm64; do
+            sha256sum -c "${asset}.sha256"
+            COSIGN_EXPERIMENTAL=1 cosign verify-blob \
+              --certificate "${asset}.tar.gz.crt" \
+              --signature "${asset}.tar.gz.sig" \
+              --certificate-identity-regexp "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/(tags/${RELEASE_TAG}|heads/master)" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              "${asset}.tar.gz"
+          done
 
           tar -xzf dbt-nova-linux-x86_64.tar.gz -C dist/oci/linux-amd64
           tar -xzf dbt-nova-linux-arm64.tar.gz -C dist/oci/linux-arm64
@@ -429,6 +442,46 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: TARGETARCH=arm64
           provenance: false
+
+      - name: Smoke ARM64 HTTP container
+        shell: bash
+        env:
+          ARM64_IMAGE: ${{ steps.image.outputs.arm64_tag }}
+        run: |
+          set -euo pipefail
+          docker rm -f dbt-nova-arm64-release-smoke >/dev/null 2>&1 || true
+          trap 'docker logs dbt-nova-arm64-release-smoke || true; docker rm -f dbt-nova-arm64-release-smoke >/dev/null 2>&1 || true' EXIT
+          docker run -d --rm \
+            --platform linux/arm64 \
+            --name dbt-nova-arm64-release-smoke \
+            -p 127.0.0.1:8081:8080 \
+            -v "$PWD/tests/fixtures:/fixtures:ro" \
+            -e DBT_MANIFEST_PATH=/fixtures/nova_manifest.json \
+            -e PORT=8080 \
+            -e DBT_NOVA_HTTP_EXPECT_AUTH_PROXY=true \
+            -e DBT_NOVA_TOOL_DENYLIST=execute_sql,run_recipe,show_config,validate_config,inspect_storage,prune_storage,cleanup_storage,warm_manifest \
+            -e DBT_NOVA_SEARCH_ENABLE_VECTOR=false \
+            -e DBT_NOVA_SEARCH_ENABLE_SPARSE=false \
+            -e DBT_NOVA_SEARCH_ENABLE_RERANKER=false \
+            "${ARM64_IMAGE}"
+
+          health_ok=0
+          ready_ok=0
+          for _ in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:8081/healthz > /tmp/dbt-nova-arm64-healthz.json; then
+              health_ok=1
+            fi
+            if curl -fsS http://127.0.0.1:8081/readyz > /tmp/dbt-nova-arm64-readyz.json; then
+              if grep -q '"status":"ready"' /tmp/dbt-nova-arm64-readyz.json; then
+                ready_ok=1
+                break
+              fi
+            fi
+            sleep 1
+          done
+
+          test "$health_ok" -eq 1
+          test "$ready_ok" -eq 1
 
       - name: Publish multi-arch manifest
         id: manifest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   immutable release tag before fetching optional support assets, adding
   cooperative deadlines to synchronous MCP/CLI search scans, accounting
   semantic timeouts as circuit-breaker failures, and correcting release-tag and
-  config-reference docs without publishing `v0.0.6`.
+  config-reference docs.
 - Redacted raw upstream Databricks and BigQuery HTTP error bodies from
   CLI/MCP responses while preserving status and provider error-code context.
 - Safety-gated MCP `reload_manifest` source, refresh, and storage mutations

--- a/benches/search_bench.rs
+++ b/benches/search_bench.rs
@@ -9,8 +9,9 @@ use std::time::Duration;
 use tokio::runtime::Runtime;
 
 use dbt_nova::params::{
-    DetailLevel, GetEntityParams, GetLineageParams, IndicatorInventoryParams, PaginationParams,
-    SearchColumnsParams, SearchParams,
+    DetailLevel, GetEntityParams, GetLineageParams, IndicatorInventoryParams,
+    ModellingConsistencyReportParams, PaginationParams, ParentGroupMode, SearchColumnsParams,
+    SearchIndicatorParams, SearchParams,
 };
 use serde_json::json;
 
@@ -110,6 +111,7 @@ fn load_large_synthetic_fixture(entity_count: usize) -> fixtures::FixtureSearchE
                 "description": format!("Synthetic benchmark model {index} for revenue customer search."),
                 "database": "analytics",
                 "schema": "benchmark",
+                "relation_name": format!("analytics.benchmark.{name}"),
                 "path": format!("models/benchmark/{name}.sql"),
                 "original_file_path": format!("models/benchmark/{name}.sql"),
                 "unique_id": unique_id,
@@ -201,6 +203,54 @@ fn bench_large_indicator_inventory(c: &mut Criterion) {
     });
 }
 
+fn bench_large_search_indicator(c: &mut Criterion) {
+    let entity_count = large_entity_count();
+    let env = load_large_synthetic_fixture(entity_count);
+    let rt = Runtime::new().unwrap();
+    let params = SearchIndicatorParams {
+        query: "gross revenue sales bookings customer".to_string(),
+        resource_types: vec!["model".to_string()],
+        indicator_types: vec!["measure".to_string()],
+        persona: Some("analyst".to_string()),
+        pagination: PaginationParams {
+            limit: Some(25),
+            offset: 0,
+        },
+        detail: Some(DetailLevel::Compact),
+        group_mode: Some(ParentGroupMode::Top),
+        include_support_signals: false,
+        ..Default::default()
+    };
+
+    c.bench_function("large_search_indicator_compact", |b| {
+        b.iter(|| {
+            rt.block_on(env.search_indicator(black_box(&params)))
+                .expect("large search_indicator failed");
+        })
+    });
+}
+
+fn bench_large_modelling_consistency_report(c: &mut Criterion) {
+    let entity_count = large_entity_count();
+    let env = load_large_synthetic_fixture(entity_count);
+    let rt = Runtime::new().unwrap();
+    let params = ModellingConsistencyReportParams {
+        resource_types: vec!["model".to_string()],
+        pagination: PaginationParams {
+            limit: Some(10),
+            offset: 0,
+        },
+        min_score: Some(0.5),
+    };
+
+    c.bench_function("large_modelling_consistency_report", |b| {
+        b.iter(|| {
+            rt.block_on(env.modelling_consistency_report(black_box(&params)))
+                .expect("large modelling report failed");
+        })
+    });
+}
+
 fn bench_large_archived_access(c: &mut Criterion) {
     let entity_count = large_entity_count();
     let env = load_large_synthetic_fixture(entity_count);
@@ -262,7 +312,8 @@ criterion_group! {
         .sample_size(50)
         .measurement_time(Duration::from_secs(7));
     targets = bench_search, bench_lineage, bench_indicator_inventory, bench_search_columns,
-        bench_large_indicator_inventory, bench_large_archived_access,
+        bench_large_indicator_inventory, bench_large_search_indicator,
+        bench_large_modelling_consistency_report, bench_large_archived_access,
         bench_large_concurrent_search_and_lookup
 }
 criterion_main!(benches);

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -58,8 +58,8 @@ denylist.
 | Tool | Purpose | Key Parameters |
 |------|---------|----------------|
 | `compare_grains` | Compare grain metadata between two entities | `entity1`, `entity2`, `entity1_resource_type`, `entity2_resource_type` |
-| `find_entity_overlap` | Detect overlapping entities using semantic evidence | `resource_types`, `package`, `min_overlap_score`, `limit`, `offset` |
-| `modelling_consistency_report` | Audit duplicate indicators, grain drift, and agent-modelling risks | `resource_types`, `package`, `limit`, `offset` |
+| `find_entity_overlap` | Detect overlapping entities using semantic evidence | `id_or_name`, `resource_type`, `resource_types`, `min_score`, `limit`, `offset` |
+| `modelling_consistency_report` | Audit duplicate indicators, grain drift, and agent-modelling risks | `resource_types`, `min_score`, `limit`, `offset` |
 
 ## Validation
 

--- a/docs/api/response-format.md
+++ b/docs/api/response-format.md
@@ -27,6 +27,29 @@ Notes:
 - For object payloads, each tool defines primary records explicitly.
 - `get_undocumented` sets `count = entities_returned + columns_returned`.
 
+## MCP Result Metadata
+
+MCP responses may include `_nova_result_meta` for machine-readable transport
+metadata:
+
+```json
+{
+  "_nova_result_meta": {
+    "next_offset": 25,
+    "response_bytes": 42117,
+    "budget_bytes": 65536,
+    "truncated": true,
+    "omitted_paths": ["$.data.0.compiled_code"],
+    "original_count": 50
+  }
+}
+```
+
+`next_offset` is pagination metadata. It appears when a paginated MCP request
+returned items and more results are available, even when truncation metadata is
+disabled. The byte-budget fields appear only when central MCP response
+budgeting attaches truncation metadata.
+
 Search responses may include suggestions when no results are found:
 
 ```json

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -60,9 +60,10 @@ see [Modes & Combinations](../getting-started/modes-and-combinations.md).
 - `DBT_NOVA_MCP_MAX_PAGE_SIZE` – MCP-specific cap for paginated result requests before the global search cap is applied (`0` disables the MCP-specific cap, default: `100`)
 - `DBT_NOVA_MCP_MAX_RESPONSE_BYTES` – central serialized MCP tool response budget in bytes (`0` disables central budgeting, default: `65536`)
 - `DBT_NOVA_MCP_MAX_STRING_CHARS` – max characters retained for long strings when central MCP budgeting truncates (default: `4096`)
-- `DBT_NOVA_MCP_INCLUDE_TRUNCATION_META` – include `_nova_result_meta` when a central MCP budget pass truncates a response (`true`|`false`, default: `true`)
+- `DBT_NOVA_MCP_INCLUDE_TRUNCATION_META` – include byte-budget fields in `_nova_result_meta` when a central MCP budget pass truncates a response; pagination `next_offset` metadata can still appear when this is false (`true`|`false`, default: `true`)
 - `DBT_NOVA_MCP_ENABLE_MANIFEST_RELOAD` – allow MCP `reload_manifest` to change `manifest_uri`, `manifest_path`, `refresh_secs`, or `storage_instance_id`; no-argument current-source reloads do not require this opt-in
 - `DBT_NOVA_MCP_ENABLE_MANIFEST_WARM` – allow MCP/`tool call` `warm_manifest` semantic cache writes
+- `DBT_NOVA_EVAL_UNSAFE_WRITE_RAW_PROVIDER_LOGS` – opt in to raw provider transcript artifacts during agent eval debugging; unsafe for shared CI or untrusted environments
 - `DBT_NOVA_SQL_PROVIDER` – SQL backend for `execute_sql` (`databricks`, `bigquery`, `snowflake`, or `duckdb`, default: `databricks`)
 - `DBT_NOVA_GCP_PROJECT_ID` – shared Google project id alias (used by BigQuery fallback resolution)
 - `DBT_NOVA_GCP_ACCESS_TOKEN` – shared Google OAuth access token alias (used by BigQuery fallback resolution)
@@ -123,8 +124,9 @@ Remote manifest notes:
   available for debugging.
 - Central MCP response budgeting is a backstop, not a replacement for tool-level
   limits. Prefer compact tool parameters first; truncated responses include
-  `_nova_result_meta` with byte budget, omitted path evidence, and `next_offset`
-  for paginated MCP responses when enabled.
+  `_nova_result_meta` with byte budget and omitted path evidence when enabled.
+  Paginated MCP responses can include `_nova_result_meta.next_offset` whenever
+  another page is available.
 - Tool filter examples:
   - Full backwards-compatible MCP catalog:
     - `DBT_NOVA_TOOL_PROFILE=all`

--- a/docs/features/agent-modelling-audits.md
+++ b/docs/features/agent-modelling-audits.md
@@ -101,7 +101,7 @@ a remediation path instead of asking the agent to infer a raw fact-table join:
     {
       "code": "ratio_like_metric_without_deterministic_surface",
       "severity": "blocker",
-      "category": "cross_grain",
+      "category": "cross_grain_risk",
       "message": "Ratio-like indicator `revenue_per_session` has no deterministic execution surface.",
       "evidence": {
         "execution_surface": "metadata_only",
@@ -128,7 +128,7 @@ a remediation path instead of asking the agent to infer a raw fact-table join:
       ],
       "top_categories": [
         {
-          "category": "cross_grain",
+          "category": "cross_grain_risk",
           "count": 1
         }
       ]

--- a/docs/features/agent-readiness.md
+++ b/docs/features/agent-readiness.md
@@ -56,8 +56,7 @@ Run agent readiness after dbt has produced `target/manifest.json`. This example
 starts in advisory mode, writes machine and human reports, always uploads the
 reports as workflow artifacts, and mirrors the Markdown report into the job
 summary. Replace `<nova-release-tag>` with a release that includes
-`audit agent-readiness`; until that release exists, install Nova from an
-immutable source commit instead of using the release installer step.
+`audit agent-readiness`; use `v0.0.5` or newer for the release installer step.
 
 ```yaml
 name: Agent readiness

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -404,6 +404,10 @@ Codex, Claude, and OpenCode. Fallback parsing only accepts MCP server aliases
 that look like Nova (`nova`, `dbt-nova`, `dbt_nova`, `dbtnova`, or
 `dbt-nova-mcp`). If your client uses a different alias, set
 `DBT_NOVA_EVAL_MCP_SERVER_ALIASES` to a comma-separated list of accepted aliases.
+Raw provider transcripts are not written by default because they may contain
+prompts, outputs, SQL, or credentials from the provider environment. Set
+`DBT_NOVA_EVAL_UNSAFE_WRITE_RAW_PROVIDER_LOGS=1` only in trusted local/debug
+runs where those raw artifacts are acceptable.
 
 ```yaml
 version: 1

--- a/docs/features/metadata-scoring.md
+++ b/docs/features/metadata-scoring.md
@@ -35,8 +35,8 @@ It is designed for:
 
 Notes:
 - `persona` is optional (`analyst`, `engineer`, `governance`, default).
-- `resource_types` and `limit` are only used for `scope=project`.
-- `offset` is optional and used for deterministic paging in `scope=project`.
+- `resource_types` selects entities for `scope=project`.
+- `limit` and `offset` page the returned project entity sample, not the aggregate project score.
 - Default project `limit` is **1000**.
 
 ## Response Structure
@@ -64,10 +64,10 @@ Notes:
 }
 ```
 
-For `scope=project`, the tool returns an overall score and a list of scored
-entities, honoring `limit` and marking responses as `truncated` when needed.
-It also returns `quality_summary.test_coverage`, aggregated across the
-returned entities (or all entities when not truncated).
+For `scope=project`, the tool returns an aggregate overall score across all
+matching entities plus a deterministic paged sample of entity scores. It marks
+the response as `truncated` when more sample rows are available. It also returns
+`quality_summary.test_coverage`, aggregated across all matching entities.
 
 All scopes include `scoring_contract.schema_version:
 "metadata_score_contract.v1"` so agents can explain scores without reading
@@ -222,8 +222,9 @@ The overall column score is still weighted by persona category weights.
 
 `scope=project`:
 - sorts selected `resource_types` and entity IDs deterministically
-- scores entities using `limit` + `offset` paging
-- returns an overall average and per‑entity results
+- scores all matching entities for the aggregate project score
+- uses `limit` + `offset` only for the returned entity sample
+- returns an overall average and paged per‑entity sample results
 - returns compact summary buckets and drill-down hints for agent triage
 - sets `truncated: true` if `offset + count < total_available`
 

--- a/docs/features/nova-meta-metrics.md
+++ b/docs/features/nova-meta-metrics.md
@@ -185,7 +185,7 @@ models:
 ## Recommended Fields (Nova‑Level)
 
 - `canonical` (bool): True for the preferred definition of the KPI.
-- `tier` (alpha|beta|gamma): Quality signal for discovery.
+- `tier` (`alpha`, `beta`, `gamma`, `gold`, `silver`, or `bronze`): Quality signal for discovery.
 - `domains` (list): Broad business domain(s) used for routing.
 - `use_cases` (list): Typical analyst questions (e.g., `weekly_report`).
 

--- a/docs/features/nova-meta-models.md
+++ b/docs/features/nova-meta-models.md
@@ -46,7 +46,7 @@ models:
 ## Recommended Fields (Model‑Level)
 
 - `canonical` (bool): True for the preferred dataset for a business concept.
-- `tier` (alpha|beta|gamma): Quality signal for discovery.
+- `tier` (`alpha`, `beta`, `gamma`, `gold`, `silver`, or `bronze`): Quality signal for discovery.
 - `domains` (list): Broad business domain(s) used for routing.
 - `use_cases` (list): Typical analyst questions (e.g., `weekly_report`).
 - `synonyms` (list): Business names analysts will search for.

--- a/docs/personas/analyst.md
+++ b/docs/personas/analyst.md
@@ -43,7 +43,7 @@ Goal: translate a business question into data requirements.
 
 Search needs:
 - Find entities by business terms (description, docs, tags).
-- Identify canonical models (alpha/beta/gamma labels, package ownership).
+- Identify canonical models (tier labels, package ownership).
 
 Required analyst behavior:
 - If the question is ambiguous or internally inconsistent, **clarify before querying**.

--- a/evals/agent-tokenomics-bridge.yml
+++ b/evals/agent-tokenomics-bridge.yml
@@ -56,6 +56,58 @@ cases:
           - data.0.description
           - data.0.explain
           - data.0.support_signals
+      - type: tool_field_equals
+        tool: search_indicator
+        params:
+          query: checkout completion rate order completed checkout start ecommerce sessions
+          resource_types: [model]
+          indicator_types: [metric]
+          persona: analyst
+          limit: 2
+          detail: compact
+          group_mode: top
+          include_support_signals: false
+        field: data.0.execution_surface
+        expected: relation
+      - type: tool_field_equals
+        tool: search_indicator
+        params:
+          query: checkout completion rate order completed checkout start ecommerce sessions
+          resource_types: [model]
+          indicator_types: [metric]
+          persona: analyst
+          limit: 2
+          detail: compact
+          group_mode: top
+          include_support_signals: false
+        field: data.0.queryable
+        expected: true
+      - type: tool_field_equals
+        tool: search_indicator
+        params:
+          query: checkout completion rate order completed checkout start ecommerce sessions
+          resource_types: [model]
+          indicator_types: [metric]
+          persona: analyst
+          limit: 2
+          detail: compact
+          group_mode: top
+          include_support_signals: false
+        field: data.0.direct_sql_queryable
+        expected: true
+      - type: tool_field_equals
+        tool: search_indicator
+        params:
+          query: checkout completion rate order completed checkout start ecommerce sessions
+          resource_types: [model]
+          indicator_types: [metric]
+          persona: analyst
+          limit: 2
+          detail: compact
+          group_mode: top
+          include_support_signals: false
+        field: data.0.queryable_via
+        expected: relation_name
 
   - id: entity_compact_contract_budget
     question: Compact entity lookup should return enough contract to execute without full context payloads.

--- a/schemas/nova/v0.json
+++ b/schemas/nova/v0.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/joe-broadhead/dbt-nova/schemas/nova/v0.json",
   "title": "Nova Meta Schema v0",
-  "x-nova-release": "0.0.0",
+  "x-nova-release": "0.0.6",
   "type": "object",
   "properties": {
     "nova": {
@@ -86,7 +86,7 @@
         "field": { "type": "string" },
         "operator": {
           "type": "string",
-          "description": "Expected values: in, not_in, =, !=, >, >=, <, <=, between, is_null, is_not_null."
+          "pattern": "^(in|not_in|=|!=|>|>=|<|<=|between|is_null|is_not_null)$"
         },
         "values": { "type": "array", "items": { "type": "string" } },
         "label": { "type": "string" }

--- a/scripts/warm_models.sh
+++ b/scripts/warm_models.sh
@@ -13,8 +13,12 @@ repo_slug="${DBT_NOVA_WARMUP_REPO:-joe-broadhead/dbt-nova}"
 release_version="${DBT_NOVA_WARMUP_VERSION:-latest}"
 fallback_from_release="${DBT_NOVA_WARMUP_FALLBACK_FROM_RELEASE:-1}"
 fallback_from_hf_direct="${DBT_NOVA_WARMUP_FALLBACK_FROM_HF_DIRECT:-1}"
-checksum_mode="${DBT_NOVA_WARMUP_CHECKSUM_MODE:-off}"
+checksum_mode="${DBT_NOVA_WARMUP_CHECKSUM_MODE:-warn}"
 checksum_file="${DBT_NOVA_WARMUP_CHECKSUM_FILE:-}"
+allow_mutable_hf_revisions="${DBT_NOVA_WARMUP_ALLOW_MUTABLE_HF_REVISIONS:-0}"
+e5_revision="${DBT_NOVA_WARMUP_E5_REVISION:-d128750597153bb5987e10b1c3493a34e5a4502a}"
+splade_revision="${DBT_NOVA_WARMUP_SPLADE_REVISION:-efcd182bc7eb351e81a9445752d4388c2bab500b}"
+reranker_revision="${DBT_NOVA_WARMUP_RERANKER_REVISION:-9cfeff2df7d40d1b78e75e5e9cebec92a99813c9}"
 pid=""
 
 usage() {
@@ -44,9 +48,14 @@ Optional env overrides:
   DBT_NOVA_WARMUP_FALLBACK_FROM_HF_DIRECT
                                        1 to seed cache from direct Hugging Face downloads on warmup failure (default: 1)
   DBT_NOVA_WARMUP_CHECKSUM_MODE        Checksum policy for direct HF fallback downloads:
-                                       off (default) | warn | required
+                                       off | warn (default) | required
   DBT_NOVA_WARMUP_CHECKSUM_FILE        Path to checksum manifest for direct HF fallback.
                                        Format: "<sha256> <url>" (space-delimited)
+  DBT_NOVA_WARMUP_E5_REVISION          Pinned intfloat/multilingual-e5-base revision
+  DBT_NOVA_WARMUP_SPLADE_REVISION      Pinned Qdrant/Splade_PP_en_v1 revision
+  DBT_NOVA_WARMUP_RERANKER_REVISION    Pinned jina reranker revision
+  DBT_NOVA_WARMUP_ALLOW_MUTABLE_HF_REVISIONS
+                                       1 to allow mutable revisions such as main/master/latest (default: 0)
 
 Example:
   # Model files only (default)
@@ -86,6 +95,31 @@ if [[ "$checksum_mode" == "required" && -z "$checksum_file" ]]; then
   echo "DBT_NOVA_WARMUP_CHECKSUM_MODE=required requires DBT_NOVA_WARMUP_CHECKSUM_FILE." >&2
   exit 1
 fi
+
+is_mutable_hf_revision() {
+  case "$1" in
+    main|master|latest) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+validate_hf_revision() {
+  local name="$1"
+  local revision="$2"
+  if [[ -z "$revision" ]]; then
+    echo "$name revision cannot be empty." >&2
+    exit 1
+  fi
+  if [[ "$fallback_from_hf_direct" == "1" && "$allow_mutable_hf_revisions" != "1" ]] \
+    && is_mutable_hf_revision "$revision"; then
+    echo "$name revision '$revision' is mutable. Set a commit SHA or DBT_NOVA_WARMUP_ALLOW_MUTABLE_HF_REVISIONS=1 to opt in." >&2
+    exit 1
+  fi
+}
+
+validate_hf_revision "DBT_NOVA_WARMUP_E5_REVISION" "$e5_revision"
+validate_hf_revision "DBT_NOVA_WARMUP_SPLADE_REVISION" "$splade_revision"
+validate_hf_revision "DBT_NOVA_WARMUP_RERANKER_REVISION" "$reranker_revision"
 
 cleanup() {
   if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
@@ -383,7 +417,6 @@ seed_repo_snapshot_from_hf() {
 }
 
 seed_from_hf_direct() {
-  local revision="main"
   local found
 
   echo "Attempting fallback seed from direct Hugging Face downloads..."
@@ -393,7 +426,7 @@ seed_from_hf_direct() {
   fi
 
   if (( required_models >= 1 )); then
-    if ! seed_repo_snapshot_from_hf "intfloat/multilingual-e5-base" "$revision" \
+    if ! seed_repo_snapshot_from_hf "intfloat/multilingual-e5-base" "$e5_revision" \
       "onnx/model.onnx" \
       "tokenizer.json" \
       "config.json" \
@@ -405,7 +438,7 @@ seed_from_hf_direct() {
   fi
 
   if (( required_models >= 2 )); then
-    if ! seed_repo_snapshot_from_hf "Qdrant/Splade_PP_en_v1" "$revision" \
+    if ! seed_repo_snapshot_from_hf "Qdrant/Splade_PP_en_v1" "$splade_revision" \
       "model.onnx" \
       "tokenizer.json" \
       "config.json" \
@@ -417,7 +450,7 @@ seed_from_hf_direct() {
   fi
 
   if (( required_models >= 3 )); then
-    if ! seed_repo_snapshot_from_hf "jinaai/jina-reranker-v2-base-multilingual" "$revision" \
+    if ! seed_repo_snapshot_from_hf "jinaai/jina-reranker-v2-base-multilingual" "$reranker_revision" \
       "onnx/model.onnx" \
       "tokenizer.json" \
       "config.json" \

--- a/src/cli/eval_cmd.rs
+++ b/src/cli/eval_cmd.rs
@@ -253,6 +253,13 @@ enum EvalAssertion {
         #[serde(default)]
         must_not_contain_paths: Vec<String>,
     },
+    ToolFieldEquals {
+        tool: String,
+        #[serde(default = "empty_object")]
+        params: JsonValue,
+        field: String,
+        expected: JsonValue,
+    },
     SqlStructure {
         actual_sql: String,
         expected_sql: String,
@@ -1384,6 +1391,18 @@ async fn evaluate_bridge_assertion(
             Err(error) => {
                 AssertionResult::error(format!("tool_response_budget:{tool}"), error.to_string())
             }
+        },
+        EvalAssertion::ToolFieldEquals {
+            tool,
+            params,
+            field,
+            expected,
+        } => match call_tool(search, tool, params.clone()).await {
+            Ok(response) => tool_field_equals_assertion(tool, &response, field, expected),
+            Err(error) => AssertionResult::error(
+                format!("tool_field_equals:{tool}:{field}"),
+                error.to_string(),
+            ),
         },
         EvalAssertion::SqlStructure {
             actual_sql,
@@ -2519,6 +2538,31 @@ fn tool_response_budget_assertion(
                 "present_forbidden_paths": present_forbidden_paths,
             }),
         )
+    }
+}
+
+fn tool_field_equals_assertion(
+    tool: &str,
+    response: &JsonValue,
+    field: &str,
+    expected: &JsonValue,
+) -> AssertionResult {
+    match json_value_at_path(response, field) {
+        Some(actual) if actual == expected => AssertionResult::pass(
+            format!("tool_field_equals:{tool}:{field}"),
+            "tool field matched expected value",
+            json!({"field": field, "expected": expected}),
+        ),
+        Some(actual) => AssertionResult::fail(
+            format!("tool_field_equals:{tool}:{field}"),
+            "tool field did not match expected value",
+            json!({"field": field, "expected": expected, "actual": actual}),
+        ),
+        None => AssertionResult::fail(
+            format!("tool_field_equals:{tool}:{field}"),
+            "tool field was missing",
+            json!({"field": field, "expected": expected}),
+        ),
     }
 }
 
@@ -5390,6 +5434,18 @@ fn validate_assertion(assertion: &EvalAssertion, case_id: &str) -> crate::error:
             {
                 return Err(DbtNovaError::InvalidParams(format!(
                     "tool_response_budget assertion in case '{case_id}' must use non-empty field paths"
+                )));
+            }
+        }
+        EvalAssertion::ToolFieldEquals { tool, field, .. } => {
+            if tool.trim().is_empty() {
+                return Err(DbtNovaError::InvalidParams(format!(
+                    "tool_field_equals assertion in case '{case_id}' must include a non-empty tool"
+                )));
+            }
+            if field.trim().is_empty() {
+                return Err(DbtNovaError::InvalidParams(format!(
+                    "tool_field_equals assertion in case '{case_id}' must include a non-empty field"
                 )));
             }
         }

--- a/src/cli/eval_cmd/tests.rs
+++ b/src/cli/eval_cmd/tests.rs
@@ -19,8 +19,9 @@ use super::{
     render_eval_card_markdown, resolve_mcp_writable_path, run_eval_command, run_validate_command,
     safe_path_segment, score_agent_expectations, score_final_answer, selected_agent_cases,
     selected_bridge_cases, sql_structure_assertion, suite_file_hash, telemetry_grade_mode,
-    telemetry_path_for_suite, telemetry_row_matches_since, tool_response_budget_assertion,
-    tool_success_assertion, validate_since_date, validate_suite, validate_telemetry_suite_name,
+    telemetry_path_for_suite, telemetry_row_matches_since, tool_field_equals_assertion,
+    tool_response_budget_assertion, tool_success_assertion, validate_since_date, validate_suite,
+    validate_telemetry_suite_name,
 };
 use crate::params::{
     CompareEvalRunsParams, GetEvalGateParams, GetEvalHistoryParams, InitEvalSuiteParams,
@@ -501,6 +502,27 @@ fn tool_response_budget_checks_bytes_and_shape() {
             "data.0.expression".to_string(),
         ],
         &["parent_groups.1".to_string()],
+    );
+
+    assert_eq!(result.status, "pass");
+}
+
+#[test]
+fn tool_field_equals_checks_json_path_value() {
+    let response = json!({
+        "data": [
+            {
+                "execution_surface": "relation",
+                "direct_sql_queryable": true
+            }
+        ]
+    });
+
+    let result = tool_field_equals_assertion(
+        "search_indicator",
+        &response,
+        "data.0.direct_sql_queryable",
+        &json!(true),
     );
 
     assert_eq!(result.status, "pass");

--- a/src/manifest/search/core.rs
+++ b/src/manifest/search/core.rs
@@ -691,7 +691,6 @@ impl ManifestSearchHandle {
         let notify = Arc::new(Notify::new());
         let refresh_stats = Arc::new(RwLock::new(RefreshStats::default()));
         let config_arc = Arc::new(RwLock::new(config.clone()));
-        let should_refresh = config.manifest_refresh_secs > 0 && !config.storage_read_only;
 
         let state_clone = state.clone();
         let notify_clone = notify.clone();
@@ -712,21 +711,19 @@ impl ManifestSearchHandle {
             notify_clone.notify_waiters();
         });
 
-        if should_refresh {
-            let refresh_state_handle = state.clone();
-            let refresh_notify = notify.clone();
-            let refresh_stats_shared = refresh_stats.clone();
-            let refresh_config = config_arc.clone();
-            tokio::spawn(async move {
-                refresh_loop(
-                    refresh_state_handle,
-                    refresh_notify,
-                    refresh_stats_shared,
-                    refresh_config,
-                )
-                .await;
-            });
-        }
+        let refresh_state_handle = state.clone();
+        let refresh_notify = notify.clone();
+        let refresh_stats_shared = refresh_stats.clone();
+        let refresh_config = config_arc.clone();
+        tokio::spawn(async move {
+            refresh_loop(
+                refresh_state_handle,
+                refresh_notify,
+                refresh_stats_shared,
+                refresh_config,
+            )
+            .await;
+        });
 
         Self {
             state,
@@ -867,11 +864,6 @@ impl ManifestSearchHandle {
 
         let bootstrap_resolution = prepare_runtime_config_for_reload(&mut next)?;
 
-        {
-            let mut guard = self.config.write().await;
-            *guard = next.clone();
-        }
-
         let active = {
             let mut guard = self.state.write().await;
             match &*guard {
@@ -903,6 +895,7 @@ impl ManifestSearchHandle {
         let state_clone = self.state.clone();
         let notify_clone = self.notify.clone();
         let refresh_stats_clone = self.refresh_stats.clone();
+        let config_clone = self.config.clone();
         tokio::spawn(async move {
             {
                 let mut refresh_stats_guard = refresh_stats_clone.write().await;
@@ -920,6 +913,10 @@ impl ManifestSearchHandle {
             let mut guard = state_clone.write().await;
             match result {
                 Ok(loaded) => {
+                    {
+                        let mut config_guard = config_clone.write().await;
+                        *config_guard = next;
+                    }
                     *guard = ManifestSearchState::Ready(Arc::new(loaded.search));
                     let mut refresh_stats_guard = refresh_stats_clone.write().await;
                     refresh_stats_guard.successes += 1;

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -370,9 +370,6 @@ fn apply_mcp_next_offset_meta(
     config: &DbtNovaConfig,
     pagination: Option<&PaginationParams>,
 ) {
-    if !config.mcp_include_truncation_meta {
-        return;
-    }
     let Some(pagination) = pagination else {
         return;
     };
@@ -409,9 +406,13 @@ fn apply_mcp_next_offset_meta(
         "next_offset".to_string(),
         serde_json::Value::from(next_offset),
     );
-    meta.entry("truncated".to_string())
-        .or_insert_with(|| serde_json::Value::from(truncated));
-    update_result_meta_response_bytes(value);
+    if config.mcp_include_truncation_meta || had_result_meta {
+        meta.entry("truncated".to_string())
+            .or_insert_with(|| serde_json::Value::from(truncated));
+    }
+    if had_result_meta {
+        update_result_meta_response_bytes(value);
+    }
     let mut refresh_response_bytes = false;
     if config.mcp_max_response_bytes > 0
         && serialized_len(value) > config.mcp_max_response_bytes
@@ -2896,6 +2897,39 @@ mod tests {
         assert_eq!(
             payload["_nova_result_meta"]["next_offset"],
             serde_json::json!(4)
+        );
+    }
+
+    #[test]
+    fn mcp_pagination_meta_survives_when_truncation_meta_disabled() {
+        let config = crate::config::DbtNovaConfig {
+            mcp_max_response_bytes: 0,
+            mcp_include_truncation_meta: false,
+            ..Default::default()
+        };
+        let response = serde_json::json!({
+            "success": true,
+            "count": 2,
+            "total_available": 5,
+            "truncated": true,
+            "data": [{"unique_id": "model.pkg.a"}, {"unique_id": "model.pkg.b"}]
+        });
+        let pagination = PaginationParams {
+            limit: Some(2),
+            offset: 2,
+        };
+
+        let serialized = DbtNovaServer::serialize_budgeted_value_with_pagination(
+            response,
+            &config,
+            Some(&pagination),
+        )
+        .expect("serialize response");
+        let payload: serde_json::Value = serde_json::from_str(&serialized).expect("response JSON");
+
+        assert_eq!(
+            payload["_nova_result_meta"],
+            serde_json::json!({"next_offset": 4})
         );
     }
 

--- a/src/tests/find_by_path.rs
+++ b/src/tests/find_by_path.rs
@@ -148,7 +148,7 @@ async fn test_find_by_path_respects_limit() {
         result
             .get("total_available")
             .and_then(serde_json::Value::as_u64),
-        Some(6)
+        Some(13)
     );
 }
 

--- a/src/tests/metadata_score.rs
+++ b/src/tests/metadata_score.rs
@@ -192,6 +192,42 @@ async fn test_metadata_score_project_scope_offset_pages_results() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_metadata_score_project_aggregate_is_page_stable() {
+    let searcher = get_searcher();
+    let page_one = GetMetadataScoreParams {
+        scope: Some("project".to_string()),
+        include_breakdown: false,
+        include_recommendations: false,
+        resource_types: vec!["model".to_string()],
+        limit: Some(1),
+        offset: Some(0),
+        ..Default::default()
+    };
+    let page_two = GetMetadataScoreParams {
+        scope: Some("project".to_string()),
+        include_breakdown: false,
+        include_recommendations: false,
+        resource_types: vec!["model".to_string()],
+        limit: Some(1),
+        offset: Some(1),
+        ..Default::default()
+    };
+
+    let result1 = searcher.get_metadata_score(&page_one).await.json();
+    let result2 = searcher.get_metadata_score(&page_two).await.json();
+
+    assert_eq!(
+        result1["data"]["overall_score"], result2["data"]["overall_score"],
+        "Project aggregate score should not depend on the entity sample page"
+    );
+    assert_eq!(result1["data"]["summary"]["scope"], json!("all_entities"));
+    assert_eq!(
+        result1["data"]["summary"]["sample_truncated"].as_bool(),
+        Some(true)
+    );
+}
+
 #[test]
 fn test_description_tier_scoring() {
     assert_eq!(description_tier_score("", 30), 0);

--- a/src/tests/modeling.rs
+++ b/src/tests/modeling.rs
@@ -315,6 +315,10 @@ async fn test_agent_modelling_findings_cover_indicator_queryability_and_grain_ru
         Some(false)
     );
     assert_eq!(
+        not_queryable["evidence"]["direct_sql_queryable"].as_bool(),
+        Some(false)
+    );
+    assert_eq!(
         not_queryable["evidence"]["queryable_via"].as_str(),
         Some("none")
     );
@@ -433,6 +437,10 @@ async fn test_agent_modelling_findings_cover_indicator_queryability_and_grain_ru
     assert_eq!(
         metadata_only_ratio["evidence"]["execution_surface"].as_str(),
         Some("metadata_only")
+    );
+    assert_eq!(
+        metadata_only_ratio["evidence"]["direct_sql_queryable"].as_bool(),
+        Some(false)
     );
 
     let cross_grain = finding_for_entity(
@@ -594,6 +602,58 @@ async fn test_modelling_consistency_report_can_disable_agent_modelling_audit() {
         data["duplicate_indicators"]
             .as_array()
             .is_some_and(|rows| !rows.is_empty())
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_modelling_consistency_report_truncates_agent_modelling_findings() {
+    let manifest_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/agent_modelling_findings.json");
+    let guard = tempfile::TempDir::new().expect("test temp dir");
+    let mut config = DbtNovaConfig {
+        manifest_path: manifest_path.to_string_lossy().to_string(),
+        search: SearchConfig {
+            enable_vector_search: false,
+            enable_sparse_search: false,
+            enable_reranker: false,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    config.storage_dir = guard.path().to_string_lossy().to_string();
+    config.storage_instance_id = "tests-audit-truncated".to_string();
+    config.storage_max_instances = 1;
+    config.cleanup_storage_on_start = true;
+    config.agent_modelling_audit.max_findings = 1;
+    let searcher = ManifestSearch::new(config)
+        .expect("Failed to load fixture manifest")
+        .search;
+
+    let result = searcher
+        .modelling_consistency_report(&ModellingConsistencyReportParams {
+            resource_types: vec![],
+            pagination: PaginationParams {
+                limit: Some(100),
+                offset: 0,
+            },
+            min_score: None,
+        })
+        .await
+        .json();
+
+    let data = result.get("data").expect("data");
+    let findings = data["agent_modelling_findings"]
+        .as_array()
+        .expect("agent modelling findings");
+    assert_eq!(findings.len(), 1);
+    assert!(
+        data["agent_modelling_finding_count"]
+            .as_u64()
+            .is_some_and(|count| count > 1)
+    );
+    assert_eq!(
+        data["summary"]["agent_modelling"]["truncated"].as_bool(),
+        Some(true)
     );
 }
 

--- a/src/tools/entity.rs
+++ b/src/tools/entity.rs
@@ -157,51 +157,50 @@ impl ManifestSearch {
         let ids: Vec<String> = params.unique_ids.clone();
 
         let detail = self.detail_level(params.detail);
-        let store = self.entities.clone();
-        let results: Vec<(String, Option<JsonValue>)> = tokio::task::spawn_blocking(move || {
-            ids.par_iter()
-                .map(|id| {
-                    let payload = match store.get_archived(id)? {
-                        Some(entity) => {
-                            let json = serde_json::from_str(entity.payload_json())
-                                .unwrap_or(JsonValue::Null);
-                            Some(json)
-                        }
-                        None => None,
-                    };
-                    Ok((id.clone(), payload))
-                })
-                .collect::<Result<Vec<_>>>()
-        })
-        .await
-        .map_err(|err| DbtNovaError::ServerError(err.to_string()))??;
-
         let mut found: Vec<JsonValue> = Vec::new();
         let mut not_found: Vec<String> = Vec::new();
 
-        for (id, entity_json) in results {
-            if let Some(entity_json) = entity_json {
-                match detail {
-                    DetailLevel::Full => {
-                        found.push(ManifestSearch::with_unique_id(entity_json, &id));
-                    }
-                    DetailLevel::Compact => {
-                        if let Some(entity) = self.get_entity_archived(&id)? {
-                            found.push(self.summary_for_compact(&id, entity));
-                        } else {
-                            not_found.push(id);
-                        }
-                    }
-                    DetailLevel::Standard => {
-                        if let Some(entity) = self.get_entity_archived(&id)? {
-                            found.push(self.summary_for_standard(&id, entity));
-                        } else {
-                            not_found.push(id);
-                        }
-                    }
+        if detail == DetailLevel::Full {
+            let store = self.entities.clone();
+            let results: Vec<(String, Option<JsonValue>)> =
+                tokio::task::spawn_blocking(move || {
+                    ids.par_iter()
+                        .map(|id| {
+                            let payload = match store.get_archived(id)? {
+                                Some(entity) => {
+                                    let json = serde_json::from_str(entity.payload_json())
+                                        .unwrap_or(JsonValue::Null);
+                                    Some(json)
+                                }
+                                None => None,
+                            };
+                            Ok((id.clone(), payload))
+                        })
+                        .collect::<Result<Vec<_>>>()
+                })
+                .await
+                .map_err(|err| DbtNovaError::ServerError(err.to_string()))??;
+
+            for (id, entity_json) in results {
+                if let Some(entity_json) = entity_json {
+                    found.push(ManifestSearch::with_unique_id(entity_json, &id));
+                } else {
+                    not_found.push(id);
                 }
-            } else {
-                not_found.push(id);
+            }
+        } else {
+            for id in ids {
+                if let Some(entity) = self.get_entity_archived(&id)? {
+                    match detail {
+                        DetailLevel::Compact => found.push(self.summary_for_compact(&id, entity)),
+                        DetailLevel::Standard => found.push(self.summary_for_standard(&id, entity)),
+                        DetailLevel::Full => {
+                            unreachable!("full detail is handled by the parallel payload path")
+                        }
+                    }
+                } else {
+                    not_found.push(id);
+                }
             }
         }
 

--- a/src/tools/metadata_score/entry/mod.rs
+++ b/src/tools/metadata_score/entry/mod.rs
@@ -94,24 +94,24 @@ impl ManifestSearch {
 
         let mut entity_scores = Vec::new();
         let mut total_scores = Vec::new();
-        let mut count = 0usize;
         let limit = params.limit.unwrap_or(DEFAULT_METADATA_SCORE_LIMIT);
         let offset = params.offset.unwrap_or(0);
-        let mut total_available = 0usize;
         let mut coverage = CoverageAggregate::default();
         let mut project_summary = ProjectScoreSummaryBuilder::default();
         let mut ordered_entity_ids = Vec::new();
 
         for resource_type in &resource_types {
             if let Some(entities) = self.by_resource_type.get(resource_type) {
-                total_available += entities.len();
                 let mut sorted_entities = entities.clone();
                 sorted_entities.sort_unstable();
                 ordered_entity_ids.extend(sorted_entities);
             }
         }
 
-        for entity_id in ordered_entity_ids.into_iter().skip(offset).take(limit) {
+        let total_available = ordered_entity_ids.len();
+        let mut scored_count = 0usize;
+
+        for (entity_index, entity_id) in ordered_entity_ids.into_iter().enumerate() {
             if let Some(entity) = self.get_entity_archived(&entity_id)? {
                 let entity_json = entity.to_json_value();
                 let score = self.score_entity(
@@ -133,21 +133,24 @@ impl ManifestSearch {
                     categories: &score.categories,
                     recommendations: &score.recommendations,
                 });
-                entity_scores.push(serde_json::json!({
-                    "unique_id": entity_id,
-                    "name": entity.name_str(),
-                    "resource_type": entity.resource_type_str(),
-                    "overall_score": score.overall_score,
-                    "grade": score.grade
-                }));
-                count += 1;
+                if entity_index >= offset && entity_scores.len() < limit {
+                    entity_scores.push(serde_json::json!({
+                        "unique_id": entity_id,
+                        "name": entity.name_str(),
+                        "resource_type": entity.resource_type_str(),
+                        "overall_score": score.overall_score,
+                        "grade": score.grade
+                    }));
+                }
+                scored_count += 1;
             }
         }
 
         let avg_overall = average_score(total_scores.into_iter().map(Some));
+        let count = entity_scores.len();
         let scanned = offset.saturating_add(count);
-        let truncated = scanned < total_available;
-        let quality_summary = coverage.build_summary(count, total_available, truncated);
+        let page_truncated = scanned < total_available;
+        let quality_summary = coverage.build_summary(scored_count, total_available, false);
         let response = serde_json::json!({
             "scope": "project",
             "persona": persona,
@@ -159,18 +162,18 @@ impl ManifestSearch {
             "quality_summary": quality_summary,
             "summary": project_summary.build(ProjectSummaryContext {
                 persona,
-                entities: count,
+                entities: scored_count,
                 total_available,
                 limit,
                 offset,
-                truncated,
-                next_offset: truncated.then_some(scanned),
+                page_truncated,
+                next_offset: page_truncated.then_some(scanned),
             }),
             "scoring_contract": metadata_score_scoring_contract()
         });
 
         let mut response = SuccessResponse::new(response, count).with_total(total_available);
-        if truncated {
+        if page_truncated {
             response = response.with_truncated(true);
         }
         Ok(serde_json::to_value(response)?)
@@ -316,10 +319,11 @@ impl ProjectScoreSummaryBuilder {
             .collect::<Vec<_>>();
 
         serde_json::json!({
-            "scope": if context.truncated { "included_entities" } else { "all_entities" },
+            "scope": "all_entities",
             "entities": context.entities,
             "entities_total": context.total_available,
-            "truncated": context.truncated,
+            "truncated": false,
+            "sample_truncated": context.page_truncated,
             "page": {
                 "limit": context.limit,
                 "offset": context.offset,
@@ -342,7 +346,7 @@ struct ProjectSummaryContext<'a> {
     total_available: usize,
     limit: usize,
     offset: usize,
-    truncated: bool,
+    page_truncated: bool,
     next_offset: Option<usize>,
 }
 

--- a/src/tools/modeling.rs
+++ b/src/tools/modeling.rs
@@ -20,6 +20,8 @@ use crate::utils::tokenize_alnum_lowercase;
 
 const AGENT_MODELLING_SCHEMA_VERSION: &str = "agent_modelling.v1";
 const AGENT_MODELLING_TOP_BUCKETS: usize = 5;
+const MAX_OVERLAP_BUCKET_SIZE: usize = 512;
+const MAX_OVERLAP_CANDIDATE_PAIRS: usize = 250_000;
 const AGENT_MODELLING_SEVERITY_ORDER: [AgentModellingSeverity; 4] = [
     AgentModellingSeverity::Blocker,
     AgentModellingSeverity::High,
@@ -75,7 +77,8 @@ impl ManifestSearch {
             .transpose()?;
 
         let profiles = self.collect_overlap_profiles(resource_filter.as_ref())?;
-        let mut rows = overlap_rows(&profiles, focus_unique_id.as_deref());
+        let overlap_result = overlap_rows(&profiles, focus_unique_id.as_deref());
+        let mut rows = overlap_result.rows;
         if let Some(min_score) = params.min_score {
             rows.retain(|row| row.score >= min_score);
         }
@@ -92,7 +95,7 @@ impl ManifestSearch {
             .map_err(|error| DbtNovaError::ServerError(error.to_string()))?;
         let count = results.len();
         let mut response = SuccessResponse::new(results, count).with_total(total);
-        if total > end {
+        if total > end || overlap_result.candidate_pairs_truncated {
             response = response.with_truncated(true);
         }
         Ok(serde_json::to_value(response)?)
@@ -119,38 +122,31 @@ impl ManifestSearch {
         let section_limit = self.page_limit(params.pagination.limit);
         let section_offset = params.pagination.offset;
 
-        let mut overlap_rows_all = overlap_rows(&profiles, None);
+        let overlap_result = overlap_rows(&profiles, None);
+        let overlap_candidate_generation_truncated = overlap_result.candidate_pairs_truncated;
+        let mut overlap_rows_all = overlap_result.rows;
         if let Some(min_score) = params.min_score {
             overlap_rows_all.retain(|row| row.score >= min_score);
         }
         let overlap_count = overlap_rows_all.len();
-        let overlap = paginate_section(overlap_rows_all.clone(), section_offset, section_limit);
+        let overlap = paginate_section(&overlap_rows_all, section_offset, section_limit);
 
         let duplicate_indicator_rows = duplicate_indicator_rows(&profiles, usize::MAX);
         let duplicate_indicator_count = duplicate_indicator_rows.len();
-        let duplicate_indicators = paginate_section(
-            duplicate_indicator_rows.clone(),
-            section_offset,
-            section_limit,
-        );
+        let duplicate_indicators =
+            paginate_section(&duplicate_indicator_rows, section_offset, section_limit);
         let canonical_conflict_rows: Vec<DuplicateIndicatorRow> = duplicate_indicator_rows
             .iter()
             .filter(|row| row.canonical_parent_count > 1)
             .cloned()
             .collect();
         let canonical_conflict_count = canonical_conflict_rows.len();
-        let canonical_conflicts = paginate_section(
-            canonical_conflict_rows.clone(),
-            section_offset,
-            section_limit,
-        );
+        let canonical_conflicts =
+            paginate_section(&canonical_conflict_rows, section_offset, section_limit);
         let multi_grain_entity_rows_all = multi_grain_entity_rows(&profiles);
         let multi_grain_entity_count = multi_grain_entity_rows_all.len();
-        let multi_grain_entities = paginate_section(
-            multi_grain_entity_rows_all.clone(),
-            section_offset,
-            section_limit,
-        );
+        let multi_grain_entities =
+            paginate_section(&multi_grain_entity_rows_all, section_offset, section_limit);
         let mut agent_modelling_findings_all = if self.config.agent_modelling_audit.enabled {
             build_agent_modelling_findings(
                 self,
@@ -175,6 +171,7 @@ impl ManifestSearch {
             ModellingReportPage {
                 limit: section_limit,
                 offset: section_offset,
+                overlap_candidate_generation_truncated,
             },
             &overlap_rows_all,
             &duplicate_indicator_rows,
@@ -430,10 +427,21 @@ struct EntityOverlapProfile {
     grain_variants: Vec<GrainVariant>,
 }
 
+struct OverlapRowsResult {
+    rows: Vec<EntityOverlapRow>,
+    candidate_pairs_truncated: bool,
+}
+
+struct CandidatePairs {
+    pairs: BTreeSet<(usize, usize)>,
+    truncated: bool,
+}
+
 #[derive(Debug, Clone, Copy)]
 struct ModellingReportPage {
     limit: usize,
     offset: usize,
+    overlap_candidate_generation_truncated: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -777,19 +785,15 @@ fn compare_entity_grains(
 fn overlap_rows(
     profiles: &[EntityOverlapProfile],
     focus_unique_id: Option<&str>,
-) -> Vec<EntityOverlapRow> {
-    let candidate_pairs = overlap_candidate_pairs(profiles);
+) -> OverlapRowsResult {
+    let focus_index = focus_unique_id
+        .and_then(|unique_id| profiles.iter().position(|p| p.unique_id == unique_id));
+    let candidate_pairs = overlap_candidate_pairs(profiles, focus_index);
     let mut rows = Vec::new();
 
-    for (left_index, right_index) in candidate_pairs {
+    for (left_index, right_index) in candidate_pairs.pairs {
         let left = &profiles[left_index];
         let right = &profiles[right_index];
-        if let Some(focus_unique_id) = focus_unique_id
-            && left.unique_id != focus_unique_id
-            && right.unique_id != focus_unique_id
-        {
-            continue;
-        }
         let evidence = overlap_evidence(left, right);
         let surface_overlap_count = evidence.surface_overlap_count();
         if surface_overlap_count == 0 {
@@ -808,10 +812,16 @@ fn overlap_rows(
     }
 
     rows.sort_by(compare_overlap_rows);
-    rows
+    OverlapRowsResult {
+        rows,
+        candidate_pairs_truncated: candidate_pairs.truncated,
+    }
 }
 
-fn overlap_candidate_pairs(profiles: &[EntityOverlapProfile]) -> BTreeSet<(usize, usize)> {
+fn overlap_candidate_pairs(
+    profiles: &[EntityOverlapProfile],
+    focus_index: Option<usize>,
+) -> CandidatePairs {
     let mut buckets: BTreeMap<String, Vec<usize>> = BTreeMap::new();
 
     for (index, profile) in profiles.iter().enumerate() {
@@ -821,14 +831,59 @@ fn overlap_candidate_pairs(profiles: &[EntityOverlapProfile]) -> BTreeSet<(usize
     }
 
     let mut pairs = BTreeSet::new();
-    for indices in buckets.into_values() {
+    let mut truncated = false;
+    for mut indices in buckets.into_values() {
+        indices.sort_unstable();
+
+        if let Some(focus_index) = focus_index {
+            if !indices.contains(&focus_index) {
+                continue;
+            }
+            if indices.len() > MAX_OVERLAP_BUCKET_SIZE {
+                truncated = true;
+            }
+            for other_index in indices
+                .into_iter()
+                .filter(|index| *index != focus_index)
+                .take(MAX_OVERLAP_BUCKET_SIZE.saturating_sub(1))
+            {
+                pairs.insert(ordered_pair(focus_index, other_index));
+                if pairs.len() >= MAX_OVERLAP_CANDIDATE_PAIRS {
+                    return CandidatePairs {
+                        pairs,
+                        truncated: true,
+                    };
+                }
+            }
+            continue;
+        }
+
+        if indices.len() > MAX_OVERLAP_BUCKET_SIZE {
+            indices.truncate(MAX_OVERLAP_BUCKET_SIZE);
+            truncated = true;
+        }
+
         for (offset, left_index) in indices.iter().enumerate() {
             for right_index in indices.iter().skip(offset + 1) {
                 pairs.insert((*left_index, *right_index));
+                if pairs.len() >= MAX_OVERLAP_CANDIDATE_PAIRS {
+                    return CandidatePairs {
+                        pairs,
+                        truncated: true,
+                    };
+                }
             }
         }
     }
-    pairs
+    CandidatePairs { pairs, truncated }
+}
+
+fn ordered_pair(left: usize, right: usize) -> (usize, usize) {
+    if left <= right {
+        (left, right)
+    } else {
+        (right, left)
+    }
 }
 
 fn overlap_bucket_keys(profile: &EntityOverlapProfile) -> BTreeSet<String> {
@@ -1076,6 +1131,8 @@ fn build_modelling_consistency_summary(
         page.limit,
         page.offset,
         overlap_rows,
+        duplicate_indicator_rows,
+        canonical_conflict_rows,
         multi_grain_entity_rows,
     )
     .then_some(page.offset.saturating_add(page.limit));
@@ -1095,14 +1152,15 @@ fn build_modelling_consistency_summary(
         "page": {
             "limit": page.limit,
             "offset": page.offset,
-            "next_offset": next_offset
+            "next_offset": next_offset,
+            "overlap_candidate_generation_truncated": page.overlap_candidate_generation_truncated
         },
         "overlap_evidence_categories": overlap_evidence_categories,
         "overlap_examples": overlap_examples,
         "top_duplicate_indicator_groups": top_duplicate_indicator_groups,
         "top_canonical_conflicts": top_canonical_conflicts,
         "top_multi_grain_entities": top_multi_grain_entities,
-        "drill_down_hints": modelling_drill_down_hints(params, page.limit, page.offset, overlap_rows, multi_grain_entity_rows)
+        "drill_down_hints": modelling_drill_down_hints(params, page.limit, page.offset, overlap_rows, duplicate_indicator_rows, canonical_conflict_rows, multi_grain_entity_rows)
     })
 }
 
@@ -1435,6 +1493,7 @@ fn collect_indicator_parent_not_queryable_findings(
             evidence: json!({
                 "execution_surface": execution.as_str(),
                 "queryable": execution.queryable(),
+                "direct_sql_queryable": execution.direct_sql_queryable(),
                 "queryable_via": execution.queryable_via()
             }),
             recommendation: "Move the indicator to a queryable dbt model, expose it through dbt Semantic Layer / MetricFlow, or mark the entity as non-analyst-facing.".to_string(),
@@ -1711,6 +1770,7 @@ fn collect_single_metric_cross_grain_findings(
                 "ratio_signals": ratio_signals,
                 "execution_surface": execution.as_str(),
                 "queryable": execution.queryable(),
+                "direct_sql_queryable": execution.direct_sql_queryable(),
                 "queryable_via": execution.queryable_via()
             }),
             recommendation: "Do not leave a ratio/cross-grain KPI as metadata-only. Expose a dbt model, MetricFlow metric, OSI-derived semantic artifact, recipe, or saved query.".to_string(),
@@ -2111,6 +2171,10 @@ impl IndicatorExecutionSurface {
 
     fn queryable(self) -> bool {
         !matches!(self, Self::MetadataOnly)
+    }
+
+    fn direct_sql_queryable(self) -> bool {
+        matches!(self, Self::Relation)
     }
 
     fn queryable_via(self) -> &'static str {
@@ -3106,6 +3170,8 @@ fn modelling_drill_down_hints(
     section_limit: usize,
     section_offset: usize,
     overlap_rows: &[EntityOverlapRow],
+    duplicate_indicator_rows: &[DuplicateIndicatorRow],
+    canonical_conflict_rows: &[DuplicateIndicatorRow],
     multi_grain_entity_rows: &[MultiGrainEntityRow],
 ) -> Vec<JsonValue> {
     let mut hints = Vec::new();
@@ -3113,6 +3179,8 @@ fn modelling_drill_down_hints(
         section_limit,
         section_offset,
         overlap_rows,
+        duplicate_indicator_rows,
+        canonical_conflict_rows,
         multi_grain_entity_rows,
     ) {
         hints.push(json!({
@@ -3156,11 +3224,18 @@ fn modelling_has_next_page(
     section_limit: usize,
     section_offset: usize,
     overlap_rows: &[EntityOverlapRow],
+    duplicate_indicator_rows: &[DuplicateIndicatorRow],
+    canonical_conflict_rows: &[DuplicateIndicatorRow],
     multi_grain_entity_rows: &[MultiGrainEntityRow],
 ) -> bool {
-    [overlap_rows.len(), multi_grain_entity_rows.len()]
-        .into_iter()
-        .any(|total| section_offset.saturating_add(section_limit) < total)
+    [
+        overlap_rows.len(),
+        duplicate_indicator_rows.len(),
+        canonical_conflict_rows.len(),
+        multi_grain_entity_rows.len(),
+    ]
+    .into_iter()
+    .any(|total| section_offset.saturating_add(section_limit) < total)
 }
 
 fn grain_signature_key(grain: &GrainVariant) -> String {
@@ -3318,8 +3393,8 @@ fn compare_duplicate_indicator_rows(
         .then_with(|| left.indicator_name.cmp(&right.indicator_name))
 }
 
-fn paginate_section<T>(rows: Vec<T>, offset: usize, limit: usize) -> Vec<T> {
-    rows.into_iter().skip(offset).take(limit).collect()
+fn paginate_section<T: Clone>(rows: &[T], offset: usize, limit: usize) -> Vec<T> {
+    rows.iter().skip(offset).take(limit).cloned().collect()
 }
 
 #[cfg(test)]
@@ -3369,6 +3444,36 @@ mod tests {
             column_semantic_types: BTreeSet::new(),
             grain_variants,
         }
+    }
+
+    fn duplicate_indicator_row(name: &str) -> DuplicateIndicatorRow {
+        DuplicateIndicatorRow {
+            indicator_name: name.to_string(),
+            indicator_type: "metric".to_string(),
+            parent_count: 2,
+            canonical_parent_count: 0,
+            parents_without_grain: 0,
+            inconsistent_grains: false,
+            parents: Vec::new(),
+            grain_signatures: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn modelling_next_page_accounts_for_duplicate_sections() {
+        let duplicate_rows = vec![
+            duplicate_indicator_row("revenue"),
+            duplicate_indicator_row("orders"),
+        ];
+
+        assert!(modelling_has_next_page(
+            1,
+            0,
+            &[],
+            &duplicate_rows,
+            &[],
+            &[],
+        ));
     }
 
     fn profile_with_indicator(
@@ -3657,9 +3762,10 @@ mod tests {
             profile_with("model.pkg.other", &["promotion_id"], vec![]),
         ];
 
-        let pairs = overlap_candidate_pairs(&profiles);
-        assert!(pairs.contains(&(0, 1)));
-        assert!(!pairs.contains(&(0, 2)));
+        let pairs = overlap_candidate_pairs(&profiles, None);
+        assert!(pairs.pairs.contains(&(0, 1)));
+        assert!(!pairs.pairs.contains(&(0, 2)));
+        assert!(!pairs.truncated);
     }
 
     #[test]

--- a/src/tools/path.rs
+++ b/src/tools/path.rs
@@ -9,6 +9,13 @@ use crate::responses::SuccessResponse;
 use crate::utils::{compile_glob, glob_match_compiled};
 use tracing::instrument;
 
+struct PathMatch {
+    unique_id: String,
+    sort_path: String,
+    original_path: String,
+    manifest_path: String,
+}
+
 impl ManifestSearch {
     /// Find entities by file path pattern.
     ///
@@ -40,12 +47,9 @@ impl ManifestSearch {
         let detail = self.detail_level(params.detail);
         let limit = self.page_limit(params.pagination.limit);
         let offset = params.pagination.offset;
-        let match_scan_cap = offset.saturating_add(limit);
 
-        let mut result_rows: Vec<JsonValue> = Vec::new();
+        let mut path_matches: Vec<PathMatch> = Vec::new();
         let mut seen: HashSet<String> = HashSet::new();
-        let mut skipped = 0usize;
-        let mut total_matches = 0usize;
 
         for unique_id in candidates {
             if !seen.insert(unique_id.clone()) {
@@ -84,65 +88,67 @@ impl ManifestSearch {
             };
 
             if let Some(matched_path) = matched_path {
-                total_matches += 1;
-                if total_matches > match_scan_cap {
-                    break;
-                }
-                if skipped < offset {
-                    skipped += 1;
-                    continue;
-                }
-
-                if result_rows.len() >= limit {
-                    continue;
-                }
-
-                if detail == DetailLevel::Full {
-                    result_rows.push(ManifestSearch::with_unique_id(entity_json, &unique_id));
+                let output_path = if original_path.is_empty() {
+                    matched_path.to_string()
                 } else {
-                    let archived = self.get_entity_archived(&unique_id)?;
-                    let mut summary = if detail == DetailLevel::Compact {
-                        archived.map_or(JsonValue::Null, |entity| {
-                            self.summary_for_compact(&unique_id, entity)
-                        })
-                    } else {
-                        self.entity_summary(&unique_id).unwrap_or(JsonValue::Null)
-                    };
-                    if let Some(obj) = summary.as_object_mut() {
-                        let output_path = if original_path.is_empty() {
-                            matched_path.to_string()
-                        } else {
-                            original_path.to_string()
-                        };
-                        obj.insert(
-                            "original_file_path".to_string(),
-                            JsonValue::String(output_path),
-                        );
-                        if !manifest_path.is_empty() {
-                            obj.insert(
-                                "path".to_string(),
-                                JsonValue::String(manifest_path.to_string()),
-                            );
-                        }
-                    }
-                    result_rows.push(summary);
-                }
+                    original_path.to_string()
+                };
+                path_matches.push(PathMatch {
+                    unique_id,
+                    sort_path: output_path,
+                    original_path: original_path.to_string(),
+                    manifest_path: manifest_path.to_string(),
+                });
             }
         }
 
-        result_rows.sort_by(|a, b| {
-            let path_a = a
-                .get("original_file_path")
-                .or_else(|| a.get("path"))
-                .and_then(|p| p.as_str())
-                .unwrap_or("");
-            let path_b = b
-                .get("original_file_path")
-                .or_else(|| b.get("path"))
-                .and_then(|p| p.as_str())
-                .unwrap_or("");
-            path_a.cmp(path_b)
+        path_matches.sort_by(|left, right| {
+            left.sort_path
+                .cmp(&right.sort_path)
+                .then_with(|| left.unique_id.cmp(&right.unique_id))
         });
+
+        let total_matches = path_matches.len();
+        let mut result_rows: Vec<JsonValue> = Vec::new();
+        for path_match in path_matches.into_iter().skip(offset).take(limit) {
+            if detail == DetailLevel::Full {
+                let Some(entity) = self.get_entity(&path_match.unique_id).await? else {
+                    continue;
+                };
+                result_rows.push(ManifestSearch::with_unique_id(
+                    entity.to_json_value(),
+                    &path_match.unique_id,
+                ));
+            } else {
+                let archived = self.get_entity_archived(&path_match.unique_id)?;
+                let mut summary = if detail == DetailLevel::Compact {
+                    archived.map_or(JsonValue::Null, |entity| {
+                        self.summary_for_compact(&path_match.unique_id, entity)
+                    })
+                } else {
+                    self.entity_summary(&path_match.unique_id)
+                        .unwrap_or(JsonValue::Null)
+                };
+                if let Some(obj) = summary.as_object_mut() {
+                    let output_path = if path_match.original_path.is_empty() {
+                        path_match.sort_path
+                    } else {
+                        path_match.original_path
+                    };
+                    obj.insert(
+                        "original_file_path".to_string(),
+                        JsonValue::String(output_path),
+                    );
+                    if !path_match.manifest_path.is_empty() {
+                        obj.insert(
+                            "path".to_string(),
+                            JsonValue::String(path_match.manifest_path),
+                        );
+                    }
+                }
+                result_rows.push(summary);
+            }
+        }
 
         let count = result_rows.len();
         let mut response = SuccessResponse::new(result_rows, count).with_total(total_matches);

--- a/src/tools/undocumented.rs
+++ b/src/tools/undocumented.rs
@@ -1,6 +1,6 @@
 use serde_json::Value as JsonValue;
 
-use crate::error::Result;
+use crate::error::{DbtNovaError, Result};
 use crate::manifest::search::ManifestSearch;
 use crate::params::GetUndocumentedParams;
 use crate::responses::SuccessResponse;
@@ -14,6 +14,13 @@ impl ManifestSearch {
     #[instrument(skip(self, params), fields(tool = "get_undocumented", resource_type = %params.resource_type, limit = ?params.pagination.limit, offset = params.pagination.offset, include_columns = params.include_columns))]
     #[allow(clippy::too_many_lines)]
     pub async fn get_undocumented(&self, params: &GetUndocumentedParams) -> Result<JsonValue> {
+        if params.pagination.offset > self.config.search.max_offset {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "Offset exceeds maximum of {}",
+                self.config.search.max_offset
+            )));
+        }
+
         let resource_type = self.normalize_resource_type_key(&params.resource_type)?;
         let resource_candidates = self.by_resource_type.get(&resource_type).ok_or_else(|| {
             crate::error::DbtNovaError::ServerError(format!(
@@ -32,17 +39,12 @@ impl ManifestSearch {
 
         let mut undocumented_entities: Vec<JsonValue> = Vec::new();
         let mut undocumented_columns: Vec<JsonValue> = Vec::new();
-        let mut skipped = 0usize;
+        let mut seen_missing_items = 0usize;
         let mut total_missing_entities = 0usize;
         let mut total_missing_columns = 0usize;
-        let mut entities_truncated = false;
-        let mut columns_truncated = false;
+        let mut returned_total = 0usize;
 
         for unique_id in candidates {
-            if undocumented_entities.len() >= limit {
-                break;
-            }
-
             let Some(entity) = self.get_entity(&unique_id).await? else {
                 continue;
             };
@@ -72,13 +74,11 @@ impl ManifestSearch {
             let mut include_entity = false;
             if desc.trim().is_empty() {
                 total_missing_entities += 1;
-                if skipped < offset {
-                    skipped += 1;
-                } else if undocumented_entities.len() < limit {
+                if seen_missing_items >= offset && returned_total < limit {
                     include_entity = true;
-                } else {
-                    entities_truncated = true;
+                    returned_total += 1;
                 }
+                seen_missing_items += 1;
             }
 
             if params.include_columns
@@ -91,14 +91,14 @@ impl ManifestSearch {
                         .unwrap_or("");
                     if col_desc.trim().is_empty() {
                         total_missing_columns += 1;
-                        if undocumented_columns.len() < limit {
+                        if seen_missing_items >= offset && returned_total < limit {
                             undocumented_columns.push(serde_json::json!({
                                 "entity_unique_id": unique_id.as_str(),
                                 "column_name": col_name,
                             }));
-                        } else {
-                            columns_truncated = true;
+                            returned_total += 1;
                         }
+                        seen_missing_items += 1;
                     }
                 }
             }
@@ -119,7 +119,7 @@ impl ManifestSearch {
 
         let returned_entities = undocumented_entities.len();
         let returned_columns = undocumented_columns.len();
-        let returned_total = returned_entities.saturating_add(returned_columns);
+        let total_missing = total_missing_entities.saturating_add(total_missing_columns);
 
         let response = serde_json::json!({
             "entities": undocumented_entities,
@@ -130,16 +130,13 @@ impl ManifestSearch {
                 "columns_returned": returned_columns,
                 "items_returned": returned_total
             },
-            "columns_truncated": columns_truncated,
+            "columns_truncated": offset.saturating_add(returned_total) < total_missing
+                && total_missing_columns > returned_columns,
             "undocumented_columns": undocumented_columns,
         });
 
-        let mut response = SuccessResponse::new(response, returned_total);
-        if entities_truncated
-            || columns_truncated
-            || (undocumented_entities.len() >= limit
-                && total_missing_entities > undocumented_entities.len() + offset)
-        {
+        let mut response = SuccessResponse::new(response, returned_total).with_total(total_missing);
+        if offset.saturating_add(returned_total) < total_missing {
             response = response.with_truncated(true);
         }
         Ok(serde_json::to_value(response)?)

--- a/src/utils/tool_trace.rs
+++ b/src/utils/tool_trace.rs
@@ -1666,6 +1666,8 @@ mod tests {
 
     #[test]
     fn redact_tool_trace_file_drops_sensitive_fields_and_keeps_summary_evidence() {
+        let _env_guard = lock_env();
+        let _max_restore = EnvVarRestore::set(TRACE_MAX_BYTES_ENV, "65536");
         let trace = NamedTempFile::new().expect("trace");
         std::fs::write(
             trace.path(),

--- a/tests/path_docs.rs
+++ b/tests/path_docs.rs
@@ -31,6 +31,66 @@ async fn glob_matches_paths() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn glob_reports_exact_total_beyond_first_page() {
+    let guard = tempfile::TempDir::new().unwrap();
+    let manifest_path = guard.path().join("nova_manifest.json");
+    let mut nodes = serde_json::Map::new();
+    for index in 0..3 {
+        let unique_id = format!("model.pkg.model_{index}");
+        nodes.insert(
+            unique_id.clone(),
+            serde_json::json!({
+                "name": format!("model_{index}"),
+                "resource_type": "model",
+                "package_name": "pkg",
+                "database": "db",
+                "schema": "sch",
+                "raw_code": "select 1 as col",
+                "columns": {},
+                "tags": [],
+                "original_file_path": format!("models/model_{index}.sql"),
+                "unique_id": unique_id
+            }),
+        );
+    }
+    std::fs::write(
+        &manifest_path,
+        serde_json::to_vec(&serde_json::json!({
+            "metadata": {
+                "dbt_version": "1.10.2",
+                "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json"
+            },
+            "nodes": nodes,
+            "sources": {},
+            "macros": {},
+            "docs": {},
+            "groups": {},
+            "exposures": {},
+            "metrics": {},
+            "parent_map": {},
+            "child_map": {}
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let searcher = support_fixtures::load_manifest_path(&manifest_path).unwrap();
+    let params = FindByPathParams {
+        path_pattern: "models/**".into(),
+        resource_types: vec![],
+        detail: Some(DetailLevel::Compact),
+        pagination: PaginationParams {
+            limit: Some(1),
+            offset: 0,
+        },
+    };
+    let result = json(searcher.find_by_path(&params).await);
+    assert_eq!(result["count"].as_u64(), Some(1));
+    assert_eq!(result["total_available"].as_u64(), Some(3));
+    assert_eq!(result["truncated"].as_bool(), Some(true));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn undocumented_entities_and_columns_reported() {
     let searcher = load_fixture("undocumented.json").unwrap();
     let params = GetUndocumentedParams {
@@ -58,5 +118,47 @@ async fn undocumented_entities_and_columns_reported() {
             .get("columns_missing_docs")
             .and_then(serde_json::Value::as_u64),
         Some(2)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn undocumented_paginates_entities_and_columns_as_one_stream() {
+    let searcher = load_fixture("undocumented.json").unwrap();
+    let first_page = GetUndocumentedParams {
+        resource_type: "model".into(),
+        id_or_name: None,
+        package: None,
+        path_prefix: None,
+        include_columns: true,
+        include_full: false,
+        pagination: PaginationParams {
+            limit: Some(1),
+            offset: 0,
+        },
+    };
+    let result = json(searcher.get_undocumented(&first_page).await);
+    assert_eq!(result["count"].as_u64(), Some(1));
+    assert_eq!(result["total_available"].as_u64(), Some(3));
+    assert_eq!(result["truncated"].as_bool(), Some(true));
+    assert_eq!(
+        result["data"]["summary"]["columns_missing_docs"].as_u64(),
+        Some(2)
+    );
+
+    let second_page = GetUndocumentedParams {
+        pagination: PaginationParams {
+            limit: Some(1),
+            offset: 1,
+        },
+        ..first_page
+    };
+    let result = json(searcher.get_undocumented(&second_page).await);
+    assert_eq!(result["count"].as_u64(), Some(1));
+    assert_eq!(result["data"]["entities"].as_array().map(Vec::len), Some(0));
+    assert_eq!(
+        result["data"]["undocumented_columns"]
+            .as_array()
+            .map(Vec::len),
+        Some(1)
     );
 }


### PR DESCRIPTION
## Summary

This hardening PR fixes the P1/P2 audit findings across runtime contracts, release gates, docs freshness, eval coverage, and test hygiene.

- Hardens pagination/count contracts for path lookup, undocumented docs, modelling consistency, metadata scoring, and MCP result metadata.
- Improves runtime resilience around search reloads, entity batch summaries, overlap candidate caps, and direct SQL queryability evidence.
- Tightens schema/eval/release gates: operator validation, eval assertions for tool field values, all-suite eval CI validation, pinned model warmup defaults, OCI verification before extraction, ARM64 HTTP smoke, and safer release-tag/workflow permissions.
- Refreshes stale docs and packaged skills, including response metadata docs, metadata scoring semantics, modelling categories, tier wording, and governance/analyst evidence templates.
- Adds benchmarks and regression tests for the hardened paths.

Linear follow-up for code bloat: [JOE-604](https://linear.app/joe-broadhead/issue/JOE-604/refactor-dbt-nova-large-modules-to-reduce-code-bloat-and-ownership)

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo deny check`
- `uv run mkdocs build --strict`
- `actionlint .github/workflows/*.yml`
- `bash scripts/check_config_reference.sh`
- `bash scripts/check_dependency_watchlist.sh`
- `bash -n scripts/warm_models.sh`
- `for suite in evals/*.yml; do cargo run --locked --no-default-features -- eval validate --suite "$suite"; done`
- Targeted regression checks for path docs, eval assertions, MCP pagination metadata, metadata scoring, modelling pagination, and trace redaction isolation.