### PR TITLE
Harden manifest warm and inventory filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed `manifest warm`/`warm_manifest` so no-flag warmup respects the resolved
+  semantic search config, added governance/tier/canonical `list_entities`
+  filters for structured inventory, and accepted `analyst`/`governance`
+  `get_context` modes as standard-projection persona aliases.
 - Hardened MCP/CLI tool parameter handling so unknown top-level params fail
   fast instead of being silently ignored, and added typed
   `get_metadata_audit` aliases for `personas`, `resource_types`,

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -15,7 +15,7 @@ machine-checked stability tier, profile, and safety-gate matrix.
 | `search_columns` | Search columns by names and semantic hints | `query`, `resource_types`, `roles`, `semantic_types`, `limit`, `offset` |
 | `column_inventory` | List columns with semantic context | `resource_types`, `roles`, `semantic_types`, `limit`, `offset` |
 | `get_entity` | Fetch single entity by ID or name | `id_or_name` (`unique_id` alias), `resource_type`, `detail` |
-| `list_entities` | List entities by type with filters | `resource_type`, `package`, `tags`, `detail` |
+| `list_entities` | List entities by type with filters | `resource_type`, `package`, `tags`, `governance`, `tier`, `canonical`, `detail` |
 | `batch_get_entities` | Retrieve multiple entities at once | `unique_ids`, `detail` |
 | `find_by_path` | Find entities by file path glob | `path_pattern`, `resource_types`, `detail` |
 

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -520,10 +520,12 @@ Required:
 
 Optional:
 - `package`, `tags`, `database_schema`
+- `governance` with optional `pii`, `sensitivity`, `compliance_includes`, and `declared`
+- `tier`, `canonical`
 - `detail` (`compact` | `standard` | `full`), `limit`, `offset`
 
 ```json
-{"name":"list_entities","arguments":{"resource_type":"model","tags":["pii"],"detail":"standard","limit":100}}
+{"name":"list_entities","arguments":{"resource_type":"model","governance":{"pii":["possible","yes"],"declared":true},"tier":["gold"],"canonical":true,"detail":"standard","limit":100}}
 ```
 
 ### `batch_get_entities`
@@ -571,7 +573,7 @@ One-shot context bundle. Returns lineage, columns, tests, docs, and summary stat
 | `include_tests` | bool | No | Include test coverage (default: true) |
 | `include_docs` | bool | No | Include documentation (default: true) |
 | `include_sql` | bool | No | Include raw/compiled SQL in entity context (default: false) |
-| `context_mode` | string | No | Output shaping (`standard` \| `engineer`, default: `standard`) |
+| `context_mode` | string | No | Output shaping (`standard` \| `analyst` \| `engineer` \| `governance`, default: `standard`; analyst/governance currently use the standard projection) |
 | `lineage_depth` | int | No | Depth for lineage traversal (default: 1) |
 
 Notes:
@@ -1288,10 +1290,11 @@ Optional:
 - `vector`, `sparse`, `reranker`
 - `force`: require freshly rebuilt manifest-scoped cache files
 
-When no component flag is supplied, `warm_manifest` requests vector and sparse
-warmup, matching `dbt-nova manifest warm`. The tool uses the manifest source and
-storage instance already configured for the running server or CLI `tool call`
-load; it does not accept a new manifest path or URI.
+When no component flag is supplied, `warm_manifest` warms only the semantic
+components enabled in the resolved runtime config. Explicit component flags
+override that default. The tool uses the manifest source and storage instance
+already configured for the running server or CLI `tool call` load; it does not
+accept a new manifest path or URI.
 
 This cache-write capability is disabled unless
 `DBT_NOVA_MCP_ENABLE_MANIFEST_WARM=1` is set. Read-only storage is rejected.

--- a/docs/personas/governance.md
+++ b/docs/personas/governance.md
@@ -87,7 +87,8 @@ Always pass `persona: "governance"` for discovery. This boosts compliance-releva
 fields (sensitivity, pii, compliance tags) and documentation signals.
 
 ### Inventory
