### PR TITLE
Add hosted identity design contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added design-only hosted identity and JWT threat-model docs, planned config
+  contract docs, and guardrail tests for the default-off identity milestone.
 - Added machine-checked MCP tool stability metadata, profile membership docs,
   and safety-gate posture for the canonical 53-tool catalog while preserving
   v0.0.x versioning.

--- a/docs/development/adrs.md
+++ b/docs/development/adrs.md
@@ -65,3 +65,24 @@ Metrics must reuse existing recorders where possible. Labels must stay
 privacy-safe: tool names and result classes are acceptable; query text, entity
 names, paths, user IDs, and credentials are not. Hosted metrics are still an
 operator surface and need the same proxy/network ACL as MCP.
+
+## ADR-006: Default-Off Hosted Identity
+
+**Status:** Accepted
+
+Nova may add hosted identity only as an opt-in request attribution and inbound
+authentication layer for `streamable_http`. The default remains `off`, and
+existing stdio, local CLI, and loopback development workflows must not require
+identity.
+
+The preferred sequence is design, fail-closed config skeleton,
+proxy-signed identity headers, then JWT validation only if the narrower proxy
+mode does not cover common hosted deployments. Any JWT support must validate
+issuer, audience, expiry, not-before, signature, and algorithm allowlists, and
+must treat claims as sanitized request identity only.
+
+Identity must not become tenant routing, per-entity authorization, warehouse
+credential brokering, semantic-layer authorization, or a multi-manifest control
+plane. Nova remains a one-manifest metadata bridge; authorization and policy
+enforcement stay at the authenticating proxy or hosting platform unless a
+separate, explicit design proves a narrower need.

