### PR TITLE
Fix CLI tool-call JSON envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed CLI `tool call --json` output so `.data` contains the tool payload
+  directly, matching dedicated CLI commands; tool response metadata now lives
+  under `.meta.tool_response`.
 - Fixed `manifest warm`/`warm_manifest` so no-flag warmup respects the resolved
   semantic search config, added governance/tier/canonical `list_entities`
   filters for structured inventory, and accepted `analyst`/`governance`

--- a/docs/api/mcp-cli-parity.md
+++ b/docs/api/mcp-cli-parity.md
@@ -36,8 +36,10 @@ checked against `src/tools/catalog.rs`.
 MCP tool bodies and CLI JSON command envelopes both expose the additive
 top-level `api` response contract marker documented in
 [Response Format](response-format.md#api-contract-marker). CLI JSON keeps its
-own command envelope shape; MCP budgeting and pagination metadata remain under
-`_nova_result_meta`.
+own command envelope shape. CLI `tool call --json` unwraps the MCP-style tool
+body so `.data` is the payload itself and tool bookkeeping lives under
+`.meta.tool_response`; MCP budgeting and pagination metadata remain under
+`_nova_result_meta` in MCP responses.
 
 ## Current Matrix
 
@@ -78,8 +80,9 @@ that:
 - CLI `tool call` supports the same canonical MCP tool names.
 - Every canonical MCP tool has stability metadata, profile membership, and a
   docs row in the Tools Reference.
-- MCP and CLI JSON envelope docs cover the shared top-level `api` marker while
-  keeping `_nova_result_meta` as MCP transport metadata.
+- MCP and CLI JSON envelope docs cover the shared top-level `api` marker, CLI
+  tool-call payload unwrapping, and `_nova_result_meta` as MCP transport
+  metadata.
 - MCP tool count references in core docs match the catalog.
 - CLI leaf commands have an explicit parity row and any gap has an owning issue.
 

--- a/docs/api/response-format.md
+++ b/docs/api/response-format.md
@@ -214,6 +214,20 @@ CLI subcommands that use `--json` return a command envelope (different from MCP 
 }
 ```
 
+`schemas/response/cli_envelope_v1.json` defines the machine-checkable CLI
+envelope shape.
+
+For `dbt-nova tool call <tool> --json`, `data` is the tool payload itself, not a
+nested MCP-style success wrapper. Tool-response bookkeeping such as `count`,
+`total_available`, `truncated`, `persona`, `suggestions`, and
+`_nova_result_meta` moves to `meta.tool_response`. The inner tool `success` flag
+is not duplicated because CLI success/error state is carried by `status` and
+`error`.
+
+For example, both `dbt-nova audit agent-readiness --json` and
+`dbt-nova tool call get_agent_readiness --json` expose the readiness report at
+`.data.overall_score`; the tool-call form also exposes `.meta.tool_response.count`.
+
 For errors, `status` is `"error"` and `error` contains the standard Nova error object.
 
 ### CLI Exit Codes

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -329,9 +329,11 @@ dbt-nova tool call reload_manifest \
   --json
 ```
 
-`tool call reload_manifest` runs as a one-shot reload and returns a
-`SuccessResponse` payload with updated manifest settings and loaded manifest
-metadata (`manifest_hash`, `manifest_version`, `entity_count`).
+`tool call reload_manifest` runs as a one-shot reload and returns updated
+manifest settings and loaded manifest metadata (`manifest_hash`,
+`manifest_version`, `entity_count`) under the CLI envelope's `.data` field.
+Tool-response bookkeeping such as `count` is available under
+`.meta.tool_response`.
 
 If both `manifest_uri` and `manifest_path` are provided in params, `manifest_path`
 takes precedence.

--- a/schemas/response/cli_envelope_v1.json
+++ b/schemas/response/cli_envelope_v1.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.dbt-nova.dev/response/cli_envelope_v1.json",
+  "title": "dbt-nova CLI JSON envelope",
+  "type": "object",
+  "required": ["api", "command", "status", "data", "meta", "error"],
+  "additionalProperties": false,
+  "properties": {
+    "api": {
+      "type": "object",
+      "required": ["envelope", "nova_version"],
+      "additionalProperties": false,
+      "properties": {
+        "envelope": {
+          "const": "nova.response.v1"
+        },
+        "nova_version": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "command": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "enum": ["success", "error"]
+    },
+    "data": true,
+    "meta": {
+      "type": "object",
+      "required": ["elapsed_ms", "timestamp_ms", "version"],
+      "additionalProperties": false,
+      "properties": {
+        "elapsed_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "timestamp_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tool_response": {
+          "type": "object",
+          "description": "Tool response metadata moved out of the MCP-style tool response wrapper for CLI tool-call output. The payload itself is always in top-level data.",
+          "not": {
+            "anyOf": [
+              { "required": ["data"] },
+              { "required": ["success"] }
+            ]
+          }
+        }
+      }
+    },
+    "error": {
+      "anyOf": [
+        { "type": "null" },
+        { "type": "object" }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": { "const": "success" }
+        },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "error": { "type": "null" }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": { "const": "error" }
+        },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "data": { "type": "null" },
+          "error": { "type": "object" }
+        }
+      }
+    }
+  ]
+}