-Use `list_entities` scoped by package or tags.
+Use `list_entities` scoped by package, tags, or structured Nova governance
+metadata.
 
 ??? example "list_entities Example"
     ```json
@@ -96,7 +97,10 @@ Use `list_entities` scoped by package or tags.
       "arguments": {
         "resource_type": "model",
         "package": "nova_test",
-        "tags": [],
+        "governance": {
+          "pii": ["possible", "yes"],
+          "declared": true
+        },
         "detail": "standard",
         "limit": 50
       }

--- a/src/cli/manifest.rs
+++ b/src/cli/manifest.rs
@@ -9,6 +9,7 @@ use serde_json::Value as JsonValue;
 use crate::cli::args::{ManifestLoadArgs, ManifestReloadArgs, ManifestWarmArgs};
 use crate::cli::output::{CliEnvelope, error_envelope};
 use crate::config::DbtNovaConfig;
+use crate::config::search::SearchConfig;
 use crate::error::{DbtNovaError, Result};
 use crate::manifest::bootstrap::prepare_runtime_config;
 use crate::manifest::rkyv_embeddings::{self, EmbeddingsCacheLoad};
@@ -108,7 +109,6 @@ pub async fn run_reload_command(args: &ManifestReloadArgs) -> DispatchResult {
 pub async fn run_warm_command(args: &ManifestWarmArgs) -> DispatchResult {
     let started = Instant::now();
     let warm_started_at = std::time::SystemTime::now();
-    let requested = requested_warm_components(args);
     let config = build_manifest_warm_config(args).map_err(|error| {
         render_or_propagate_error(
             "manifest warm",
@@ -117,6 +117,7 @@ pub async fn run_warm_command(args: &ManifestWarmArgs) -> DispatchResult {
             started.elapsed().as_millis(),
         )
     })?;
+    let requested = requested_warm_components(args, &config.search);
     let mut load_result = execute_manifest_load(config).await.map_err(|error| {
         render_or_propagate_error(
             "manifest warm",
@@ -178,9 +179,13 @@ pub async fn build_manifest_warm_tool_response(
 
     let started_at = Instant::now();
     let warm_started_at = std::time::SystemTime::now();
-    let requested =
-        requested_warm_components_from_flags(params.vector, params.sparse, params.reranker);
     let mut config = search.config().clone();
+    let requested = requested_warm_components_from_flags(
+        params.vector,
+        params.sparse,
+        params.reranker,
+        &config.search,
+    );
     apply_manifest_warm_settings(&mut config, requested, params.force)?;
     let mut load_result = execute_manifest_load(config).await?;
     warm_requested_query_models(&mut load_result.search, requested)?;
@@ -425,7 +430,7 @@ pub fn build_manifest_warm_config(args: &ManifestWarmArgs) -> Result<DbtNovaConf
         false,
         false,
     )?;
-    let requested = requested_warm_components(args);
+    let requested = requested_warm_components(args, &config.search);
     apply_manifest_warm_settings(&mut config, requested, args.force)?;
     finalize_manifest_config(config)
 }
@@ -525,20 +530,29 @@ pub(crate) async fn execute_manifest_load(
         .map_err(|error| DbtNovaError::ServerError(error.to_string()))?
 }
 
-fn requested_warm_components(args: &ManifestWarmArgs) -> SearchReadyInfo {
-    requested_warm_components_from_flags(args.vector, args.sparse, args.reranker)
+fn requested_warm_components(args: &ManifestWarmArgs, search: &SearchConfig) -> SearchReadyInfo {
+    requested_warm_components_from_flags(args.vector, args.sparse, args.reranker, search)
 }
 
 fn requested_warm_components_from_flags(
     vector: bool,
     sparse: bool,
     reranker: bool,
+    search: &SearchConfig,
 ) -> SearchReadyInfo {
     let any_explicit = vector || sparse || reranker;
-    SearchReadyInfo {
-        vector: vector || !any_explicit,
-        sparse: sparse || !any_explicit,
-        reranker,
+    if any_explicit {
+        SearchReadyInfo {
+            vector,
+            sparse,
+            reranker,
+        }
+    } else {
+        SearchReadyInfo {
+            vector: search.enable_vector_search,
+            sparse: search.enable_sparse_search,
+            reranker: search.enable_reranker,
+        }
     }
 }
 
@@ -821,6 +835,7 @@ mod tests {
     };
     use crate::cli::args::{ManifestLoadArgs, ManifestReloadArgs, ManifestWarmArgs};
     use crate::config::DbtNovaConfig;
+    use crate::config::SearchConfig;
     use crate::manifest::rkyv_embeddings::save_embeddings;
     use crate::manifest::rkyv_sparse_embeddings::save_sparse_embeddings;
     use crate::manifest::rkyv_types::{
@@ -936,19 +951,55 @@ mod tests {
     }
 
     #[test]
-    fn requested_warm_components_defaults_to_vector_and_sparse() {
-        let requested = requested_warm_components(&ManifestWarmArgs::default());
-        assert!(requested.vector);
+    fn requested_warm_components_defaults_to_enabled_config_components() {
+        let mut search = SearchConfig {
+            enable_vector_search: false,
+            enable_sparse_search: false,
+            enable_reranker: false,
+            ..Default::default()
+        };
+        let requested = requested_warm_components(&ManifestWarmArgs::default(), &search);
+        assert!(!requested.vector);
+        assert!(!requested.sparse);
+        assert!(!requested.reranker);
+
+        search.enable_sparse_search = true;
+        let requested = requested_warm_components(&ManifestWarmArgs::default(), &search);
+        assert!(!requested.vector);
         assert!(requested.sparse);
         assert!(!requested.reranker);
     }
 
     #[test]
+    fn requested_warm_components_explicit_flags_override_config() {
+        let search = SearchConfig {
+            enable_vector_search: false,
+            enable_sparse_search: false,
+            enable_reranker: false,
+            ..Default::default()
+        };
+        let requested = requested_warm_components(
+            &ManifestWarmArgs {
+                vector: true,
+                ..ManifestWarmArgs::default()
+            },
+            &search,
+        );
+        assert!(requested.vector);
+        assert!(!requested.sparse);
+        assert!(!requested.reranker);
+    }
+
+    #[test]
     fn requested_warm_components_honors_explicit_reranker() {
-        let requested = requested_warm_components(&ManifestWarmArgs {
-            reranker: true,
-            ..ManifestWarmArgs::default()
-        });
+        let search = SearchConfig::default();
+        let requested = requested_warm_components(
+            &ManifestWarmArgs {
+                reranker: true,
+                ..ManifestWarmArgs::default()
+            },
+            &search,
+        );
         assert!(!requested.vector);
         assert!(!requested.sparse);
         assert!(requested.reranker);

--- a/src/params.rs
+++ b/src/params.rs
@@ -303,11 +303,38 @@ pub struct ListEntitiesParams {
     pub tags: Vec<String>,
     /// Filter by database.schema pattern
     pub database_schema: Option<String>,
+    /// Optional governance filters over meta.nova.governance.
+    #[serde(default)]
+    pub governance: Option<ListEntitiesGovernanceFilter>,
+    /// Filter by meta.nova.tier. Matches any listed value.
+    #[serde(default)]
+    pub tier: Vec<String>,
+    /// Filter by meta.nova.canonical.
+    #[serde(default)]
+    pub canonical: Option<bool>,
     /// Response detail level: compact, standard, or full. Omit to use the active result profile.
     #[serde(default)]
     pub detail: Option<DetailLevel>,
     #[serde(default, flatten)]
     pub pagination: PaginationParams,
+}
+
+/// Governance filters for `list_entities`.
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ListEntitiesGovernanceFilter {
+    /// Match any listed meta.nova.governance.pii value.
+    #[serde(default)]
+    pub pii: Vec<String>,
+    /// Match any listed meta.nova.governance.sensitivity value.
+    #[serde(default)]
+    pub sensitivity: Vec<String>,
+    /// Require all listed compliance tags.
+    #[serde(default)]
+    pub compliance_includes: Vec<String>,
+    /// Filter by whether the governance block is declared.
+    #[serde(default)]
+    pub declared: Option<bool>,
 }
 
 /// Parameters for searching and discovering recipe templates.
@@ -620,8 +647,12 @@ pub enum ContextMode {
     /// Standard context output (default).
     #[default]
     Standard,
+    /// Analyst persona alias for standard context output.
+    Analyst,
     /// Engineer-focused output (suppresses long descriptions).
     Engineer,
+    /// Governance persona alias for standard context output.
+    Governance,
 }
 
 /// Parameters for the get_metadata_score tool.
@@ -1095,7 +1126,10 @@ pub struct ExecuteSqlParams {
 mod tests {
     use serde_json::json;
 
-    use super::{ExecuteSqlParams, GetEntityParams, GetMetadataAuditParams, ListEntitiesParams};
+    use super::{
+        ContextMode, ExecuteSqlParams, GetContextParams, GetEntityParams, GetMetadataAuditParams,
+        ListEntitiesParams,
+    };
 
     #[test]
     fn get_entity_accepts_unique_id_alias() {
@@ -1121,6 +1155,23 @@ mod tests {
         .expect_err("unknown params should fail");
 
         assert!(err.to_string().contains("unknown field `governance_pii`"));
+    }
+
+    #[test]
+    fn get_context_accepts_persona_context_mode_aliases() {
+        let analyst: GetContextParams = serde_json::from_value(json!({
+            "id_or_name": "model.pkg.orders",
+            "context_mode": "analyst"
+        }))
+        .expect("analyst context mode");
+        let governance: GetContextParams = serde_json::from_value(json!({
+            "id_or_name": "model.pkg.orders",
+            "context_mode": "governance"
+        }))
+        .expect("governance context mode");
+
+        assert_eq!(analyst.context_mode, ContextMode::Analyst);
+        assert_eq!(governance.context_mode, ContextMode::Governance);
     }
 
     #[test]

--- a/src/tests/list_entities.rs
+++ b/src/tests/list_entities.rs
@@ -10,6 +10,9 @@ async fn test_list_entities_models() {
         package: None,
         tags: vec![],
         database_schema: None,
+        governance: None,
+        tier: vec![],
+        canonical: None,
         detail: Some(DetailLevel::Full),
         pagination: PaginationParams {
             limit: Some(10),
@@ -42,6 +45,9 @@ async fn test_list_entities_with_tag_filter() {
         package: None,
         tags: vec!["sql".to_string()],
         database_schema: None,
+        governance: None,
+        tier: vec![],
+        canonical: None,
         detail: Some(DetailLevel::Standard),
         pagination: PaginationParams {
             limit: Some(50),
@@ -57,6 +63,77 @@ async fn test_list_entities_with_tag_filter() {
         }
     }
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_entities_filters_governance_tier_and_canonical() {
+    let searcher = get_searcher_with_fixture("perfect_model.json");
+    let params = ListEntitiesParams {
+        resource_type: "model".to_string(),
+        package: None,
+        tags: vec![],
+        database_schema: None,
+        governance: Some(ListEntitiesGovernanceFilter {
+            pii: vec!["TRUE".to_string()],
+            sensitivity: vec!["HIGH".to_string()],
+            compliance_includes: vec!["gdpr".to_string(), "HIPAA".to_string()],
+            declared: Some(true),
+        }),
+        tier: vec!["GOLD".to_string()],
+        canonical: Some(true),
+        detail: Some(DetailLevel::Standard),
+        pagination: PaginationParams {
+            limit: Some(10),
+            offset: 0,
+        },
+    };
+
+    let result = searcher.list_entities(&params).await.json();
+    assert_eq!(
+        result.get("success").and_then(JsonValue::as_bool),
+        Some(true)
+    );
+    assert_eq!(result.get("count").and_then(JsonValue::as_u64), Some(1));
+
+    let row = result["data"]
+        .as_array()
+        .and_then(|rows| rows.first())
+        .expect("filtered row");
+    assert_eq!(row["unique_id"], "model.nova_test.perfect_model");
+    assert_eq!(row["nova_summary"]["governance"]["pii"], "true");
+    assert_eq!(row["nova_summary"]["governance"]["sensitivity"], "high");
+    assert_eq!(row["nova_summary"]["tier"], "gold");
+    assert_eq!(row["nova_summary"]["canonical"], true);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_entities_filters_missing_governance_and_noncanonical() {
+    let searcher = get_searcher_with_fixture("minimal.json");
+    let params = ListEntitiesParams {
+        resource_type: "model".to_string(),
+        package: None,
+        tags: vec![],
+        database_schema: None,
+        governance: Some(ListEntitiesGovernanceFilter {
+            declared: Some(false),
+            ..ListEntitiesGovernanceFilter::default()
+        }),
+        tier: vec![],
+        canonical: Some(false),
+        detail: Some(DetailLevel::Standard),
+        pagination: PaginationParams {
+            limit: Some(10),
+            offset: 0,
+        },
+    };
+
+    let result = searcher.list_entities(&params).await.json();
+    assert_eq!(
+        result.get("success").and_then(JsonValue::as_bool),
+        Some(true)
+    );
+    assert_eq!(result.get("count").and_then(JsonValue::as_u64), Some(1));
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_list_entities_sources() {
     let searcher = get_searcher();
@@ -65,6 +142,9 @@ async fn test_list_entities_sources() {
         package: None,
         tags: vec![],
         database_schema: None,
+        governance: None,
+        tier: vec![],
+        canonical: None,
         detail: Some(DetailLevel::Full),
         pagination: PaginationParams {
             limit: Some(10),
@@ -86,6 +166,9 @@ async fn test_list_entities_groups() {
         package: None,
         tags: vec![],
         database_schema: None,
+        governance: None,
+        tier: vec![],
+        canonical: None,
         detail: Some(DetailLevel::Full),
         pagination: PaginationParams {
             limit: Some(50),
@@ -107,6 +190,9 @@ async fn test_list_entities_invalid_type() {
         package: None,
         tags: vec![],
         database_schema: None,
+        governance: None,
+        tier: vec![],
+        canonical: None,
         detail: Some(DetailLevel::Full),
         pagination: PaginationParams {
             limit: Some(10),

--- a/src/tools/search/entities.rs
+++ b/src/tools/search/entities.rs
@@ -1,3 +1,5 @@
+use crate::manifest::entity::{ArchivedEntity, ArchivedNovaMeta};
+
 use super::{
     DbtNovaError, DetailLevel, HashSet, JsonValue, ListEntitiesParams, ManifestSearch, Result,
     SuccessResponse,
@@ -20,7 +22,156 @@ fn apply_set_filter(allowed: &mut Option<HashSet<String>>, ids: &HashSet<String>
     }
 }
 
+fn normalized_matches(value: &str, expected: &str) -> bool {
+    value.trim().eq_ignore_ascii_case(expected.trim())
+}
+
+fn matches_any_filter(value: Option<&str>, expected: &[String]) -> bool {
+    expected.is_empty()
+        || value.is_some_and(|actual| {
+            expected
+                .iter()
+                .any(|candidate| normalized_matches(actual, candidate))
+        })
+}
+
+fn matches_all_compliance(nova: Option<&ArchivedNovaMeta>, expected: &[String]) -> bool {
+    expected.is_empty()
+        || nova
+            .and_then(|nova| nova.governance.as_ref())
+            .is_some_and(|governance| {
+                expected.iter().all(|candidate| {
+                    governance
+                        .compliance
+                        .iter()
+                        .any(|actual| normalized_matches(actual.as_str(), candidate))
+                })
+            })
+}
+
+fn matches_governance_filter(entity: &ArchivedEntity, params: &ListEntitiesParams) -> bool {
+    let Some(filter) = params.governance.as_ref() else {
+        return true;
+    };
+    let nova = entity.nova_meta();
+    let governance = nova.and_then(|nova| nova.governance.as_ref());
+
+    if let Some(declared) = filter.declared
+        && governance.is_some() != declared
+    {
+        return false;
+    }
+
+    matches_any_filter(
+        governance
+            .and_then(|governance| governance.pii.as_ref())
+            .map(rkyv::string::ArchivedString::as_str),
+        &filter.pii,
+    ) && matches_any_filter(
+        governance
+            .and_then(|governance| governance.sensitivity.as_ref())
+            .map(rkyv::string::ArchivedString::as_str),
+        &filter.sensitivity,
+    ) && matches_all_compliance(nova, &filter.compliance_includes)
+}
+
+fn matches_tier_filter(entity: &ArchivedEntity, tiers: &[String]) -> bool {
+    matches_any_filter(
+        entity
+            .nova_meta()
+            .and_then(|nova| nova.tier.as_ref())
+            .map(rkyv::string::ArchivedString::as_str),
+        tiers,
+    )
+}
+
+fn matches_canonical_filter(entity: &ArchivedEntity, canonical: Option<bool>) -> bool {
+    canonical
+        .is_none_or(|expected| entity.nova_meta().is_some_and(|nova| nova.canonical) == expected)
+}
+
+fn matches_nova_filters(entity: &ArchivedEntity, params: &ListEntitiesParams) -> bool {
+    matches_governance_filter(entity, params)
+        && matches_tier_filter(entity, &params.tier)
+        && matches_canonical_filter(entity, params.canonical)
+}
+
+fn has_nova_filters(params: &ListEntitiesParams) -> bool {
+    params.governance.is_some() || !params.tier.is_empty() || params.canonical.is_some()
+}
+
+fn should_collect_row(
+    total: &mut usize,
+    skipped: &mut usize,
+    offset: usize,
+    result_count: usize,
+    limit: usize,
+) -> bool {
+    *total += 1;
+    if *skipped < offset {
+        *skipped += 1;
+        return false;
+    }
+    result_count < limit
+}
+
+fn empty_list_entities_response() -> Result<JsonValue> {
+    Ok(serde_json::to_value(SuccessResponse::new(
+        Vec::<JsonValue>::new(),
+        0,
+    ))?)
+}
+
 impl ManifestSearch {
+    fn list_entity_row(&self, id: &str, entity: &ArchivedEntity, detail: DetailLevel) -> JsonValue {
+        match detail {
+            DetailLevel::Full => ManifestSearch::with_unique_id(entity.to_json_value(), id),
+            DetailLevel::Compact => self.summary_for_compact(id, entity),
+            DetailLevel::Standard => self.summary_for_standard(id, entity),
+        }
+    }
+
+    fn list_entities_allowed_ids(&self, params: &ListEntitiesParams) -> Option<HashSet<String>> {
+        let mut allowed: Option<HashSet<String>> = None;
+
+        if let Some(ref pkg) = params.package {
+            match self.by_package.get(pkg) {
+                Some(ids) => apply_vec_filter(&mut allowed, ids),
+                None => return Some(HashSet::new()),
+            }
+        }
+
+        if let Some(ref db_schema) = params.database_schema {
+            if let Some(ids) = self.by_database_schema.get(db_schema) {
+                apply_vec_filter(&mut allowed, ids);
+            } else {
+                let mut matches: HashSet<String> = HashSet::new();
+                for (key, ids) in &self.by_database_schema {
+                    if key.contains(db_schema) {
+                        matches.extend(ids.iter().cloned());
+                    }
+                }
+                if matches.is_empty() {
+                    return Some(HashSet::new());
+                }
+                if let Some(ref mut current) = allowed {
+                    current.retain(|id| matches.contains(id));
+                } else {
+                    allowed = Some(matches);
+                }
+            }
+        }
+
+        for tag in &params.tags {
+            match self.by_tag.get(tag) {
+                Some(ids) => apply_set_filter(&mut allowed, ids),
+                None => return Some(HashSet::new()),
+            }
+        }
+
+        allowed
+    }
+
     /// List entities by type with optional filtering.
     ///
     /// # Errors
@@ -39,56 +190,9 @@ impl ManifestSearch {
                 ))
             })?;
 
-        let mut allowed: Option<HashSet<String>> = None;
-
-        if let Some(ref pkg) = params.package {
-            match self.by_package.get(pkg) {
-                Some(ids) => apply_vec_filter(&mut allowed, ids),
-                None => {
-                    return Ok(serde_json::to_value(SuccessResponse::new(
-                        Vec::<JsonValue>::new(),
-                        0,
-                    ))?);
-                }
-            }
-        }
-
-        if let Some(ref db_schema) = params.database_schema {
-            if let Some(ids) = self.by_database_schema.get(db_schema) {
-                apply_vec_filter(&mut allowed, ids);
-            } else {
-                let mut matches: HashSet<String> = HashSet::new();
-                for (key, ids) in &self.by_database_schema {
-                    if key.contains(db_schema) {
-                        matches.extend(ids.iter().cloned());
-                    }
-                }
-                if matches.is_empty() {
-                    return Ok(serde_json::to_value(SuccessResponse::new(
-                        Vec::<JsonValue>::new(),
-                        0,
-                    ))?);
-                }
-                if let Some(ref mut current) = allowed {
-                    current.retain(|id| matches.contains(id));
-                } else {
-                    allowed = Some(matches);
-                }
-            }
-        }
-
-        if !params.tags.is_empty() {
-            for tag in &params.tags {
-                match self.by_tag.get(tag) {
-                    Some(ids) => apply_set_filter(&mut allowed, ids),
-                    None => {
-                        return Ok(serde_json::to_value(SuccessResponse::new(
-                            Vec::<JsonValue>::new(),
-                            0,
-                        ))?);
-                    }
-                }
-            }
+        let allowed = self.list_entities_allowed_ids(params);
+        if allowed.as_ref().is_some_and(HashSet::is_empty) {
+            return empty_list_entities_response();
         }
 
         let detail = self.detail_level(params.detail);
@@ -96,6 +200,7 @@ impl ManifestSearch {
         let mut total = 0usize;
         let mut skipped = 0usize;
         let mut results: Vec<JsonValue> = Vec::with_capacity(limit);
+        let apply_nova_filters = has_nova_filters(params);
 
         for id in candidates {
             let allowed_match = allowed
@@ -105,27 +210,39 @@ impl ManifestSearch {
                 continue;
             }
 
-            total += 1;
-            if skipped < params.pagination.offset {
-                skipped += 1;
-                continue;
-            }
-            if results.len() >= limit {
+            if !apply_nova_filters {
+                if !should_collect_row(
+                    &mut total,
+                    &mut skipped,
+                    params.pagination.offset,
+                    results.len(),
+                    limit,
+                ) {
+                    continue;
+                }
+
+                if let Some(entity) = self.get_entity_archived(id)? {
+                    results.push(self.list_entity_row(id, entity, detail));
+                }
                 continue;
             }
 
             if let Some(entity) = self.get_entity_archived(id)? {
-                match detail {
-                    DetailLevel::Full => {
-                        results.push(ManifestSearch::with_unique_id(entity.to_json_value(), id));
-                    }
-                    DetailLevel::Compact => {
-                        results.push(self.summary_for_compact(id, entity));
-                    }
-                    DetailLevel::Standard => {
-                        results.push(self.summary_for_standard(id, entity));
-                    }
+                if !matches_nova_filters(entity, params) {
+                    continue;
                 }
+
+                if !should_collect_row(
+                    &mut total,
+                    &mut skipped,
+                    params.pagination.offset,
+                    results.len(),
+                    limit,
+                ) {
+                    continue;
+                }
+
+                results.push(self.list_entity_row(id, entity, detail));
             }
         }
 

--- a/tests/lineage_prop.rs
+++ b/tests/lineage_prop.rs
@@ -42,6 +42,9 @@ proptest! {
             package: None,
             tags: vec![],
             database_schema: None,
+            governance: None,
+            tier: vec![],
+            canonical: None,
             detail: Some(DetailLevel::Standard),
             pagination: PaginationParams { limit: Some(100), offset: 0 },
 };

--- a/tests/loader.rs
+++ b/tests/loader.rs
@@ -18,6 +18,9 @@ async fn loads_minimal_manifest_and_indexes() {
         package: None,
         tags: vec![],
         database_schema: None,
+        governance: None,
+        tier: vec![],
+        canonical: None,
         detail: Some(DetailLevel::Standard),
         pagination: PaginationParams {
             limit: Some(10),


### PR DESCRIPTION
## Summary

- make no-flag `manifest warm` / `warm_manifest` derive requested semantic cache components from the resolved runtime search config instead of forcing vector+sparse on
- add structured `list_entities` filters for `meta.nova.governance`, `meta.nova.tier`, and `meta.nova.canonical`, while preserving the existing fast path when those filters are omitted
- accept `analyst` and `governance` as `get_context.context_mode` aliases for the current standard projection
- refresh API/persona docs and changelog for the new contracts

## Root Cause

`manifest warm` treated missing component flags as an implicit vector+sparse request, then overwrote disabled runtime search settings. `list_entities` had no structured inventory filters for already-parsed Nova governance metadata, and `get_context.context_mode` used a narrower vocabulary than the rest of the agent persona surface.

## Validation

- `cargo test --locked --lib params::tests`
- `cargo test --locked --lib tests::list_entities`
- `cargo test --locked --lib cli::manifest::tests`
- `cargo test --locked --test loader --test context`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `uv run mkdocs build --strict`
- `cargo fmt --check`
- `scripts/check_module_size.sh`
- `git diff --check`

Closes #274.
Closes #286.
Closes #290.
