### PR TITLE
Harden tool params and temporal payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Hardened MCP/CLI tool parameter handling so unknown top-level params fail
+  fast instead of being silently ignored, and added typed
+  `get_metadata_audit` aliases for `personas`, `resource_types`,
+  `changed_files`, and `entity_ids`.
+- Fixed `get_entity` summary projection drift by including Nova governance
+  metadata in `nova_summary` and the established `provenance.owner` block.
+- Fixed DuckDB `execute_sql`/`run_recipe` temporal result cells so DATE,
+  TIMESTAMP, and TIME values serialize as ISO-style strings instead of raw
+  epoch-day or tick integers.
 - Added a fail-closed hosted auth config skeleton for future proxy/JWT identity
   work while keeping effective runtime behavior default-off.
 - Added design-only hosted identity and JWT threat-model docs, planned config

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -47,7 +47,7 @@ machine-checked stability tier, profile, and safety-gate matrix.
 |------|---------|----------------|
 | `get_test_coverage` | Schema/data test coverage | `id_or_name`, `resource_type`, `include_full`, `columns_limit` |
 | `get_metadata_score` | Metadata quality score | `id_or_name`, `persona`, `scope` |
-| `get_metadata_audit` | Metadata audit report and gate | `selection_mode`, `changed_files_json`, `entity_ids_json`, `thresholds_json` |
+| `get_metadata_audit` | Metadata audit report and gate | `selection_mode`, `changed_files`/`changed_files_json`, `entity_ids`/`entity_ids_json`, `personas`/`personas_json`, `thresholds_json` |
 | `get_agent_readiness` | Agent-readiness report | `personas_json`, `thresholds_json`, `eval_gate_json` |
 | `get_undocumented` | Find entities missing descriptions | `resource_type`, `include_columns`, `package`, `path_prefix` |
 | `search_recipes` | Find analysis recipe templates + parameter contracts | `topic`, `query`, `include_queries`, `limit`, `offset` |

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -843,9 +843,13 @@ report-ready JSON.
 Optional:
 - `selection_mode` (`project`, `changed`, `entities`; default `project`)
 - `changed_files_json`: JSON array of changed file paths for `changed`
+- `changed_files`: typed array alias for `changed_files_json`
 - `entity_ids_json`: JSON array of ids or names for `entities`
+- `entity_ids`: typed array alias for `entity_ids_json`
 - `resource_types_json`: JSON array, defaulting to `["model"]`
+- `resource_types`: typed array alias for `resource_types_json`
 - `personas_json`: JSON array, defaulting to `["engineer"]`
+- `personas`: typed array alias for `personas_json`
 - `thresholds_json`: JSON required/advisory threshold configuration
 - `include_breakdown`, `include_recommendations`
 - `fail_on_no_targets`
@@ -859,6 +863,9 @@ drill-down hints.
 ```json
 {"name":"get_metadata_audit","arguments":{"selection_mode":"changed","changed_files_json":"[\"models/marts/orders.sql\"]"}}
 ```
+
+Unknown top-level tool parameters are rejected instead of ignored. Use either a
+typed array alias or its `*_json` form for the same setting, not both.
 
 See `docs/features/metadata-audit.md` for report fields and threshold examples.
 
@@ -1219,6 +1226,8 @@ Notes:
 - Snowflake provider is available via `DBT_NOVA_SQL_PROVIDER=snowflake`; named parameters are rewritten to SQL API positional binds and null values require explicit `parameter_types`.
 - DuckDB provider is available via `DBT_NOVA_SQL_PROVIDER=duckdb`; named parameters are supported, but `parameter_types` is not. Ad-hoc DuckDB file-scan functions in `execute_sql` text are rejected. Connection-level external access for trusted file-backed database objects is disabled unless `DBT_NOVA_DUCKDB_ALLOW_EXTERNAL_ACCESS=true` is paired with `DBT_NOVA_DUCKDB_FILE_SEARCH_PATH`.
 - DuckDB reuses pooled read-only connections per `(duckdb_path,file_search_path,external_access)` key (`DBT_NOVA_DUCKDB_POOL_MAX_SIZE`).
+- DuckDB DATE, TIMESTAMP, and TIME result cells are serialized as ISO-style
+  strings while `column_types` retains the provider type names.
 - Object-level preflight checks (`preflight_catalog`, `preflight_schema`, `preflight_relation`) require a non-empty probe result across providers; missing/inaccessible targets return `ok=false`.
 - BigQuery credentials can come from OAuth token env vars, `GOOGLE_APPLICATION_CREDENTIALS`, or gcloud ADC (same auth family used by GCS SDK mode).
 - Snowflake credentials can use key-pair JWT, a supplied OAuth bearer token, a Snowflake programmatic access token, or local interactive external browser SSO (`DBT_NOVA_SNOWFLAKE_AUTH=externalbrowser`). Snowflake SQL API workload identity federation is not implemented yet.

--- a/src/cli/audit_cmd.rs
+++ b/src/cli/audit_cmd.rs
@@ -7,19 +7,20 @@ use std::time::Instant;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
+mod tool_params;
+
 use crate::cli::args::{MetadataAuditArgs, MetadataAuditSelectionModeArg};
 use crate::cli::manifest::{build_manifest_load_config, execute_manifest_load};
 use crate::cli::output::CliEnvelope;
 use crate::error::{DbtNovaError, Result};
 use crate::manifest::entity::ArchivedEntity;
 use crate::manifest::search::ManifestSearch;
-use crate::params::{
-    GetMetadataAuditParams, GetMetadataScoreParams, MetadataAuditSelectionModeParam,
-};
+use crate::params::{GetMetadataAuditParams, GetMetadataScoreParams};
 use crate::responses::SuccessResponse;
 use crate::tools::metadata_score::metadata_score_scoring_contract;
 use crate::utils::SearchPersona;
 
+use self::tool_params::metadata_audit_args_from_tool_params;
 use super::{DispatchError, DispatchResult};
 
 const DEFAULT_RESOURCE_TYPES_JSON: &str = "[\"model\"]";