--- a/src/cli/nova_meta_cmd.rs
+++ b/src/cli/nova_meta_cmd.rs
@@ -61,11 +61,7 @@ pub fn run_nova_meta_command(args: &NovaMetaAuditArgs) -> DispatchResult {
                 command: "audit nova-meta",
                 status: "error",
                 data: &report,
-                meta: CliMeta {
-                    elapsed_ms,
-                    timestamp_ms: timestamp_ms(),
-                    version: env!("CARGO_PKG_VERSION"),
-                },
+                meta: CliMeta::new(elapsed_ms),
                 error: Some(
                     DbtNovaError::ServerError(format!(
                         "nova meta validation failed ({} error(s), {} warning(s))",
@@ -157,13 +153,6 @@ pub fn build_nova_meta_tool_response(
 
     serde_json::to_value(SuccessResponse::new(payload, 1))
         .map_err(|error| DbtNovaError::ServerError(error.to_string()))
-}
-
-fn timestamp_ms() -> u128 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |duration| duration.as_millis())
 }
 
 fn print_human_report(

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -9,6 +9,26 @@ pub struct CliMeta {
     pub elapsed_ms: u128,
     pub timestamp_ms: u128,
     pub version: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_response: Option<JsonValue>,
+}
+
+impl CliMeta {
+    #[must_use]
+    pub(crate) fn new(elapsed_ms: u128) -> Self {
+        Self {
+            elapsed_ms,
+            timestamp_ms: timestamp_ms(),
+            version: env!("CARGO_PKG_VERSION"),
+            tool_response: None,
+        }
+    }
+
+    #[must_use]
+    fn with_tool_response(mut self, tool_response: Option<JsonValue>) -> Self {
+        self.tool_response = tool_response;
+        self
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -35,11 +55,24 @@ where
             command: command.into(),
             status: "success",
             data: Some(data),
-            meta: CliMeta {
-                elapsed_ms,
-                timestamp_ms: timestamp_ms(),
-                version: env!("CARGO_PKG_VERSION"),
-            },
+            meta: CliMeta::new(elapsed_ms),
+            error: None,
+        }
+    }
+
+    #[must_use]
+    pub fn success_with_tool_response(
+        command: impl Into<String>,
+        data: T,
+        tool_response: Option<JsonValue>,
+        elapsed_ms: u128,
+    ) -> Self {
+        Self {
+            api: response_api_contract(),
+            command: command.into(),
+            status: "success",
+            data: Some(data),
+            meta: CliMeta::new(elapsed_ms).with_tool_response(tool_response),
             error: None,
         }
     }
@@ -56,11 +89,7 @@ pub fn error_envelope(
         command: command.into(),
         status: "error",
         data: None,
-        meta: CliMeta {
-            elapsed_ms,
-            timestamp_ms: timestamp_ms(),
-            version: env!("CARGO_PKG_VERSION"),
-        },
+        meta: CliMeta::new(elapsed_ms),
         error: Some(error.to_response()),
     }
 }

--- a/src/cli/tool.rs
+++ b/src/cli/tool.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 
 use schemars::{JsonSchema, SchemaGenerator};
 use serde::de::DeserializeOwned;
-use serde_json::Value as JsonValue;
+use serde_json::{Map as JsonMap, Value as JsonValue};
 use std::collections::BTreeSet;
 
 use crate::cli::agent_readiness_cmd::build_agent_readiness_tool_response;
@@ -326,7 +326,7 @@ pub async fn run_call_command(args: &ToolCallArgs) -> DispatchResult {
     );
 
     if args.json {
-        let envelope = CliEnvelope::success(
+        let envelope = tool_call_success_envelope(
             format!("tool call {}", args.tool_name),
             result,
             started.elapsed().as_millis(),
@@ -385,7 +385,7 @@ async fn run_reload_manifest_tool_call(args: &ToolCallArgs, started: Instant) ->
     );
 
     if args.json {
-        let envelope = CliEnvelope::success(
+        let envelope = tool_call_success_envelope(
             format!("tool call {}", args.tool_name),
             result,
             started.elapsed().as_millis(),
@@ -403,6 +403,35 @@ async fn run_reload_manifest_tool_call(args: &ToolCallArgs, started: Instant) ->
     }
 
     Ok(())
+}
+
+fn tool_call_success_envelope(
+    command: impl Into<String>,
+    result: JsonValue,
+    elapsed_ms: u128,
+) -> CliEnvelope<JsonValue> {
+    let (data, tool_response_meta) = split_tool_success_response(result);
+    CliEnvelope::success_with_tool_response(command, data, tool_response_meta, elapsed_ms)
+}
+
+fn split_tool_success_response(result: JsonValue) -> (JsonValue, Option<JsonValue>) {
+    let JsonValue::Object(mut response) = result else {
+        return (result, None);
+    };
+    let Some(data) = response.remove("data") else {
+        return (JsonValue::Object(response), None);
+    };
+
+    // The CLI envelope already owns success/error status. Keep tool result
+    // bookkeeping in metadata without duplicating status or nesting payloads.
+    response.remove("success");
+    let mut meta = JsonMap::new();
+    for (key, value) in response {
+        meta.insert(key, value);
+    }
+
+    let meta = (!meta.is_empty()).then_some(JsonValue::Object(meta));
+    (data, meta)
 }
 
 fn build_reload_args_from_tool_call(
@@ -1066,7 +1095,7 @@ mod tests {
     use super::{
         build_reload_args_from_tool_call, decode_tool_params, dispatch_tool,
         resolve_params_value_with_stdin, run_call_command, run_search_with_timeout,
-        tool_registry_names,
+        tool_call_success_envelope, tool_registry_names,
     };
     use crate::cli::args::{ManifestLoadArgs, ToolCallArgs};
     use crate::cli::manifest::{build_manifest_load_config, execute_manifest_load};
@@ -1322,6 +1351,111 @@ mod tests {
         assert_eq!(
             result["data"]["eval_status"]["status"],
             serde_json::json!("allowed")
+        );
+    }
+
+    fn assert_cli_envelope_schema(payload: &serde_json::Value) {
+        let schema: serde_json::Value =
+            serde_json::from_str(include_str!("../../schemas/response/cli_envelope_v1.json"))
+                .expect("CLI envelope schema");
+        let compiled = jsonschema::draft202012::options()
+            .build(&schema)
+            .expect("compile CLI envelope schema");
+        if !compiled.is_valid(payload) {
+            let messages: Vec<String> = compiled
+                .iter_errors(payload)
+                .take(5)
+                .map(|error| error.to_string())
+                .collect();
+            panic!("CLI envelope does not match schema: {messages:?}");
+        }
+    }
+
+    #[test]
+    fn tool_call_json_envelope_unwraps_payload_and_moves_tool_metadata() {
+        let envelope = tool_call_success_envelope(
+            "tool call search",
+            serde_json::json!({
+                "success": true,
+                "count": 2,
+                "total_available": 5,
+                "truncated": true,
+                "persona": "analyst",
+                "suggestions": ["orders"],
+                "_nova_result_meta": {
+                    "next_offset": 2
+                },
+                "data": [
+                    {"unique_id": "model.pkg.orders"},
+                    {"unique_id": "model.pkg.customers"}
+                ]
+            }),
+            7,
+        );
+        let payload = serde_json::to_value(envelope).expect("serialize CLI envelope");
+
+        assert_cli_envelope_schema(&payload);
+        assert!(payload["data"].as_array().is_some());
+        assert_eq!(
+            payload["data"][0]["unique_id"],
+            serde_json::json!("model.pkg.orders")
+        );
+        assert_eq!(
+            payload["meta"]["tool_response"]["count"],
+            serde_json::json!(2)
+        );
+        assert_eq!(
+            payload["meta"]["tool_response"]["total_available"],
+            serde_json::json!(5)
+        );
+        assert_eq!(
+            payload["meta"]["tool_response"]["truncated"],
+            serde_json::json!(true)
+        );
+        assert_eq!(
+            payload["meta"]["tool_response"]["persona"],
+            serde_json::json!("analyst")
+        );
+        assert_eq!(
+            payload["meta"]["tool_response"]["_nova_result_meta"]["next_offset"],
+            serde_json::json!(2)
+        );
+        assert!(
+            payload["meta"]["tool_response"]
+                .as_object()
+                .is_some_and(|meta| !meta.contains_key("success") && !meta.contains_key("data"))
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_call_json_envelope_matches_agent_readiness_cli_payload_path() {
+        let searcher = fixture_searcher().await;
+        let result = dispatch_tool(
+            &searcher,
+            "get_agent_readiness",
+            serde_json::json!({
+                "personas_json": "[\"engineer\"]"
+            }),
+        )
+        .await
+        .expect("agent readiness");
+        let envelope = tool_call_success_envelope("tool call get_agent_readiness", result, 9);
+        let payload = serde_json::to_value(envelope).expect("serialize CLI envelope");
+
+        assert_cli_envelope_schema(&payload);
+        assert_eq!(
+            payload["data"]["schema_version"],
+            serde_json::json!("agent_readiness.v1")
+        );
+        assert!(payload["data"]["overall_score"].is_number());
+        assert!(
+            payload["data"]
+                .as_object()
+                .is_some_and(|data| !data.contains_key("data") && !data.contains_key("success"))
+        );
+        assert_eq!(
+            payload["meta"]["tool_response"]["count"],
+            serde_json::json!(1)
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes the CLI JSON envelope mismatch reported in #291.

`dbt-nova tool call <tool> --json` now unwraps the MCP-style tool response before putting it into the CLI command envelope:

- CLI `.data` is the tool payload itself.
- Tool bookkeeping (`count`, `total_available`, `truncated`, `persona`, `suggestions`, `_nova_result_meta`, etc.) moves to `.meta.tool_response`.
- The inner `success` flag is not duplicated because CLI command success/error state already lives in `.status`/`.error`.
- MCP tool responses and non-JSON human output are unchanged.

This makes `tool call get_agent_readiness --json` line up with `audit agent-readiness --json`: both expose the readiness report at `.data.overall_score`.

## Contract coverage

- Added `schemas/response/cli_envelope_v1.json` for the CLI command envelope.
- Added regression tests that validate CLI tool-call envelopes against the schema.
- Added a direct readiness regression for the reported `.data.data` vs `.data` path.
- Updated response-format, CLI, and MCP/CLI parity docs.

## Validation

- `cargo test --locked --lib cli::tool::tests::tool_call_json_envelope -- --nocapture`
- `cargo test --locked --lib cli::nova_meta_cmd::tests -- --nocapture`
- Direct CLI proof with `cargo run --locked --quiet -- tool call get_agent_readiness ... --json` and `cargo run --locked --quiet -- audit agent-readiness ... --json`: both now report `data_overall: 95`, `nested_overall: null`; tool-call metadata reports `tool_count: 1` and no duplicated `success`.
- `cargo test --locked --lib cli::tool::tests`
- `uv run mkdocs build --strict`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo fmt --check`
- `scripts/check_module_size.sh`
- `git diff --check`

Closes #291.