--- a/docs/development/hosted-identity-contract.md
+++ b/docs/development/hosted-identity-contract.md
@@ -1,0 +1,96 @@
+# Hosted Identity Contract
+
+Status: planned contract for JOE-665. These settings are not implemented in the
+current runtime configuration reference.
+
+## Product Boundary
+
+Hosted identity is an optional `streamable_http` extension for request
+attribution and inbound authentication checks. It does not change Nova's core
+role as a one-manifest metadata bridge for agents.
+
+Identity is not authorization. Tool exposure remains controlled by runtime
+presets, allowlists, denylists, and explicit safety gates. Entity-level and
+warehouse-level authorization stay outside Nova.
+
+## Planned Modes
+
+| Mode | Purpose | Default |
+|---|---|---|
+| `off` | Current behavior: rely on the authenticating proxy or platform layer | Yes |
+| `proxy_signed_headers` | Verify a small signed identity envelope produced by a trusted proxy | No |
+| `jwt` | Validate bearer JWTs at the Nova HTTP boundary | No |
+
+Unknown modes fail validation. Non-off modes fail closed when required
+validation material is missing or invalid.
+
+## Planned Config Surface
+
+The names below are the design contract for future implementation. They should
+not appear in `docs/configuration/reference.md` until the runtime parser exists.
+
+| Setting | Applies to | Contract |
+|---|---|---|
+| `DBT_NOVA_AUTH_MODE` | all hosted identity | `off`, `proxy_signed_headers`, or `jwt`; default `off` |
+| `DBT_NOVA_AUTH_REQUIRED` | non-off modes | Reject unauthenticated requests when true; non-off modes should default to required |
+| `DBT_NOVA_IDENTITY_SUBJECT_CLAIM` | proxy/JWT | Claim or field used as the stable subject; required for non-off modes |
+| `DBT_NOVA_IDENTITY_EMAIL_CLAIM` | proxy/JWT | Optional email claim; sanitized and never used as an authz decision by default |
+| `DBT_NOVA_IDENTITY_NAME_CLAIM` | proxy/JWT | Optional display-name claim; sanitized |
+| `DBT_NOVA_IDENTITY_GROUPS_CLAIM` | proxy/JWT | Optional groups claim for future policy hooks; no implicit authorization |
+| `DBT_NOVA_PROXY_IDENTITY_HEADER` | proxy mode | Header carrying the identity envelope |
+| `DBT_NOVA_PROXY_SIGNATURE_HEADER` | proxy mode | Header carrying the signature |
+| `DBT_NOVA_PROXY_IDENTITY_SECRET_FILE` | proxy mode | Local file containing the verification secret |
+| `DBT_NOVA_PROXY_IDENTITY_MAX_AGE_SECS` | proxy mode | Timestamp freshness window |
+| `DBT_NOVA_JWT_ISSUER` | JWT mode | Required issuer allowlist entry |
+| `DBT_NOVA_JWT_AUDIENCE` | JWT mode | Required audience allowlist entry |
+| `DBT_NOVA_JWT_JWKS_URL` | JWT mode | HTTPS JWKS endpoint for signature verification |
+| `DBT_NOVA_JWT_ALGORITHMS` | JWT mode | Explicit algorithm allowlist; `none` is never accepted |
+| `DBT_NOVA_JWT_CLOCK_SKEW_SECS` | JWT mode | Small leeway for `exp` and `nbf` checks |
+
+Secrets and key material must not be logged or returned by `show_config`.
+Config validation should report presence and posture, not raw values.
+
+## Runtime Behavior Contract
+
+Mode `off`:
+
+- Preserve current hosted behavior.
+- Do not require identity for stdio, CLI, local server development, or loopback
+  HTTP.
+- Continue to require `DBT_NOVA_HTTP_EXPECT_AUTH_PROXY=true` for non-loopback
+  binds.
+
+Mode `proxy_signed_headers`:
+
+- Accept identity only from configured headers.
+- Verify signature and timestamp before constructing request identity.
+- Reject malformed, unsigned, stale, or oversized envelopes.
+- Treat identity as request context only.
+
+Mode `jwt`:
+
+- Require `Authorization: Bearer <token>`.
+- Validate issuer, audience, expiry, not-before, signature, and accepted
+  algorithm.
+- Reject unsigned tokens and unsupported algorithms.
+- Treat claims as sanitized request context only.
+
+## Observability Contract
+
+Identity-aware logs may include bounded `auth_mode`, request ID, and sanitized
+subject hash or subject string only after explicit review. Metrics must not add
+raw subject, email, group, token, query text, entity name, path, or credential
+labels by default.
+
+## Tests Before Implementation
+
+The implementation PRs should add failing-closed tests before enabling behavior:
+
+- Unknown mode fails validation.
+- Non-off mode without required config fails validation.
+- Stdio and CLI behavior are unchanged when mode is `off`.
+- Proxy mode rejects missing/invalid/stale signatures.
+- JWT mode rejects missing bearer token, bad issuer, bad audience, expired
+  token, not-yet-valid token, invalid signature, and unsupported algorithms.
+- Sanitized identity never leaks secrets through config, metrics, or error
+  payloads.