@@ -243,36 +244,11 @@ pub(crate) async fn build_metadata_audit_tool_response(
     search: &ManifestSearch,
     params: &GetMetadataAuditParams,
 ) -> Result<JsonValue> {
-    let args = metadata_audit_args_from_tool_params(params);
+    let args = metadata_audit_args_from_tool_params(params)?;
     let audit_inputs = parse_audit_inputs(&args)?;
     let report = build_metadata_audit_report(search, &audit_inputs, &args).await?;
     serde_json::to_value(SuccessResponse::new(report, 1))
         .map_err(|error| DbtNovaError::ServerError(error.to_string()))
-}
-
-fn metadata_audit_args_from_tool_params(params: &GetMetadataAuditParams) -> MetadataAuditArgs {
-    MetadataAuditArgs {
-        selection_mode: metadata_audit_selection_mode_from_param(params.selection_mode),
-        changed_files_json: params.changed_files_json.clone(),
-        entity_ids_json: params.entity_ids_json.clone(),
-        resource_types_json: params.resource_types_json.clone(),
-        personas_json: params.personas_json.clone(),
-        thresholds_json: params.thresholds_json.clone(),
-        include_breakdown: params.include_breakdown,
-        include_recommendations: params.include_recommendations,
-        fail_on_no_targets: params.fail_on_no_targets,
-        ..MetadataAuditArgs::default()
-    }
-}
-
-fn metadata_audit_selection_mode_from_param(
-    mode: MetadataAuditSelectionModeParam,
-) -> MetadataAuditSelectionModeArg {
-    match mode {
-        MetadataAuditSelectionModeParam::Project => MetadataAuditSelectionModeArg::Project,
-        MetadataAuditSelectionModeParam::Changed => MetadataAuditSelectionModeArg::Changed,
-        MetadataAuditSelectionModeParam::Entities => MetadataAuditSelectionModeArg::Entities,
-    }
 }
 
 fn parse_audit_inputs(args: &MetadataAuditArgs) -> Result<AuditInputs> {

--- a/src/cli/audit_cmd/tool_params.rs
+++ b/src/cli/audit_cmd/tool_params.rs
@@ -1,0 +1,69 @@
+use crate::cli::args::{MetadataAuditArgs, MetadataAuditSelectionModeArg};
+use crate::error::{DbtNovaError, Result};
+use crate::params::{GetMetadataAuditParams, MetadataAuditSelectionModeParam};
+
+pub(super) fn metadata_audit_args_from_tool_params(
+    params: &GetMetadataAuditParams,
+) -> Result<MetadataAuditArgs> {
+    Ok(MetadataAuditArgs {
+        selection_mode: metadata_audit_selection_mode_from_param(params.selection_mode),
+        changed_files_json: typed_array_or_json(
+            "changed_files",
+            &params.changed_files,
+            "changed_files_json",
+            params.changed_files_json.as_ref(),
+        )?,
+        entity_ids_json: typed_array_or_json(
+            "entity_ids",
+            &params.entity_ids,
+            "entity_ids_json",
+            params.entity_ids_json.as_ref(),
+        )?,
+        resource_types_json: typed_array_or_json(
+            "resource_types",
+            &params.resource_types,
+            "resource_types_json",
+            params.resource_types_json.as_ref(),
+        )?,
+        personas_json: typed_array_or_json(
+            "personas",
+            &params.personas,
+            "personas_json",
+            params.personas_json.as_ref(),
+        )?,
+        thresholds_json: params.thresholds_json.clone(),
+        include_breakdown: params.include_breakdown,
+        include_recommendations: params.include_recommendations,
+        fail_on_no_targets: params.fail_on_no_targets,
+        ..MetadataAuditArgs::default()
+    })
+}
+
+fn typed_array_or_json(
+    typed_name: &str,
+    typed_values: &[String],
+    json_name: &str,
+    json_value: Option<&String>,
+) -> Result<Option<String>> {
+    if typed_values.is_empty() {
+        return Ok(json_value.cloned());
+    }
+    if json_value.is_some() {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "use only one of {typed_name} or {json_name}"
+        )));
+    }
+    serde_json::to_string(typed_values)
+        .map(Some)
+        .map_err(|error| DbtNovaError::InvalidParams(format!("invalid {typed_name}: {error}")))
+}
+
+fn metadata_audit_selection_mode_from_param(
+    mode: MetadataAuditSelectionModeParam,
+) -> MetadataAuditSelectionModeArg {
+    match mode {
+        MetadataAuditSelectionModeParam::Project => MetadataAuditSelectionModeArg::Project,
+        MetadataAuditSelectionModeParam::Changed => MetadataAuditSelectionModeArg::Changed,
+        MetadataAuditSelectionModeParam::Entities => MetadataAuditSelectionModeArg::Entities,
+    }
+}

--- a/src/cli/tool.rs
+++ b/src/cli/tool.rs
@@ -3,8 +3,10 @@ use std::io::Read;
 use std::pin::Pin;
 use std::time::{Duration, Instant};
 
+use schemars::{JsonSchema, SchemaGenerator};
 use serde::de::DeserializeOwned;
 use serde_json::Value as JsonValue;
+use std::collections::BTreeSet;
 
 use crate::cli::agent_readiness_cmd::build_agent_readiness_tool_response;
 use crate::cli::args::{ManifestLoadArgs, ManifestReloadArgs, ToolCallArgs};
@@ -537,10 +539,86 @@ fn parse_params_payload(source: &str, raw: &str) -> Result<JsonValue> {
     })
 }
 
