### PR TITLE
Add hosted request correlation logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5826,6 +5826,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5835,12 +5845,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ thiserror = "1.0"
 sqlparser = { version = "0.60", features = ["visitor"] }
 tantivy = "0.22"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 rayon = "1.10"
 moka = { version = "0.12", features = ["sync"] }
 memmap2 = "0.9"

--- a/docs/config_defaults.json
+++ b/docs/config_defaults.json
@@ -128,6 +128,7 @@
   "layer_rules": [],
   "lineage_max_depth": 200,
   "lineage_max_results": 10000,
+  "log_format": "human",
   "manifest_allow_http": false,
   "manifest_cache_dir": "",
   "manifest_fetch_timeout_secs": 300,

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -68,7 +68,8 @@ see [Modes & Combinations](../getting-started/modes-and-combinations.md).
 - `DBT_NOVA_S3_MODE` – S3 fetch mode (`https` or `sdk`, default: `https`)
 - `DBT_NOVA_GCS_MODE` – GCS fetch mode (`https` or `sdk`, default: `https`)
 - `DBT_NOVA_RECIPES_DIR` – manifest `original_file_path` prefix used to discover recipe `analysis` nodes (default: `analyses/recipes`). Recipe SQL is resolved from manifest `compiled_code` (or `raw_code` fallback). Recipes are documented in [Analysis Recipes](../features/recipes.md).
-- `DBT_NOVA_LOG` / `RUST_LOG` – enable structured logs to stderr (e.g., `info`, `debug`, `trace`)
+- `DBT_NOVA_LOG` / `RUST_LOG` – enable logs to stderr (e.g., `info`, `debug`, `trace`)
+- `DBT_NOVA_LOG_FORMAT` – log output format when logging is enabled (`human` or `json`, default: `human`; JSON logs are newline-delimited and include request correlation fields for hosted HTTP requests)
 - `DBT_NOVA_DISABLE_TOOL_SCHEMAS` – strip JSON schema hints from MCP tools (useful for strict clients like Gemini; see [MCP Clients](../getting-started/mcp-clients.md))
 - `DBT_NOVA_TOOL_PROFILE` – MCP tool profile (`agent`, `analyst`, `engineer`, `governance`, `ops`, or `all`; default: `agent`)
 - `DBT_NOVA_TOOL_ALLOWLIST` – optional comma-separated allowlist of exact MCP tool names to expose; when set, only these tools are eligible for exposure
@@ -194,6 +195,13 @@ Remote manifest notes:
   that path out of the MCP fallback. Protect `/metrics` with the same
   proxy/network ACL as MCP because it exposes tool names, call counts, latency,
   and readiness posture.
+- Hosted HTTP requests propagate a safe `X-Request-ID` response header. Nova
+  accepts proxy-provided `X-Request-ID` or `X-Correlation-ID` values when they
+  are short printable identifiers, otherwise it generates a UUID. Request logs
+  include method, path, status, duration, and request ID; they do not include
+  query strings, raw SQL, request bodies, credentials, manifests, tokens, or
+  private URIs. MCP tool logs include tool name, duration, success/failure, and
+  request ID only.
 
 Manifest pruning notes:
 - Matching is against dbt `unique_id` (not `fqn`).

--- a/docs/features/traces.md
+++ b/docs/features/traces.md
@@ -6,6 +6,9 @@ per observed Nova tool call. Use the `trace` commands to inspect, summarize,
 redact, and replay those files before attaching evidence to PRs, eval
 artifacts, or support threads.
 
+Hosted HTTP tool calls include `request_id` when request correlation is active,
+so redacted trace artifacts can be matched back to hosted request logs.
+
 Trace commands operate on local files only. Inspect, summarize, and redact do
 not replay tool calls, call providers, execute SQL, upload artifacts, or read
 arbitrary provider logs. `trace replay` replays only supported deterministic

--- a/docs/operations/hosted-deployment.md
+++ b/docs/operations/hosted-deployment.md
@@ -61,6 +61,8 @@ export DBT_NOVA_HTTP_PATH=/mcp
 export DBT_NOVA_HTTP_EXPECT_AUTH_PROXY=true
 export DBT_NOVA_HTTP_ALLOWED_HOSTS=nova.example.com
 export DBT_NOVA_HTTP_MAX_BODY_BYTES=16777216
+export DBT_NOVA_LOG=info
+export DBT_NOVA_LOG_FORMAT=json
 # Optional if the proxy/network cannot restrict scrapes:
 # export DBT_NOVA_METRICS_ENABLED=false
 export DBT_NOVA_STORAGE_DIR=/tmp/dbt-nova
@@ -85,6 +87,9 @@ Why these defaults matter:
 - `DBT_NOVA_HTTP_EXPECT_AUTH_PROXY=true` is required for non-loopback hosted binds and documents that an authenticating reverse proxy is in front of Nova.
 - `DBT_NOVA_HTTP_ALLOWED_HOSTS` allows the public/proxy `Host` header while the transport still rejects unexpected hosts.
 - `DBT_NOVA_HTTP_MAX_BODY_BYTES` caps request bodies before the mounted MCP transport buffers them; keep it bounded unless a stricter proxy limit is enforced.