--- a/docs/development/hosted-identity-threat-model.md
+++ b/docs/development/hosted-identity-threat-model.md
@@ -1,0 +1,106 @@
+# Hosted Identity Threat Model
+
+Status: design contract for JOE-665. This page does not describe shipped
+runtime authentication behavior.
+
+## Current State
+
+`streamable_http` has no built-in authentication. Non-loopback hosted
+deployments must sit behind an authenticating reverse proxy or platform auth
+layer and set `DBT_NOVA_HTTP_EXPECT_AUTH_PROXY=true` only when that layer is
+actually enforcing access.
+
+The identity extension track is default-off and proxy-first. It is scoped to
+request attribution and optional inbound authentication checks for hosted HTTP.
+It must not change stdio, CLI, loopback development, or the one-manifest
+metadata-bridge model.
+
+## Assets
+
+Protect:
+
+- Manifest-derived metadata, lineage, SQL text, recipes, and readiness evidence.
+- Warehouse-backed execution paths such as `execute_sql` and `run_recipe`.
+- Operator surfaces such as config inspection, storage admin, eval execution,
+  trace writes, and manifest lifecycle controls.
+- Logs, traces, metrics, and future request identity fields.
+- Local storage and prebuilt artifacts materialized by the Nova process.
+
+## Trust Boundaries
+
+- Client to authenticating proxy or platform auth layer.
+- Proxy to Nova `streamable_http` listener.
+- Nova process to local storage, prebuilt artifact stores, and configured
+  warehouse providers.
+- Nova process to logs, metrics, and trace artifacts.
+
+Nova may trust identity only after validating the selected auth mode. A request
+identity is not a tenant boundary and is not evidence that a caller may access a
+specific entity, column, model, metric, recipe, or warehouse credential.
+
+## Threats
+
+| Threat | Required control |
+|---|---|
+| Direct internet access to Nova without proxy auth | Non-loopback bind validation plus proxy deployment requirement |
+| Spoofed proxy identity headers | Signed proxy envelope, trusted header names, timestamp/nonce bounds, and fail-closed parsing |
+| Bearer token replay or substitution | JWT issuer, audience, expiry, not-before, signature, and algorithm allowlist validation |
+| Algorithm confusion or unsigned token acceptance | Explicit accepted algorithms, reject `none`, reject unsupported key types |
+| Claim injection into logs or metrics | Sanitize and bound request identity fields; never add user IDs to Prometheus labels by default |
+| Confusing identity with authorization | Document identity as request attribution only; keep tool exposure controlled by presets/allowlists/denylists |
+| Tenant or manifest isolation by claim | Explicitly reject tenant routing and multi-manifest selection in this track |
+| Warehouse credential brokering by claim | Keep provider credentials configured out of band; no per-request credential exchange |
+| Semantic-layer authorization drift | Do not use identity claims to authorize MetricFlow/dbt Semantic Layer execution inside Nova |
+
+## Non-Goals
+
+Identity work must not add:
+
+- Tenant routing.
+- Per-entity, per-column, or per-indicator ABAC.
+- warehouse credential brokering.
+- Semantic-layer authorization.
+- A SaaS control plane.
+- Multi-manifest isolation.
+- Required identity for stdio, CLI, or loopback local development.
+
+## Request Identity
+
+If implemented, request identity is limited to sanitized attribution context:
+
+- Stable subject.
+- Optional display name.
+- Optional email when explicitly configured.
+- Optional groups or roles only for future policy hooks, not implicit
+  authorization.
+- Issuer or proxy source.
+- Authentication mode.
+
+Request identity may appear in structured logs or audit events only after
+redaction, length limits, and cardinality review. It must not become a
+Prometheus label by default.
+
+## Fail-Closed Rules
+
+Nova must reject startup or requests when:
+
+- An unknown auth mode is configured.
+- A non-off auth mode lacks required validation material.
+- A proxy-signed header envelope has an invalid signature, stale timestamp, or
+  malformed identity body.
+- JWT mode receives a missing bearer token, invalid issuer, invalid audience,
+  expired token, not-yet-valid token, unsupported algorithm, invalid signature,
+  or missing required subject claim.
+
+Mode `off` preserves current behavior: Nova relies on the external proxy or
+platform layer and does not construct request identity.
+
+## Sequencing
+
+1. JOE-665: accept this threat model and default-off hosted identity design.
+2. JOE-662: add a fail-closed config skeleton without changing effective
+   runtime behavior for mode `off`.
+3. JOE-663: implement proxy-signed identity headers if the design remains
+   valid.
+4. JOE-664: implement JWT validation only after the skeleton and proxy mode are
+   reviewed.

--- a/docs/operations/hosted-deployment.md
+++ b/docs/operations/hosted-deployment.md
@@ -9,6 +9,12 @@ Hosted `streamable_http` mode has no built-in authentication or authorization.
 If you expose it beyond loopback, you must place it behind an authenticating
 reverse proxy or platform auth layer first.
 
+Default-off hosted identity and JWT validation are being designed separately.
+The current runtime still relies on the proxy or platform layer for
+authentication. See
+[Hosted Identity Threat Model](../development/hosted-identity-threat-model.md)
+and [Hosted Identity Contract](../development/hosted-identity-contract.md).
+
 ## Admin Tool Exposure
 
 MCP/CLI parity includes operator/admin tools such as `show_config`,