-fn decode_tool_params<T: DeserializeOwned>(tool_name: &str, value: JsonValue) -> Result<T> {
+fn decode_tool_params<T>(tool_name: &str, value: JsonValue) -> Result<T>
+where
+    T: DeserializeOwned + JsonSchema,
+{
+    validate_known_param_keys::<T>(tool_name, &value)?;
     serde_json::from_value(value).map_err(|error| {
         DbtNovaError::InvalidParams(format!("invalid params for '{tool_name}': {error}"))
     })
+}
+
+fn validate_known_param_keys<T: JsonSchema>(tool_name: &str, value: &JsonValue) -> Result<()> {
+    let Some(params) = value.as_object() else {
+        return Ok(());
+    };
+    if params.is_empty() {
+        return Ok(());
+    }
+
+    let supported = supported_param_keys::<T>(tool_name);
+    for key in params.keys() {
+        if !supported.contains(key) {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "unknown parameter '{key}' for '{tool_name}'; supported parameters: {}",
+                supported.into_iter().collect::<Vec<_>>().join(", ")
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn supported_param_keys<T: JsonSchema>(tool_name: &str) -> BTreeSet<String> {
+    let mut generator = SchemaGenerator::default();
+    let schema = generator.root_schema_for::<T>().to_value();
+    let mut keys = BTreeSet::new();
+    collect_schema_properties(&schema, &schema, &mut keys);
+    for alias in serde_param_aliases(tool_name) {
+        keys.insert((*alias).to_string());
+    }
+    keys
+}
+
+fn collect_schema_properties(schema: &JsonValue, root: &JsonValue, keys: &mut BTreeSet<String>) {
+    let Some(object) = schema.as_object() else {
+        return;
+    };
+
+    if let Some(reference) = object.get("$ref").and_then(JsonValue::as_str) {
+        if let Some(target) = resolve_local_schema_ref(root, reference) {
+            collect_schema_properties(target, root, keys);
+        }
+        return;
+    }
+
+    if let Some(properties) = object.get("properties").and_then(JsonValue::as_object) {
+        keys.extend(properties.keys().cloned());
+    }
+
+    for keyword in ["allOf", "anyOf", "oneOf"] {
+        if let Some(schemas) = object.get(keyword).and_then(JsonValue::as_array) {
+            for schema in schemas {
+                collect_schema_properties(schema, root, keys);
+            }
+        }
+    }
+}
+
+fn resolve_local_schema_ref<'a>(root: &'a JsonValue, reference: &str) -> Option<&'a JsonValue> {
+    reference
+        .strip_prefix('#')
+        .and_then(|pointer| root.pointer(pointer))
+}
+
+fn serde_param_aliases(tool_name: &str) -> &'static [&'static str] {
+    match tool_name {
+        "get_entity" => &["unique_id"],
+        "validate_nova_meta" => &["path"],
+        "execute_sql" => &["sql"],
+        _ => &[],
+    }
 }
 
 fn decode_empty_params(tool_name: &str, value: JsonValue) -> Result<()> {
@@ -983,18 +1061,17 @@ fn dispatch_cleanup_storage(searcher: &ManifestSearch, params: JsonValue) -> Too
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use tempfile::NamedTempFile;
 
     use super::{
-        build_reload_args_from_tool_call, dispatch_tool, resolve_params_value_with_stdin,
-        run_call_command, run_search_with_timeout, tool_registry_names,
+        build_reload_args_from_tool_call, decode_tool_params, dispatch_tool,
+        resolve_params_value_with_stdin, run_call_command, run_search_with_timeout,
+        tool_registry_names,
     };
     use crate::cli::args::{ManifestLoadArgs, ToolCallArgs};
     use crate::cli::manifest::{build_manifest_load_config, execute_manifest_load};
-    use crate::params::ReloadManifestParams;
-    use crate::tests::common::fixture_manifest_path_string;
+    use crate::params::{ExecuteSqlParams, ReloadManifestParams};
+    use crate::tests::common::{fixture_manifest_path_string, get_searcher_with_fixture};
     use crate::tools::catalog::MCP_TOOL_NAMES;
 
     async fn fixture_searcher() -> crate::manifest::search::ManifestSearch {
@@ -1084,6 +1161,129 @@ mod tests {
         .await
         .expect("search");
         assert!(result["data"].is_array());
+    }
+
+    #[tokio::test]
+    async fn dispatch_rejects_unknown_params_before_tool_execution() {
+        let searcher = fixture_searcher().await;
+        let err = dispatch_tool(
+            &searcher,
+            "list_entities",
+            serde_json::json!({
+                "resource_type": "model",
+                "governance_pii": "possible"
+            }),
+        )
+        .await
+        .expect_err("unknown params should fail");
+
+        assert!(
+            err.to_string()
+                .contains("unknown parameter 'governance_pii' for 'list_entities'")
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_rejects_unknown_params_across_registered_tools() {
+        let searcher = fixture_searcher().await;
+        let empty_param_tools = [
+            "show_metadata",
+            "health",
+            "list_tags",
+            "list_packages",
+            "list_databases",
+        ];
+
+        for tool in tool_registry_names() {
+            if tool == "reload_manifest" {
+                continue;
+            }
+            let err = dispatch_tool(
+                &searcher,
+                tool,
+                serde_json::json!({
+                    "__bogus_param": true
+                }),
+            )
+            .await
+            .expect_err("tool should reject bogus params");
+            let message = err.to_string();
+            if empty_param_tools.contains(&tool) {
+                assert!(
+                    message.contains("does not accept parameters"),
+                    "unexpected error for {tool}: {message}"
+                );
+            } else {
+                assert!(
+                    message.contains("unknown parameter '__bogus_param'"),
+                    "unexpected error for {tool}: {message}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn decode_tool_params_keeps_serde_aliases() {
+        let params: ExecuteSqlParams = decode_tool_params(
+            "execute_sql",
+            serde_json::json!({
+                "sql": "select 1"
+            }),
+        )
+        .expect("sql alias should be supported");
+
+        assert_eq!(params.statement, "select 1");
+    }
+
+    #[tokio::test]
+    async fn dispatch_get_metadata_audit_honors_typed_aliases() {
+        let searcher = fixture_searcher().await;
+        let result = dispatch_tool(
+            &searcher,
+            "get_metadata_audit",
+            serde_json::json!({
+                "selection_mode": "project",
+                "resource_types": ["model"],
+                "personas": ["governance"],
+                "include_recommendations": false
+            }),
+        )
+        .await
+        .expect("metadata audit");
+
+        assert_eq!(result["success"], serde_json::json!(true));
+        assert_eq!(
+            result["data"]["personas"],
+            serde_json::json!(["governance"])
+        );
+        assert_eq!(
+            result["data"]["summary"]["worst_entities_by_persona"][0]["persona"],
+            serde_json::json!("governance")
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_get_entity_includes_governance_and_owner_projection() {
+        let searcher = get_searcher_with_fixture("perfect_model.json");
+        let result = dispatch_tool(
+            &searcher,
+            "get_entity",
+            serde_json::json!({
+                "id_or_name": "model.nova_test.perfect_model"
+            }),
+        )
+        .await
+        .expect("get entity");
+
+        assert_eq!(result["success"], serde_json::json!(true));
+        assert_eq!(
+            result["data"]["nova_summary"]["governance"]["sensitivity"],
+            serde_json::json!("high")
+        );
+        assert_eq!(
+            result["data"]["provenance"]["owner"],
+            serde_json::json!("test.owner@example.com")
+        );
     }
 
     #[tokio::test]
@@ -1286,8 +1486,7 @@ cases:
     #[tokio::test]
     async fn run_search_with_timeout_enforces_timeout() {
         let err = run_search_with_timeout(1, async {
-            tokio::time::sleep(Duration::from_millis(50)).await;
-            Ok(serde_json::json!({"ok": true}))
+            std::future::pending::<crate::error::Result<serde_json::Value>>().await
         })
         .await
         .expect_err("timeout should fail");

--- a/src/manifest/search/summary/nova.rs
+++ b/src/manifest/search/summary/nova.rs
@@ -266,6 +266,9 @@ impl ManifestSearch {
         if let Some(grain) = nova.grain.as_ref().and_then(Self::nova_grain_summary) {
             obj.insert("grain".to_string(), grain);
         }
+        if let Some(governance) = Self::nova_governance_summary(nova) {
+            obj.insert("governance".to_string(), governance);
+        }
         let measures = Self::nova_measures_summary(nova);
         if !measures.is_empty() {
             obj.insert("measures".to_string(), JsonValue::Array(measures));
@@ -310,6 +313,9 @@ impl ManifestSearch {
         let mut obj = serde_json::Map::new();
         if let Some(grain) = nova.grain.as_ref().and_then(Self::nova_grain_summary) {
             obj.insert("grain".to_string(), grain);
+        }
+        if let Some(governance) = Self::nova_governance_summary(nova) {
+            obj.insert("governance".to_string(), governance);
         }
         if nova.canonical {
             obj.insert("canonical".to_string(), JsonValue::from(true));

--- a/src/params.rs
+++ b/src/params.rs
@@ -18,6 +18,7 @@ pub fn default_true() -> bool {
 }
 
 #[derive(Debug, Deserialize, JsonSchema, Clone, Copy, Default)]
+#[serde(deny_unknown_fields)]
 #[serde(default)]
 pub struct PaginationParams {
     /// Maximum results. Omit or pass 0 to use the configured default limit.
@@ -27,6 +28,7 @@ pub struct PaginationParams {
 }
 
 #[derive(Debug, Deserialize, JsonSchema, Clone, Copy)]
+#[serde(deny_unknown_fields)]
 #[serde(default)]
 pub struct ContextLimits {
     /// Maximum depth for lineage traversal (default: 1 for immediate only)
@@ -73,6 +75,7 @@ pub enum ParentGroupMode {
 /// Parameters for the search tool.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Deserialize, JsonSchema, Default)]
+#[serde(deny_unknown_fields)]
 pub struct SearchParams {
     /// Search query - matches names, descriptions, SQL code, file paths, column names.
     /// Supports boolean operators, phrases, field-specific queries, and prefix wildcards.
@@ -108,6 +111,7 @@ pub struct SearchParams {
 
 /// Parameters for the search_indicator tool.
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct SearchIndicatorParams {
     /// Search query - resolves Nova measures and metrics by name, synonym, field, description, or expression.
     #[serde(default)]
@@ -163,6 +167,7 @@ impl Default for SearchIndicatorParams {
 
 /// Parameters for the indicator_inventory tool.
 #[derive(Debug, Deserialize, JsonSchema, Default)]
+#[serde(deny_unknown_fields)]
 pub struct IndicatorInventoryParams {
     /// Filter parent entities by resource types (for example: model, source).
     #[serde(default)]
@@ -179,6 +184,7 @@ pub struct IndicatorInventoryParams {
 
 /// Parameters for the search_columns tool.
 #[derive(Debug, Deserialize, JsonSchema, Default)]
+#[serde(deny_unknown_fields)]
 pub struct SearchColumnsParams {
     /// Search query - resolves columns by name, synonym, description, role, semantic_type, or example_values.
     #[serde(default)]
@@ -201,6 +207,7 @@ pub struct SearchColumnsParams {
 
 /// Parameters for the column_inventory tool.
 #[derive(Debug, Deserialize, JsonSchema, Default)]
+#[serde(deny_unknown_fields)]
 pub struct ColumnInventoryParams {
     /// Filter parent entities by resource types (for example: model, source).
     #[serde(default)]
@@ -220,6 +227,7 @@ pub struct ColumnInventoryParams {
 
 /// Parameters for the compare_grains tool.
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct CompareGrainsParams {
     /// First entity unique ID or name
     pub entity1: String,
@@ -235,6 +243,7 @@ pub struct CompareGrainsParams {
 
 /// Parameters for the find_entity_overlap tool.
 #[derive(Debug, Deserialize, JsonSchema, Default)]
+#[serde(deny_unknown_fields)]
 pub struct FindEntityOverlapParams {
     /// Optional focus entity unique ID or name. When set, only overlap pairs involving this entity are returned.
     #[serde(default)]
@@ -254,6 +263,7 @@ pub struct FindEntityOverlapParams {
 
 /// Parameters for the modelling_consistency_report tool.
 #[derive(Debug, Deserialize, JsonSchema, Default)]
+#[serde(deny_unknown_fields)]
 pub struct ModellingConsistencyReportParams {
     /// Filter candidate entities by resource types (for example: model, source).
     #[serde(default)]
@@ -268,6 +278,7 @@ pub struct ModellingConsistencyReportParams {
 
 /// Parameters for the get_entity tool.
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct GetEntityParams {
     /// Unique ID (e.g., "model.package.name") or entity name
     #[serde(alias = "unique_id")]
@@ -281,6 +292,7 @@ pub struct GetEntityParams {
 
 /// Parameters for the list_entities tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct ListEntitiesParams {
     /// Resource type: model, source, macro, doc, test, seed, snapshot, analysis, exposure, metric, group
     pub resource_type: String,
@@ -300,6 +312,7 @@ pub struct ListEntitiesParams {
 
 /// Parameters for searching and discovering recipe templates.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct SearchRecipesParams {
     /// Optional text filter on recipe id, description, or tags.
     #[serde(default)]
@@ -316,6 +329,7 @@ pub struct SearchRecipesParams {
 
 /// Parameters for loading a recipe definition.
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct GetRecipeParams {
     /// Recipe identifier derived from manifest analysis path (e.g. `weekly_country_kpi_report` or `marketplace/weekly_report`)
     pub recipe_id: String,
@@ -339,6 +353,7 @@ pub struct GetRecipeParams {
 
 /// Parameters for running a recipe as a reusable, deterministic analysis sequence.
 #[derive(Debug, Deserialize, JsonSchema, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct RunRecipeParams {
     /// Recipe identifier derived from manifest analysis path (e.g. `weekly_country_kpi_report` or `marketplace/weekly_report`)
     pub recipe_id: String,
@@ -396,6 +411,7 @@ pub struct RunRecipeParams {
 
 /// Parameters for the get_lineage tool.
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct GetLineageParams {
     /// Unique ID or name of the entity
     pub id_or_name: String,
@@ -413,6 +429,7 @@ pub struct GetLineageParams {
 
 /// Parameters for the get_sql tool.
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct GetSqlParams {
     /// Unique ID or name of the model
     pub id_or_name: String,
@@ -423,6 +440,7 @@ pub struct GetSqlParams {
 
 /// Parameters for the get_columns tool.
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct GetColumnsParams {
     /// Unique ID or name of the model/source
     pub id_or_name: String,
@@ -430,6 +448,7 @@ pub struct GetColumnsParams {
 
 /// Parameters for the diff_entities tool.
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct DiffEntitiesParams {
     /// First entity unique ID or name
     pub entity1: String,
@@ -448,6 +467,7 @@ pub struct DiffEntitiesParams {
 
 /// Parameters for the get_impact tool.
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct GetImpactParams {
     /// Unique ID or name of the entity to assess
     pub id_or_name: String,
@@ -455,6 +475,7 @@ pub struct GetImpactParams {
 
 /// Parameters for the get_column_lineage tool.
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct GetColumnLineageParams {
     /// Unique ID or name of the model/source
     pub id_or_name: String,
@@ -474,6 +495,7 @@ pub struct GetColumnLineageParams {
 
 /// Parameters for the get_test_coverage tool.
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct GetTestCoverageParams {
     /// Unique ID or name of the model/source to analyze
     pub id_or_name: String,
@@ -490,6 +512,7 @@ pub struct GetTestCoverageParams {
 
 /// Parameters for the batch_get_entities tool.
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct BatchGetParams {
     /// List of unique IDs to retrieve
     pub unique_ids: Vec<String>,
@@ -500,6 +523,7 @@ pub struct BatchGetParams {
 
 /// Parameters for the find_by_path tool.
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct FindByPathParams {
     /// File path pattern to match (e.g., "models/staging/**", "models/*.sql")
     pub path_pattern: String,
@@ -515,6 +539,7 @@ pub struct FindByPathParams {
 
 /// Parameters for the get_undocumented tool.
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct GetUndocumentedParams {
     /// Resource type to check: model, source, macro, etc.
     pub resource_type: String,
@@ -547,6 +572,7 @@ pub enum ValidateDagDetail {
 
 /// Parameters for the validate_dag tool.
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct ValidateDagParams {
     /// Detail level: full or summary (default: full)
     #[serde(default)]
@@ -555,6 +581,7 @@ pub struct ValidateDagParams {
 
 /// Parameters for the get_context tool.
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct GetContextParams {
     /// Unique ID or name of the entity to get context for
@@ -599,6 +626,7 @@ pub enum ContextMode {
 
 /// Parameters for the get_metadata_score tool.
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct GetMetadataScoreParams {
     /// Entity to score (optional for project scope)
     #[serde(default)]
@@ -647,6 +675,7 @@ impl Default for GetMetadataScoreParams {
 
 /// Parameters for the get_agent_readiness tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct GetAgentReadinessParams {
     /// JSON array of personas to score. Defaults to `["engineer","analyst","governance"]`.
     #[serde(default)]
@@ -674,6 +703,7 @@ pub enum MetadataAuditSelectionModeParam {
 
 /// Parameters for the get_metadata_audit tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct GetMetadataAuditParams {
     /// Audit selection mode. Defaults to project.
     #[serde(default)]
@@ -681,15 +711,27 @@ pub struct GetMetadataAuditParams {
     /// JSON array of changed file paths for changed selection mode.
     #[serde(default)]
     pub changed_files_json: Option<String>,
+    /// Typed alias for `changed_files_json`.
+    #[serde(default)]
+    pub changed_files: Vec<String>,
     /// JSON array of entity ids or names for entities selection mode.
     #[serde(default)]
     pub entity_ids_json: Option<String>,
+    /// Typed alias for `entity_ids_json`.
+    #[serde(default)]
+    pub entity_ids: Vec<String>,
     /// JSON array of resource types. Defaults to `["model"]`.
     #[serde(default)]
     pub resource_types_json: Option<String>,
+    /// Typed alias for `resource_types_json`.
+    #[serde(default)]
+    pub resource_types: Vec<String>,
     /// JSON array of personas. Defaults to `["engineer"]`.
     #[serde(default)]
     pub personas_json: Option<String>,
+    /// Typed alias for `personas_json`.
+    #[serde(default)]
+    pub personas: Vec<String>,
     /// JSON threshold configuration for required/advisory gates.
     #[serde(default)]
     pub thresholds_json: Option<String>,
@@ -720,6 +762,7 @@ pub enum NovaMetaResourceKindParam {
 
 /// Parameters for the validate_nova_meta tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct ValidateNovaMetaParams {
     /// dbt project directory to scan. Relative paths are resolved under the server working directory.
     #[serde(default)]
@@ -740,6 +783,7 @@ pub struct ValidateNovaMetaParams {
 
 /// Parameters for the validate_eval_suite tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct ValidateEvalSuiteParams {
     /// YAML or JSON eval suite path under the server working directory.
     pub suite: String,
@@ -747,6 +791,7 @@ pub struct ValidateEvalSuiteParams {
 
 /// Parameters for the get_eval_gate tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct GetEvalGateParams {
     /// Eval suite name to check in telemetry.
     pub suite: String,
@@ -754,6 +799,7 @@ pub struct GetEvalGateParams {
 
 /// Parameters for the get_eval_history tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct GetEvalHistoryParams {
     /// Eval suite name to read history for.
     pub suite: String,
@@ -763,6 +809,7 @@ pub struct GetEvalHistoryParams {
 
 /// Parameters for the compare_eval_runs tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct CompareEvalRunsParams {
     /// Before eval result directory or results.json path under the server working directory.
     pub before: String,
@@ -772,6 +819,7 @@ pub struct CompareEvalRunsParams {
 
 /// Parameters for the run_eval tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct RunEvalParams {
     /// YAML or JSON eval suite path under the server working directory.
     pub suite: String,
@@ -794,6 +842,7 @@ pub struct RunEvalParams {
 
 /// Parameters for the init_eval_suite tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct InitEvalSuiteParams {
     /// Persona to use in the generated starter suite. Defaults to analyst.
     #[serde(default)]
@@ -807,6 +856,7 @@ pub struct InitEvalSuiteParams {
 
 /// Parameters for the run_agent_eval tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct RunAgentEvalParams {
     /// YAML or JSON eval suite path under the server working directory.
     pub suite: String,
@@ -859,6 +909,7 @@ pub struct RunAgentEvalParams {
 
 /// Parameters for the inspect_tool_trace tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct TraceInspectParams {
     /// JSONL tool trace path under the server working directory.
     pub path: String,
@@ -866,6 +917,7 @@ pub struct TraceInspectParams {
 
 /// Parameters for the summarize_tool_trace tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct TraceSummarizeParams {
     /// JSONL tool trace path under the server working directory.
     pub path: String,
@@ -876,6 +928,7 @@ pub struct TraceSummarizeParams {
 
 /// Parameters for the redact_tool_trace tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct TraceRedactParams {
     /// JSONL tool trace path under the server working directory.
     pub path: String,
@@ -885,6 +938,7 @@ pub struct TraceRedactParams {
 
 /// Parameters for the replay_tool_trace tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct TraceReplayParams {
     /// JSONL tool trace path under the server working directory.
     pub path: String,
@@ -892,6 +946,7 @@ pub struct TraceReplayParams {
 
 /// Parameters for the show_config tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct ConfigShowParams {
     /// Return default configuration instead of the active runtime configuration.
     #[serde(default)]
@@ -900,10 +955,12 @@ pub struct ConfigShowParams {
 
 /// Parameters for the validate_config tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct ConfigValidateParams {}
 
 /// Parameters for the reload_manifest tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct ReloadManifestParams {
     /// Manifest URI to load (e.g. http(s)://, s3://, gs://, dbfs://)
     pub manifest_uri: Option<String>,
@@ -933,6 +990,7 @@ fn non_empty_param(value: Option<&str>) -> bool {
 
 /// Parameters for the warm_manifest tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct WarmManifestParams {
     /// Warm vector embedding query/model caches.
@@ -951,6 +1009,7 @@ pub struct WarmManifestParams {
 
 /// Parameters for the inspect_storage tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct StorageInspectParams {
     /// Optional storage instance id to inspect as the configured instance.
     #[serde(default)]
@@ -959,6 +1018,7 @@ pub struct StorageInspectParams {
 
 /// Parameters for the prune_storage tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct StoragePruneParams {
     /// Number of stale storage instances to retain. Defaults to storage policy.
     #[serde(default)]
@@ -973,6 +1033,7 @@ pub struct StoragePruneParams {
 
 /// Parameters for the cleanup_storage tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct StorageCleanupParams {
     /// Optional storage instance id to clean up.
     #[serde(default)]
@@ -981,6 +1042,7 @@ pub struct StorageCleanupParams {
 
 /// Parameters for the execute_sql tool.
 #[derive(Debug, Deserialize, JsonSchema, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct ExecuteSqlParams {
     /// SQL statement to execute.
     /// Optional when `preflight_only=true`.
@@ -1033,7 +1095,7 @@ pub struct ExecuteSqlParams {
 mod tests {
     use serde_json::json;
 
-    use super::{ExecuteSqlParams, GetEntityParams};
+    use super::{ExecuteSqlParams, GetEntityParams, GetMetadataAuditParams, ListEntitiesParams};
 
     #[test]
     fn get_entity_accepts_unique_id_alias() {
@@ -1049,5 +1111,31 @@ mod tests {
             serde_json::from_value(json!({"sql": "select 1"})).expect("params");
 
         assert_eq!(params.statement, "select 1");
+    }
+
+    #[test]
+    fn params_reject_unknown_fields_for_mcp_deserialization() {
+        let err = serde_json::from_value::<ListEntitiesParams>(
+            json!({"resource_type": "model", "governance_pii": "possible"}),
+        )
+        .expect_err("unknown params should fail");
+
+        assert!(err.to_string().contains("unknown field `governance_pii`"));
+    }
+
+    #[test]
+    fn metadata_audit_accepts_typed_alias_fields() {
+        let params: GetMetadataAuditParams = serde_json::from_value(json!({
+            "personas": ["governance"],
+            "resource_types": ["model"],
+            "changed_files": ["models/marts/orders.sql"],
+            "entity_ids": ["model.pkg.orders"]
+        }))
+        .expect("typed params");
+
+        assert_eq!(params.personas, vec!["governance"]);
+        assert_eq!(params.resource_types, vec!["model"]);
+        assert_eq!(params.changed_files, vec!["models/marts/orders.sql"]);
+        assert_eq!(params.entity_ids, vec!["model.pkg.orders"]);
     }
 }

--- a/src/tools/entity.rs
+++ b/src/tools/entity.rs
@@ -1,7 +1,7 @@
 use serde_json::Value as JsonValue;
 
 use crate::error::{DbtNovaError, Result};
-use crate::manifest::entity::normalized_column_meta_json;
+use crate::manifest::entity::{ArchivedEntity, normalized_column_meta_json};
 use crate::manifest::search::ManifestSearch;
 use crate::params::{BatchGetParams, DetailLevel, GetColumnsParams, GetEntityParams, GetSqlParams};
 use crate::responses::SuccessResponse;
@@ -27,7 +27,11 @@ impl ManifestSearch {
             let mut matches: Vec<JsonValue> = Vec::new();
             for k in &keys {
                 if let Some(entity) = self.get_entity_archived(k)? {
-                    matches.push(self.summary_for_standard(k, entity));
+                    matches.push(self.add_entity_provenance(
+                        k,
+                        entity,
+                        self.summary_for_standard(k, entity),
+                    ));
                 }
             }
             return Ok(serde_json::to_value(SuccessResponse::new(
@@ -38,13 +42,29 @@ impl ManifestSearch {
 
         let entity = self.get_entity_archived(&keys[0])?.map_or_else(
             || JsonValue::Null,
-            |entity| match detail {
-                DetailLevel::Full => entity.to_json_value(),
-                DetailLevel::Compact => self.summary_for_compact(&keys[0], entity),
-                DetailLevel::Standard => self.summary_for_standard(&keys[0], entity),
+            |entity| {
+                let payload = match detail {
+                    DetailLevel::Full => entity.to_json_value(),
+                    DetailLevel::Compact => self.summary_for_compact(&keys[0], entity),
+                    DetailLevel::Standard => self.summary_for_standard(&keys[0], entity),
+                };
+                self.add_entity_provenance(&keys[0], entity, payload)
             },
         );
         Ok(serde_json::to_value(SuccessResponse::new(entity, 1))?)
+    }
+
+    fn add_entity_provenance(
+        &self,
+        unique_id: &str,
+        entity: &ArchivedEntity,
+        mut payload: JsonValue,
+    ) -> JsonValue {
+        let provenance = self.provenance_for_archived(unique_id, entity);
+        if let Some(obj) = payload.as_object_mut() {
+            obj.insert("provenance".to_string(), provenance);
+        }
+        payload
     }
 
     /// Get raw or compiled SQL for a model.

--- a/src/warehouse/duckdb.rs
+++ b/src/warehouse/duckdb.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 
 use base64::Engine as _;
 use duckdb::params_from_iter;
-use duckdb::types::Value as DuckValue;
+use duckdb::types::{TimeUnit, Value as DuckValue};
 use duckdb::{AccessMode, Config, Connection};
 use serde_json::{Map as JsonMap, Value, json};
 use tokio::sync::{OwnedSemaphorePermit, RwLock, Semaphore};
@@ -532,10 +532,11 @@ fn duck_value_to_json(value: DuckValue) -> Value {
         DuckValue::Boolean(value) => json!(value),
         DuckValue::TinyInt(value) => json!(value),
         DuckValue::SmallInt(value) => json!(value),
-        DuckValue::Int(value) | DuckValue::Date32(value) => json!(value),
-        DuckValue::BigInt(value) | DuckValue::Timestamp(_, value) | DuckValue::Time64(_, value) => {
-            json!(value)
-        }
+        DuckValue::Int(value) => json!(value),
+        DuckValue::Date32(value) => Value::String(date32_to_iso(value)),
+        DuckValue::BigInt(value) => json!(value),
+        DuckValue::Timestamp(unit, value) => Value::String(timestamp_to_iso(unit, value)),
+        DuckValue::Time64(unit, value) => Value::String(time64_to_iso(unit, value)),
         DuckValue::HugeInt(value) => Value::String(value.to_string()),
         DuckValue::UTinyInt(value) => json!(value),
         DuckValue::USmallInt(value) => json!(value),
@@ -574,6 +575,93 @@ fn duck_value_to_json(value: DuckValue) -> Value {
         ),
         DuckValue::Union(value) => duck_value_to_json(*value),
     }
+}
+
+fn date32_to_iso(days_since_epoch: i32) -> String {
+    let (year, month, day) = civil_from_days(i64::from(days_since_epoch));
+    format_date(year, month, day)
+}
+
+fn timestamp_to_iso(unit: TimeUnit, value: i64) -> String {
+    let (seconds, nanos) = match unit {
+        TimeUnit::Second => (value, 0),
+        TimeUnit::Millisecond => {
+            let (seconds, millis) = div_rem_floor(value, 1_000);
+            (seconds, millis * 1_000_000)
+        }
+        TimeUnit::Microsecond => {
+            let (seconds, micros) = div_rem_floor(value, 1_000_000);
+            (seconds, micros * 1_000)
+        }
+        TimeUnit::Nanosecond => div_rem_floor(value, 1_000_000_000),
+    };
+    let (days, seconds_of_day) = div_rem_floor(seconds, 86_400);
+    let (year, month, day) = civil_from_days(days);
+    format!(
+        "{}T{}",
+        format_date(year, month, day),
+        format_time_of_day(seconds_of_day, nanos)
+    )
+}
+
+fn time64_to_iso(unit: TimeUnit, value: i64) -> String {
+    let nanos = match unit {
+        TimeUnit::Second => value.saturating_mul(1_000_000_000),
+        TimeUnit::Millisecond => value.saturating_mul(1_000_000),
+        TimeUnit::Microsecond => value.saturating_mul(1_000),
+        TimeUnit::Nanosecond => value,
+    };
+    let (_, nanos_of_day) = div_rem_floor(nanos, 86_400_000_000_000);
+    let seconds_of_day = nanos_of_day / 1_000_000_000;
+    let fraction_nanos = nanos_of_day % 1_000_000_000;
+    format_time_of_day(seconds_of_day, fraction_nanos)
+}
+
+fn div_rem_floor(value: i64, divisor: i64) -> (i64, i64) {
+    let mut quotient = value / divisor;
+    let mut remainder = value % divisor;
+    if remainder < 0 {
+        quotient -= 1;
+        remainder += divisor;
+    }
+    (quotient, remainder)
+}
+
+fn civil_from_days(days_since_epoch: i64) -> (i64, i64, i64) {
+    let days = days_since_epoch + 719_468;
+    let era = if days >= 0 { days } else { days - 146_096 } / 146_097;
+    let day_of_era = days - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_phase = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_phase + 2) / 5 + 1;
+    let month = month_phase + if month_phase < 10 { 3 } else { -9 };
+    let year = year + i64::from(month <= 2);
+    (year, month, day)
+}
+
+fn format_date(year: i64, month: i64, day: i64) -> String {
+    if (0..=9999).contains(&year) {
+        format!("{year:04}-{month:02}-{day:02}")
+    } else {
+        format!("{year}-{month:02}-{day:02}")
+    }
+}
+
+fn format_time_of_day(seconds_of_day: i64, nanos: i64) -> String {
+    let hours = seconds_of_day / 3_600;
+    let minutes = (seconds_of_day % 3_600) / 60;
+    let seconds = seconds_of_day % 60;
+    if nanos == 0 {
+        return format!("{hours:02}:{minutes:02}:{seconds:02}");
+    }
+    let mut fraction = format!("{nanos:09}");
+    while fraction.ends_with('0') {
+        fraction.pop();
+    }
+    format!("{hours:02}:{minutes:02}:{seconds:02}.{fraction}")
 }
 
 fn normalized_limit(limit: Option<u64>, fallback: u64) -> u64 {
@@ -1016,8 +1104,9 @@ mod tests {
         DuckDbConfig, build_bind_values, catalog_preflight_statement,
         configuration_failure_preflight_payload, missing_configuration_preflight_payload,
         normalize_preflight_relation, relation_preflight_statement, resolve_duckdb_pool_max_size,
-        rewrite_named_parameters, schema_preflight_statement,
+        rewrite_named_parameters, schema_preflight_statement, time64_to_iso,
     };
+    use duckdb::types::TimeUnit;
     use serde_json::json;
     use std::collections::HashMap;
     use std::path::PathBuf;
@@ -1182,5 +1271,15 @@ mod tests {
     fn resolve_duckdb_pool_max_size_clamps_zero_to_one() {
         assert_eq!(resolve_duckdb_pool_max_size(Some(0), None), 1);
         assert_eq!(resolve_duckdb_pool_max_size(None, Some(0)), 1);
+    }
+
+    #[test]
+    fn time64_to_iso_preserves_nanosecond_precision() {
+        let nanos = 12 * 3_600_000_000_000 + 34 * 60_000_000_000 + 56 * 1_000_000_000 + 123_456_789;
+
+        assert_eq!(
+            time64_to_iso(TimeUnit::Nanosecond, nanos),
+            "12:34:56.123456789"
+        );
     }
 }

--- a/tests/duckdb_provider.rs
+++ b/tests/duckdb_provider.rs
@@ -241,6 +241,36 @@ fn duckdb_execute_supports_named_params_and_row_limit_truncation() {
 }
 
 #[test]
+fn duckdb_execute_serializes_temporal_values_as_strings() {
+    let _env_lock = lock_env();
+    let (_temp_dir, db_path) = create_fixture_database();
+    let _env_guard = configure_duckdb_env(Some(&db_path), None);
+
+    let params = base_params(
+        "SELECT
+             DATE '2026-07-09' AS order_date,
+             TIMESTAMP '2026-07-09 12:34:56.789123' AS observed_at,
+             TIME '12:34:56.123456' AS observed_time",
+    );
+
+    let runtime = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let payload = runtime
+        .block_on(DUCKDB_PROVIDER.execute(&params))
+        .expect("duckdb execute should succeed");
+
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(
+        payload["data"]["rows"][0],
+        json!([
+            "2026-07-09",
+            "2026-07-09T12:34:56.789123",
+            "12:34:56.123456"
+        ])
+    );
+    assert_eq!(payload["data"]["column_types"][0], json!("Date32"));
+}
+
+#[test]
 fn duckdb_execute_honors_byte_limit_truncation() {
     let _env_lock = lock_env();
     let (_temp_dir, db_path) = create_fixture_database();

--- a/tests/snapshots/snapshots__get_entity_orders.snap
+++ b/tests/snapshots/snapshots__get_entity_orders.snap
@@ -12,6 +12,21 @@ expression: result
     "name": "fct__orders",
     "original_file_path": "models/marts/sales/fct__orders.sql",
     "package_name": "nova_test",
+    "provenance": {
+      "freshness": {
+        "reason": "no_freshness_timestamp",
+        "status": "unknown"
+      },
+      "readiness": {
+        "doc_coverage_pct": 100.0,
+        "has_nova_meta": false,
+        "has_owner": false,
+        "metadata_grade": "F",
+        "metadata_score": 2,
+        "tests_total": 0
+      },
+      "tier": "curated"
+    },
     "resource_type": "model",
     "schema": "dbt_test",
     "unique_id": "model.nova_test.fct__orders"


### PR DESCRIPTION
## Summary
- Reject unknown top-level MCP/CLI tool params before execution and add typed `get_metadata_audit` array aliases while preserving existing `*_json` forms.
- Restore `get_entity` projection consistency by including Nova governance metadata and `provenance.owner` in entity payloads.
- Serialize DuckDB DATE/TIMESTAMP/TIME result cells as ISO-style strings instead of raw epoch/tick integers, including nanosecond-preserving `Time64` formatting.
- Keep the metadata-audit adapter under the module-size ratchet by splitting tool-param conversion into a small submodule.
- Update the `get_entity` snapshot for the intended additive provenance payload.

Fixes #281.
Fixes #282.
Fixes #288.

## Validation
- `cargo fmt --check`
- `cargo test --locked --lib cli::tool::tests`
- `cargo test --locked --lib params::tests`
- `cargo test --locked --lib warehouse::duckdb::tests::time64_to_iso_preserves_nanosecond_precision`
- `cargo test --locked --test snapshots snapshot_get_entity_orders -- --nocapture`
- `uv run mkdocs build --strict`
- `cargo test --locked --test duckdb_provider duckdb_execute_serializes_temporal_values_as_strings -- --nocapture`
- `scripts/check_module_size.sh`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `git diff --check`

## Notes
- Kept the change additive to documented aliases and payload fields, except for the intentional hardening behavior that unknown top-level params now fail fast instead of being silently ignored.
- Did not release.