+- `DBT_NOVA_LOG=info` plus `DBT_NOVA_LOG_FORMAT=json` emits newline-delimited
+  JSON logs that are suitable for hosted collectors. Leave
+  `DBT_NOVA_LOG_FORMAT` unset for the default human-readable stderr format.
 - `GET /metrics` is enabled by default for hosted HTTP. It does not include
   query text, entity names, paths, user IDs, or credentials, but it does expose
   readiness, tool names, call counts, error counts, and latency histograms.
@@ -97,6 +102,30 @@ Why these defaults matter:
 - `DBT_NOVA_EMBEDDINGS_CACHE_DIR=/tmp/dbt-nova/models` keeps model cache resolution deterministic.
 - `DBT_NOVA_BOOTSTRAP_URI` should point at the stable bootstrap alias published by the reusable asset workflow.
 - First start should **not** use strict read-only mode. Nova may need to materialize prebuilt assets locally before it can serve traffic.
+
+## Request Correlation
+
+Hosted HTTP mode adds request correlation without implementing identity. Nova
+accepts a proxy-provided `X-Request-ID` first, then `X-Correlation-ID`, when the
+value is a short printable identifier. If neither header is present or the value
+is unsafe, Nova generates a UUID. Every hosted HTTP response echoes the effective
+ID in `X-Request-ID`.
+
+Example probe:
+
+```bash
+curl -i \
+  -H 'X-Request-ID: deploy-smoke-001' \
+  http://127.0.0.1:8080/healthz
+```
+
+With `DBT_NOVA_LOG=info DBT_NOVA_LOG_FORMAT=json`, request logs include the
+request ID, method, path, status, and duration. MCP tool logs include request
+ID, tool name, duration, and success/failure. These logs intentionally omit
+query strings, request bodies, raw SQL, credentials, manifests, tokens, and
+private URIs. When `DBT_NOVA_TRACE_TOOL_CALLS_PATH` is enabled, MCP trace rows
+also include `request_id` so a redacted trace artifact can be matched back to
+hosted request logs.
 
 ## Hosted SQL-Enabled Profile
 

--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -112,7 +112,20 @@ Runtime enforcement:
 - Non-loopback `streamable_http` binds fail validation unless `DBT_NOVA_HTTP_EXPECT_AUTH_PROXY=true`.
 - Streamable HTTP requests are rejected when their `Host` header is outside the transport loopback defaults and `DBT_NOVA_HTTP_ALLOWED_HOSTS`.
 - Streamable HTTP request bodies are capped by `DBT_NOVA_HTTP_MAX_BODY_BYTES` before the MCP transport buffers them.
+- Streamable HTTP responses include `X-Request-ID`. Nova propagates safe
+  `X-Request-ID`/`X-Correlation-ID` proxy headers or generates a UUID, then logs
+  request and tool completion with that ID when logging is enabled.
 - Successful `streamable_http` startup logs a warning that the transport has no built-in auth.
+
+Logging privacy:
+
+- `DBT_NOVA_LOG_FORMAT=json` changes formatting only; it does not add request
+  payload logging.
+- Hosted request logs include method, path, status, duration, and request ID.
+  They do not include query strings, request bodies, raw SQL, credentials,
+  manifests, tokens, or private URIs.
+- MCP tool logs include tool name, success/failure, duration, and request ID
+  when one is available. Tool response payload contracts are unchanged.
 
 ## Advisory Exceptions
 

--- a/src/cli/config_cmd.rs
+++ b/src/cli/config_cmd.rs
@@ -30,6 +30,7 @@ pub struct ConfigValidationChecklist {
     pub tool_denylist: Vec<String>,
     pub exposed_tool_count: usize,
     pub tool_exposure: ToolExposureChecklist,
+    pub logging: LoggingPosture,
     pub hosted_http: HostedHttpChecklist,
     pub hosted_auth: HostedAuthPosture,
     pub metrics: MetricsPosture,
@@ -53,6 +54,12 @@ pub struct ExecutionToolExposure {
 pub struct OperationalToolExposure {
     pub admin_tools_exposed: bool,
     pub write_tools_exposed: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LoggingPosture {
+    pub format: String,
+    pub json_enabled: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -369,6 +376,10 @@ fn build_validation_checklist(config: &DbtNovaConfig) -> ConfigValidationCheckli
                     ],
                 ),
             },
+        },
+        logging: LoggingPosture {
+            format: config.log_format.as_str().to_string(),
+            json_enabled: config.log_format == crate::logging::LogFormat::Json,
         },
         hosted_http,
         hosted_auth,
@@ -698,6 +709,14 @@ mod tests {
         );
         assert!(response["data"]["checklist"]["tool_denylist"].is_array());
         assert!(response["data"]["checklist"]["hosted_http"]["enabled"].is_boolean());