--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -54,6 +54,13 @@ it is privacy-safe by label design, but still exposes readiness, tool names,
 call counts, error counts, and latency. Restrict scrapes with the same
 proxy/network ACL as MCP, or set `DBT_NOVA_METRICS_ENABLED=false`.
 
+Hosted identity and JWT validation are design-track work, not current runtime
+behavior. See [Hosted Identity Threat Model](../development/hosted-identity-threat-model.md)
+and [Hosted Identity Contract](../development/hosted-identity-contract.md) for
+the default-off, proxy-first boundaries. Until an implementation lands, treat
+the reverse proxy or platform auth layer as the authentication and
+authorization boundary.
+
 Some tools read from the server filesystem. `validate_nova_meta` validates dbt
 YAML under the server working directory and rejects absolute or traversal paths
 outside the selected project, but callers still control which in-scope project

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,6 +151,8 @@ nav:
   - Development:
     - Architecture: development/architecture.md
     - Architecture Decisions: development/adrs.md
+    - Hosted Identity Threat Model: development/hosted-identity-threat-model.md
+    - Hosted Identity Contract: development/hosted-identity-contract.md
     - Module Size Ratchet: development/module-size-ratchet.md
     - Negative Results Log: development/negative-results.md
     - Agent Tokenomics Plan: development/agent-tokenomics-plan.md

--- a/tests/hosted_identity_docs.rs
+++ b/tests/hosted_identity_docs.rs
@@ -1,0 +1,47 @@
+use std::fs;
+use std::path::Path;
+
+fn read_doc(path: &str) -> String {
+    fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join(path))
+        .unwrap_or_else(|error| panic!("failed to read {path}: {error}"))
+}
+
+#[test]
+fn hosted_identity_docs_lock_default_off_guardrails() {
+    let threat_model = read_doc("docs/development/hosted-identity-threat-model.md");
+    let contract = read_doc("docs/development/hosted-identity-contract.md");
+    let adrs = read_doc("docs/development/adrs.md");
+
+    for required in [
+        "default-off",
+        "proxy-first",
+        "one-manifest metadata bridge",
+        "Identity is not authorization",
+        "tenant routing",
+        "per-entity",
+        "warehouse credential brokering",
+        "semantic-layer authorization",
+        "issuer, audience, expiry, not-before, signature, and algorithm",
+    ] {
+        assert!(
+            threat_model.contains(required)
+                || contract.contains(required)
+                || adrs.contains(required),
+            "hosted identity docs must mention `{required}`"
+        );
+    }
+}
+
+#[test]
+fn hosted_identity_contract_is_not_documented_as_runtime_config_yet() {
+    let contract = read_doc("docs/development/hosted-identity-contract.md");
+    let config_reference = read_doc("docs/configuration/reference.md");
+
+    assert!(contract.contains("DBT_NOVA_AUTH_MODE"));
+    assert!(contract.contains("proxy_signed_headers"));
+    assert!(contract.contains("jwt"));
+    assert!(
+        !config_reference.contains("DBT_NOVA_AUTH_MODE"),
+        "DBT_NOVA_AUTH_MODE should stay out of the runtime config reference until implemented"
+    );
+}


### PR DESCRIPTION
## Summary

Spec-first PR for Linear JOE-665. This adds the hosted identity/JWT design boundary without implementing runtime auth behavior.

## What changed

- Added ADR-006 for default-off hosted identity.
- Added a hosted identity threat model covering trust boundaries, threats, fail-closed rules, and non-goals.
- Added a planned hosted identity config contract for future JOE-662/JOE-663/JOE-664 work while keeping those settings out of the runtime config reference.
- Linked the design docs from hosted deployment and security docs.
- Added docs contract tests so the default-off/proxy-first guardrails are checked before implementation.

## Product boundary

This keeps Nova as a one-manifest metadata bridge. Identity is request attribution / inbound auth context only, not tenant routing, per-entity authorization, warehouse credential brokering, semantic-layer authorization, or a SaaS control plane.

## Validation

- `cargo test --locked --test hosted_identity_docs`
- `uv run mkdocs build --strict`
- `cargo fmt --check`
- `git diff --check`

## Linear

- JOE-665