+        assert_eq!(
+            response["data"]["checklist"]["logging"]["format"],
+            serde_json::json!("human")
+        );
+        assert_eq!(
+            response["data"]["checklist"]["logging"]["json_enabled"],
+            serde_json::json!(false)
+        );
         assert_eq!(
             response["data"]["checklist"]["hosted_auth"]["mode"],
             serde_json::json!("off")

--- a/src/cli/server_cmd.rs
+++ b/src/cli/server_cmd.rs
@@ -6,6 +6,7 @@ use axum::{
     Json, Router,
     extract::State,
     http::{StatusCode, header},
+    middleware,
     response::{IntoResponse, Response},
     routing::get,
 };
@@ -24,6 +25,7 @@ use crate::config::{DbtNovaConfig, ServerTransport};
 use crate::error::{DbtNovaError, Result};
 use crate::manifest::bootstrap::prepare_runtime_config;
 use crate::manifest::search::ManifestSearchHandle;
+use crate::server::correlation::correlate_http_request;
 use crate::server::health::build_manifest_health_payload;
 use crate::server::mcp::DbtNovaServer;
 use crate::utils::{ToolMetricsStore, sanitize_uri};
@@ -283,6 +285,7 @@ async fn serve_streamable_http(
     } else {
         app
     };
+    let app = app.layer(middleware::from_fn(correlate_http_request));
 
     let bind_host = settings.host.clone();
     let bind_port = settings.port;
@@ -757,10 +760,18 @@ mod tests {
 
         let liveness = client
             .get(format!("http://127.0.0.1:{port}/healthz"))
+            .header("X-Request-ID", "req-test-001")
             .send()
             .await
             .expect("liveness request should succeed");
         assert_eq!(liveness.status(), reqwest::StatusCode::OK);
+        assert_eq!(
+            liveness
+                .headers()
+                .get("x-request-id")
+                .and_then(|value| value.to_str().ok()),
+            Some("req-test-001")
+        );
         let liveness_body = liveness.json::<Value>().await.expect("liveness JSON");
         assert_eq!(liveness_body["status"], "ok");
         assert_eq!(liveness_body["version"], env!("CARGO_PKG_VERSION"));

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -6,6 +6,7 @@ use std::path::{Component, Path, PathBuf};
 use blake3;
 
 use crate::error::{DbtNovaError, Result};
+use crate::logging::LogFormat;
 use crate::params::DetailLevel;
 use crate::tools::catalog::{
     DEFAULT_MCP_TOOL_PROFILE, MCP_TOOL_NAMES, MCP_TOOL_PROFILE_NAMES, mcp_tool_profile_names,
@@ -410,6 +411,8 @@ pub struct DbtNovaConfig {
     pub artifact_allow_http: bool,
     /// Server transport mode (`stdio` or `streamable_http`)
     pub server_transport: ServerTransport,
+    /// Log output format when `DBT_NOVA_LOG` or `RUST_LOG` enables logs.
+    pub log_format: LogFormat,
     /// Bind host for hosted HTTP mode
     pub http_host: String,
     /// Bind port for hosted HTTP mode
@@ -546,6 +549,7 @@ impl Default for DbtNovaConfig {
             artifact_archive_max_uncompressed_bytes: 10 * 1024 * 1024 * 1024, // 10 GiB
             artifact_allow_http: false,
             server_transport: ServerTransport::Stdio,
+            log_format: LogFormat::Human,
             http_host: "127.0.0.1".to_string(),
             http_port: 8000,
             http_path: "/mcp".to_string(),
@@ -1272,6 +1276,17 @@ impl DbtNovaConfig {
                     "Invalid DBT_NOVA_SERVER_TRANSPORT value '{}'; expected stdio|streamable_http",
                     value
                 );
+            }
+        }
+        if let Some(value) = env_string("DBT_NOVA_LOG_FORMAT")
+            && !value.trim().is_empty()
+        {
+            if let Some(log_format) = LogFormat::parse(&value) {
+                self.log_format = log_format;
+            } else {
+                self.env_errors.push(format!(
+                    "Invalid DBT_NOVA_LOG_FORMAT value '{value}'; expected human|json"
+                ));
             }
         }
 

--- a/src/config/core/tests.rs
+++ b/src/config/core/tests.rs
@@ -5,6 +5,7 @@ use super::{
     HOSTED_SQL_TRUSTED_TOOL_DENYLIST, HostedAuthMode, ResultProfile, RuntimePreset,
     ServerTransport,
 };
+use crate::logging::LogFormat;
 
 static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
@@ -213,10 +214,35 @@ fn default_result_profiles_keep_cli_standard_and_mcp_compact() {
     assert_eq!(config.mcp_result_profile, ResultProfile::Compact);
     assert_eq!(config.mcp_default_limit, 10);
     assert_eq!(config.mcp_max_page_size, 100);
+    assert_eq!(config.log_format, LogFormat::Human);
     assert_eq!(config.hosted_auth.mode, HostedAuthMode::Off);
     assert!(!config.hosted_auth.required);
     assert_eq!(config.hosted_auth.identity_subject_claim, "sub");
     assert!(config.hosted_auth.jwt_algorithms.is_empty());
+}
+
+#[test]
+fn from_env_reads_json_log_format() {
+    let config = with_env_vars(
+        &[("DBT_NOVA_LOG_FORMAT", Some("json"))],
+        DbtNovaConfig::from_env,
+    );
+
+    assert_eq!(config.log_format, LogFormat::Json);
+    config.validate().expect("json log format should validate");
+}
+
+#[test]
+fn from_env_records_invalid_log_format() {
+    let config = with_env_vars(
+        &[("DBT_NOVA_LOG_FORMAT", Some("xml"))],
+        DbtNovaConfig::from_env,
+    );
+
+    let error = config
+        .validate()
+        .expect_err("invalid log format should fail validation");
+    assert!(error.to_string().contains("DBT_NOVA_LOG_FORMAT"));
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cli;
 pub mod config;
 pub mod dbt_types;
 pub mod error;
+pub mod logging;
 pub mod manifest;
 pub mod nova_meta;
 pub mod params;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,87 @@
+use serde::{Deserialize, Serialize};
+use tracing_subscriber::fmt::format::FmtSpan;
+
+/// Runtime log output format.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum LogFormat {
+    /// Human-readable stderr logs.
+    #[default]
+    Human,
+    /// Newline-delimited JSON logs for hosted collectors.
+    Json,
+}
+
+impl LogFormat {
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "human" => Some(Self::Human),
+            "json" => Some(Self::Json),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Human => "human",
+            Self::Json => "json",
+        }
+    }
+}
+
+/// Initialize tracing from environment variables.
+///
+/// Logging remains opt-in through `DBT_NOVA_LOG` or `RUST_LOG`. When enabled,
+/// `DBT_NOVA_LOG_FORMAT=json` switches to collector-friendly JSON output.
+pub fn init_tracing_from_env() {
+    let Some(filter) = std::env::var("DBT_NOVA_LOG")
+        .or_else(|_| std::env::var("RUST_LOG"))
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return;
+    };
+
+    let format = std::env::var("DBT_NOVA_LOG_FORMAT")
+        .ok()
+        .and_then(|value| LogFormat::parse(&value))
+        .unwrap_or_default();
+
+    let init_result = match format {
+        LogFormat::Human => tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_writer(std::io::stderr)
+            .with_target(false)
+            .with_span_events(FmtSpan::CLOSE)
+            .try_init(),
+        LogFormat::Json => tracing_subscriber::fmt()
+            .json()
+            .flatten_event(true)
+            .with_current_span(true)
+            .with_span_list(true)
+            .with_env_filter(filter)
+            .with_writer(std::io::stderr)
+            .with_target(false)
+            .try_init(),
+    };
+
+    if let Err(err) = init_result {
+        tracing::warn!(error = %err, "failed to initialize tracing subscriber");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LogFormat;
+
+    #[test]
+    fn log_format_parse_accepts_documented_values() {
+        assert_eq!(LogFormat::parse("human"), Some(LogFormat::Human));
+        assert_eq!(LogFormat::parse(" HUMAN "), Some(LogFormat::Human));
+        assert_eq!(LogFormat::parse("json"), Some(LogFormat::Json));
+        assert_eq!(LogFormat::parse("JSON"), Some(LogFormat::Json));
+        assert_eq!(LogFormat::parse("xml"), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use dbt_nova::cli::args::{Cli, Command};
 use dbt_nova::cli::output::exit_code;
 use dbt_nova::error::Result;
 use tracing::error;
-use tracing_subscriber::fmt::format::FmtSpan;
 
 enum LaunchTarget {
     Command(Box<Command>),
@@ -12,7 +11,7 @@ enum LaunchTarget {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    init_tracing();
+    dbt_nova::logging::init_tracing_from_env();
 
     match launch_target(Cli::parse()) {
         LaunchTarget::Command(command) => {
@@ -34,22 +33,6 @@ fn launch_target(cli: Cli) -> LaunchTarget {
         LaunchTarget::Command(Box::new(command))
     } else {
         LaunchTarget::Server
-    }
-}
-
-fn init_tracing() {
-    let filter = std::env::var("DBT_NOVA_LOG")
-        .or_else(|_| std::env::var("RUST_LOG"))
-        .ok();
-    if let Some(filter) = filter
-        && let Err(err) = tracing_subscriber::fmt()
-            .with_env_filter(filter)
-            .with_writer(std::io::stderr)
-            .with_target(false)
-            .with_span_events(FmtSpan::CLOSE)
-            .try_init()
-    {
-        tracing::warn!(error = %err, "failed to initialize tracing subscriber");
     }
 }
 

--- a/src/server/correlation.rs
+++ b/src/server/correlation.rs
@@ -1,0 +1,228 @@
+use std::time::{Duration, Instant};
+
+use axum::{
+    extract::Request,
+    http::{HeaderMap, HeaderName, HeaderValue, Method, Uri},
+    middleware::Next,
+    response::Response,
+};
+use tokio::task_local;
+use tracing::{Instrument, info, warn};
+
+const REQUEST_ID_HEADER_NAME: &str = "x-request-id";
+const CORRELATION_ID_HEADER_NAME: &str = "x-correlation-id";
+const MAX_REQUEST_ID_LEN: usize = 128;
+
+task_local! {
+    static CURRENT_REQUEST_ID: RequestId;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RequestId(String);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RequestIdSource {
+    Proxy,
+    Generated,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RequestLogFields {
+    pub request_id: String,
+    pub request_id_source: &'static str,
+    pub method: String,
+    pub path: String,
+}
+
+impl RequestId {
+    fn generated() -> Self {
+        Self(uuid::Uuid::new_v4().to_string())
+    }
+
+    #[must_use]
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl RequestIdSource {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Proxy => "proxy",
+            Self::Generated => "generated",
+        }
+    }
+}
+
+pub(crate) fn current_request_id() -> Option<String> {
+    CURRENT_REQUEST_ID
+        .try_with(|request_id| request_id.as_str().to_string())
+        .ok()
+}
+
+pub(crate) async fn correlate_http_request(mut request: Request, next: Next) -> Response {
+    let started = Instant::now();
+    let (request_id, source) = resolve_request_id(request.headers());
+    let fields = RequestLogFields::new(request.method(), request.uri(), &request_id, source);
+    request.extensions_mut().insert(request_id.clone());
+
+    let span = tracing::info_span!(
+        "hosted_http_request",
+        request_id = %request_id.as_str(),
+        request_id_source = fields.request_id_source,
+        method = %fields.method,
+        path = %fields.path,
+    );
+
+    let mut response = CURRENT_REQUEST_ID
+        .scope(request_id.clone(), async move {
+            next.run(request).instrument(span).await
+        })
+        .await;
+    insert_response_request_id(response.headers_mut(), &request_id);
+    log_request_completed(&fields, response.status().as_u16(), started.elapsed());
+    response
+}
+
+pub(crate) fn resolve_request_id(headers: &HeaderMap) -> (RequestId, RequestIdSource) {
+    for header_name in [REQUEST_ID_HEADER_NAME, CORRELATION_ID_HEADER_NAME] {
+        if let Some(value) = headers.get(header_name)
+            && let Ok(value) = value.to_str()
+            && valid_request_id(value)
+        {
+            return (RequestId(value.trim().to_string()), RequestIdSource::Proxy);
+        }
+    }
+    (RequestId::generated(), RequestIdSource::Generated)
+}
+
+pub(crate) fn insert_response_request_id(headers: &mut HeaderMap, request_id: &RequestId) {
+    if let Ok(value) = HeaderValue::from_str(request_id.as_str()) {
+        headers.insert(HeaderName::from_static(REQUEST_ID_HEADER_NAME), value);
+    }
+}
+
+impl RequestLogFields {
+    #[must_use]
+    fn new(method: &Method, uri: &Uri, request_id: &RequestId, source: RequestIdSource) -> Self {
+        Self {
+            request_id: request_id.as_str().to_string(),
+            request_id_source: source.as_str(),
+            method: method.as_str().to_string(),
+            path: uri.path().to_string(),
+        }
+    }
+}
+
+fn log_request_completed(fields: &RequestLogFields, status: u16, elapsed: Duration) {
+    let duration_ms = elapsed_ms_to_u64(elapsed);
+    if status >= 500 {
+        warn!(
+            request_id = %fields.request_id,
+            request_id_source = fields.request_id_source,
+            method = %fields.method,
+            path = %fields.path,
+            status,
+            duration_ms,
+            "hosted HTTP request completed with server error"
+        );
+    } else {
+        info!(
+            request_id = %fields.request_id,
+            request_id_source = fields.request_id_source,
+            method = %fields.method,
+            path = %fields.path,
+            status,
+            duration_ms,
+            "hosted HTTP request completed"
+        );
+    }
+}
+
+fn valid_request_id(value: &str) -> bool {
+    let trimmed = value.trim();
+    !trimmed.is_empty()
+        && trimmed.len() <= MAX_REQUEST_ID_LEN
+        && trimmed
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':'))
+}
+
+fn elapsed_ms_to_u64(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::{HeaderMap, Method, Uri};
+
+    use super::{
+        CORRELATION_ID_HEADER_NAME, REQUEST_ID_HEADER_NAME, RequestId, RequestIdSource,
+        RequestLogFields, insert_response_request_id, resolve_request_id,
+    };
+
+    #[test]
+    fn request_id_resolution_prefers_safe_proxy_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(REQUEST_ID_HEADER_NAME, "req-123.trace".parse().unwrap());
+        headers.insert(CORRELATION_ID_HEADER_NAME, "corr-456".parse().unwrap());
+
+        let (request_id, source) = resolve_request_id(&headers);
+
+        assert_eq!(request_id.as_str(), "req-123.trace");
+        assert_eq!(source, RequestIdSource::Proxy);
+    }
+
+    #[test]
+    fn request_id_resolution_falls_back_to_correlation_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CORRELATION_ID_HEADER_NAME, "corr-456".parse().unwrap());
+
+        let (request_id, source) = resolve_request_id(&headers);
+
+        assert_eq!(request_id.as_str(), "corr-456");
+        assert_eq!(source, RequestIdSource::Proxy);
+    }
+
+    #[test]
+    fn request_id_resolution_rejects_sensitive_or_unsafe_header_values() {
+        let mut headers = HeaderMap::new();
+        headers.insert(REQUEST_ID_HEADER_NAME, "Bearer raw-token".parse().unwrap());
+
+        let (request_id, source) = resolve_request_id(&headers);
+
+        assert_ne!(request_id.as_str(), "Bearer raw-token");
+        assert_eq!(source, RequestIdSource::Generated);
+        assert_eq!(request_id.as_str().len(), 36);
+    }
+
+    #[test]
+    fn response_request_id_header_uses_resolved_id() {
+        let mut headers = HeaderMap::new();
+        let request_id = RequestId("req-123".to_string());
+
+        insert_response_request_id(&mut headers, &request_id);
+
+        assert_eq!(
+            headers
+                .get(REQUEST_ID_HEADER_NAME)
+                .and_then(|v| v.to_str().ok()),
+            Some("req-123")
+        );
+    }
+
+    #[test]
+    fn request_log_fields_drop_query_strings() {
+        let request_id = RequestId("req-123".to_string());
+        let uri: Uri = "/mcp?token=raw-token&query=select%20secret"
+            .parse()
+            .unwrap();
+
+        let fields =
+            RequestLogFields::new(&Method::POST, &uri, &request_id, RequestIdSource::Proxy);
+
+        assert_eq!(fields.path, "/mcp");
+        assert!(!fields.path.contains("raw-token"));
+        assert!(!fields.path.contains("select"));
+    }
+}

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -51,6 +51,7 @@ use crate::params::{
     ValidateEvalSuiteParams, ValidateNovaMetaParams, WarmManifestParams,
 };
 use crate::responses::{SuccessResponse, attach_response_api_contract};
+use crate::server::correlation::current_request_id;
 use crate::server::health::build_manifest_health_payload;
 use crate::utils::{ToolMetricsStore, ToolRateLimiter};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
@@ -219,15 +220,18 @@ impl DbtNovaServer {
                 let out = Self::error_response(&err);
                 let duration_ms = elapsed_ms_to_u64(start.elapsed());
                 let parsed_trace_response = serde_json::from_str::<serde_json::Value>(&out).ok();
-                crate::utils::tool_trace::record_tool_call(
+                let request_id = current_request_id();
+                crate::utils::tool_trace::record_tool_call_with_request_id(
                     "mcp",
                     tool,
                     None,
                     parsed_trace_response.as_ref(),
                     success,
                     duration_ms,
+                    request_id.as_deref(),
                 );
                 self.record_metrics(tool, persona, duration_ms, success);
+                Self::log_tool_call(tool, duration_ms, success, request_id.as_deref());
                 return Err(out);
             }
         };
@@ -240,15 +244,18 @@ impl DbtNovaServer {
             }));
             let duration_ms = elapsed_ms_to_u64(start.elapsed());
             let parsed_trace_response = serde_json::from_str::<serde_json::Value>(&out).ok();
-            crate::utils::tool_trace::record_tool_call(
+            let request_id = current_request_id();
+            crate::utils::tool_trace::record_tool_call_with_request_id(
                 "mcp",
                 tool,
                 None,
                 parsed_trace_response.as_ref(),
                 success,
                 duration_ms,
+                request_id.as_deref(),
             );
             self.record_metrics(tool, persona, duration_ms, success);
+            Self::log_tool_call(tool, duration_ms, success, request_id.as_deref());
             return Err(out);
         }
 
@@ -269,15 +276,18 @@ impl DbtNovaServer {
         };
         let duration_ms = elapsed_ms_to_u64(start.elapsed());
         let parsed_trace_response = serde_json::from_str::<serde_json::Value>(&out).ok();
-        crate::utils::tool_trace::record_tool_call(
+        let request_id = current_request_id();
+        crate::utils::tool_trace::record_tool_call_with_request_id(
             "mcp",
             tool,
             None,
             parsed_trace_response.as_ref(),
             success,
             duration_ms,
+            request_id.as_deref(),
         );
         self.record_metrics(tool, persona, duration_ms, success);
+        Self::log_tool_call(tool, duration_ms, success, request_id.as_deref());
         if success { Ok(out) } else { Err(out) }
     }
 }
@@ -291,6 +301,27 @@ impl DbtNovaServer {
         if let Some(persona) = persona {
             let key = format!("{}.{}", tool, persona.to_lowercase());
             self.metrics.record(&key, duration_ms, success);
+        }
+    }
+
+    fn log_tool_call(tool: &str, duration_ms: u64, success: bool, request_id: Option<&str>) {
+        match (success, request_id) {
+            (true, Some(request_id)) => tracing::info!(
+                tool,
+                duration_ms,
+                success,
+                request_id,
+                "mcp tool call completed"
+            ),
+            (true, None) => tracing::info!(tool, duration_ms, success, "mcp tool call completed"),
+            (false, Some(request_id)) => tracing::warn!(
+                tool,
+                duration_ms,
+                success,
+                request_id,
+                "mcp tool call failed"
+            ),
+            (false, None) => tracing::warn!(tool, duration_ms, success, "mcp tool call failed"),
         }
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,3 +1,4 @@
+pub mod correlation;
 pub mod health;
 pub mod mcp;
 

--- a/src/utils/tool_trace.rs
+++ b/src/utils/tool_trace.rs
@@ -90,6 +90,8 @@ struct ToolTraceRow {
     success: bool,
     duration_ms: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
+    request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     error_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     params_summary: Option<Value>,
@@ -207,6 +209,27 @@ pub fn record_tool_call(
     success: bool,
     duration_ms: u64,
 ) {
+    record_tool_call_with_request_id(
+        transport,
+        tool,
+        params,
+        response,
+        success,
+        duration_ms,
+        None,
+    );
+}
+
+/// Append a sanitized tool-call trace row with optional request correlation.
+pub fn record_tool_call_with_request_id(
+    transport: &str,
+    tool: &str,
+    params: Option<&Value>,
+    response: Option<&Value>,
+    success: bool,
+    duration_ms: u64,
+    request_id: Option<&str>,
+) {
     let Ok(path) = std::env::var(TRACE_ENV) else {
         return;
     };
@@ -227,11 +250,14 @@ pub fn record_tool_call(
     let row = build_tool_trace_row(
         trace_path,
         transport,
-        tool,
-        params,
-        response,
-        success,
-        duration_ms,
+        &ToolTraceRowInput {
+            tool,
+            params,
+            response,
+            success,
+            duration_ms,
+            request_id,
+        },
     );
 
     let serialized = match serde_json::to_string(&row) {
@@ -245,30 +271,41 @@ pub fn record_tool_call(
     append_serialized_trace_row(trace_path, &serialized);
 }
 
+struct ToolTraceRowInput<'a> {
+    tool: &'a str,
+    params: Option<&'a Value>,
+    response: Option<&'a Value>,
+    success: bool,
+    duration_ms: u64,
+    request_id: Option<&'a str>,
+}
+
 fn build_tool_trace_row(
     trace_path: &Path,
     transport: &str,
-    tool: &str,
-    params: Option<&Value>,
-    response: Option<&Value>,
-    success: bool,
-    duration_ms: u64,
+    input: &ToolTraceRowInput<'_>,
 ) -> ToolTraceRow {
     ToolTraceRow {
         timestamp_ms: timestamp_ms(),
         tool_call_index: next_tool_call_index(trace_path),
         transport: transport.to_string(),
-        tool: tool.to_string(),
-        success,
-        duration_ms,
-        error_code: response.and_then(extract_error_code),
-        params_summary: params.map(summarize_params),
-        response_bytes: response.map_or(0, serialized_len),
-        response_truncated: response.is_some_and(extract_response_truncated),
-        result_count: response.and_then(|value| value.get("count").and_then(Value::as_u64)),
-        total_available: response.and_then(total_available_from_response),
-        selected_unique_ids: response.map(extract_unique_ids).unwrap_or_default(),
-        top_unique_ids: response.map(extract_top_unique_ids).unwrap_or_default(),
+        tool: input.tool.to_string(),
+        success: input.success,
+        duration_ms: input.duration_ms,
+        request_id: input.request_id.map(ToOwned::to_owned),
+        error_code: input.response.and_then(extract_error_code),
+        params_summary: input.params.map(summarize_params),
+        response_bytes: input.response.map_or(0, serialized_len),
+        response_truncated: input.response.is_some_and(extract_response_truncated),
+        result_count: input
+            .response
+            .and_then(|value| value.get("count").and_then(Value::as_u64)),
+        total_available: input.response.and_then(total_available_from_response),
+        selected_unique_ids: input.response.map(extract_unique_ids).unwrap_or_default(),
+        top_unique_ids: input
+            .response
+            .map(extract_top_unique_ids)
+            .unwrap_or_default(),
     }
 }
 
@@ -864,6 +901,7 @@ fn redact_trace_row(row: &Value, fields_removed: &mut usize, fields_masked: &mut
     copy_string_field(map, &mut out, "tool", fields_removed, fields_masked);
     copy_bool_field(map, &mut out, "success", fields_removed);
     copy_u64_field(map, &mut out, "duration_ms", fields_removed);
+    copy_string_field(map, &mut out, "request_id", fields_removed, fields_masked);
     copy_string_field(map, &mut out, "error_code", fields_removed, fields_masked);
     if let Some(params) = map.get("params_summary") {
         let redacted = redact_params_summary(params, fields_removed, fields_masked);
@@ -907,6 +945,7 @@ fn is_redacted_top_level_key(key: &str) -> bool {
             | "tool"
             | "success"
             | "duration_ms"
+            | "request_id"
             | "error_code"
             | "response_bytes"
             | "response_truncated"
@@ -1398,7 +1437,8 @@ mod tests {
     use super::{
         MAX_SELECTED_UNIQUE_IDS, TRACE_ENV, TRACE_MAX_BYTES_ENV, extract_response_truncated,
         extract_top_unique_ids, extract_unique_ids, read_tool_trace_file, record_tool_call,
-        redact_tool_trace_file, summarize_params, summarize_tool_trace,
+        record_tool_call_with_request_id, redact_tool_trace_file, summarize_params,
+        summarize_tool_trace,
     };
 
     static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
@@ -1633,6 +1673,41 @@ mod tests {
     }
 
     #[test]
+    fn record_tool_call_with_request_id_adds_safe_correlation_without_raw_payloads() {
+        let _env_guard = lock_env();
+        let dir = TempDir::new().expect("dir");
+        let trace_path = dir.path().join("trace.jsonl");
+        let _path_restore = EnvVarRestore::set(TRACE_ENV, &trace_path.to_string_lossy());
+        let _max_restore = EnvVarRestore::set(TRACE_MAX_BYTES_ENV, "65536");
+
+        record_tool_call_with_request_id(
+            "mcp",
+            "execute_sql",
+            Some(&json!({
+                "query": "revenue",
+                "authorization": "Bearer raw-token",
+            })),
+            Some(&json!({
+                "success": false,
+                "error_code": "SQL_ERROR",
+                "error": "query failed",
+            })),
+            false,
+            9,
+            Some("req-123"),
+        );
+
+        let read = read_tool_trace_file(&trace_path);
+        assert_eq!(read.rows.len(), 1);
+        let row = &read.rows[0];
+        assert_eq!(row["request_id"], json!("req-123"));
+        assert_eq!(row["tool"], json!("execute_sql"));
+        assert_eq!(row["success"], json!(false));
+        let serialized = row.to_string();
+        assert!(!serialized.contains("raw-token"));
+    }
+
+    #[test]
     fn summarize_tool_trace_reports_order_budgets_and_semantic_first() {
         let trace = NamedTempFile::new().expect("trace");
         std::fs::write(
@@ -1677,6 +1752,7 @@ mod tests {
                 "\"params_summary\":{\"query\":\"s3://bucket/path?token=secret\",",
                 "\"limit\":5,\"keys\":[\"query\",\"token\"],",
                 "\"parameters\":{\"password\":\"secret\"}},",
+                "\"request_id\":\"req-123\",",
                 "\"manifest_uri\":\"s3://bucket/manifest.json?token=secret\",",
                 "\"provider_raw_output\":\"secret stdout\",",
                 "\"response_bytes\":10,\"response_truncated\":false,",
@@ -1702,6 +1778,7 @@ mod tests {
         assert!(!redacted.contains("parameters"));
         assert!(redacted.contains("[REDACTED]"));
         assert!(redacted.contains("model.pkg.orders"));
+        assert!(redacted.contains("\"request_id\":\"req-123\""));
 
         let read = read_tool_trace_file(dir.path().join("trace.redacted.jsonl").as_path());
         let summary = summarize_tool_trace(&read);


### PR DESCRIPTION
## Summary

Implements JOE-666 request correlation and structured hosted logging without changing MCP tool response payloads.

- Adds hosted HTTP request ID propagation/generation for `X-Request-ID` and `X-Correlation-ID`, with `X-Request-ID` echoed on responses.
- Adds opt-in newline-delimited JSON log formatting via `DBT_NOVA_LOG_FORMAT=json` while keeping human logs as the default.
- Logs hosted request/tool completion metadata with request IDs and avoids query strings, raw SQL, request bodies, credentials, manifests, tokens, and private URIs.
- Carries request IDs into redaction-safe tool trace rows when hosted correlation is active.
- Documents hosted proxy headers, JSON logging, and logging privacy posture.

## Validation

- `cargo test --locked --lib http_transport_serves_initialize_requests`
- `cargo fmt --check`
- `git diff --check`
- `uv run mkdocs build --strict`
- `bash scripts/check_config_reference.sh`
- `bash scripts/check_dependency_watchlist.sh`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo deny check`
- `bash scripts/check_module_size.sh`
- `cargo test --locked --lib log_format`

Notes: `cargo deny check` reports existing duplicate-crate warnings but exits successfully. `scripts/check_module_size.sh` reports existing soft-target files and passes the ratchet.