### PR TITLE
Add column lineage fallback and reference evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added additive column-lineage evidence for unresolved derived columns and
+  rename planning: `get_column_lineage` can now return defining SQL
+  expressions, candidate upstream columns, and optional metadata/test/recipe
+  references; `get_impact` accepts an optional `column` scope with reference
+  counts by kind.
 - Fixed CLI `tool call --json` output so `.data` contains the tool payload
   directly, matching dedicated CLI commands; tool response metadata now lives
   under `.meta.tool_response`.

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -30,8 +30,8 @@ machine-checked stability tier, profile, and safety-gate matrix.
 | Tool | Purpose | Key Parameters |
 |------|---------|----------------|
 | `get_lineage` | Traverse entity lineage | `id_or_name`, `direction`, `depth`, `resource_types`, `detail` |
-| `get_impact` | Blast-radius estimate | `id_or_name` |
-| `get_column_lineage` | Trace column upstream/downstream | `id_or_name`, `resource_type`, `column_name`, `direction`, `confidence` |
+| `get_impact` | Blast-radius estimate | `id_or_name`, `column` |
+| `get_column_lineage` | Trace column upstream/downstream | `id_or_name`, `resource_type`, `column_name`, `direction`, `confidence`, `include_references` |
 
 ## Code & Schema
 

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -616,8 +616,17 @@ Blast‑radius estimate for an entity.
 Required:
 - `id_or_name`
 
+Optional:
+- `column` scopes downstream impact to a single column and adds
+  `reference_count` plus `references_by_kind` totals for metadata, tests, and
+  recipe SQL references to that column name.
+
 ```json
 {"name":"get_impact","arguments":{"id_or_name":"model.jaffle_shop.orders"}}
+```
+
+```json
+{"name":"get_impact","arguments":{"id_or_name":"model.jaffle_shop.orders","column":"customer_id"}}
 ```
 
 ### `get_column_lineage`
@@ -631,13 +640,27 @@ Required:
 Optional:
 - `resource_type` (disambiguates `id_or_name` when name matches multiple entities)
 - `depth`, `confidence` (`high`|`medium`|`low`)
+- `include_references` adds a `references` array for Nova grain dimensions,
+  Nova measure/metric expressions, dbt tests, and manifest-backed recipe SQL
+  that reference the requested column name.
 
 Notes:
 - Response includes `lineage_status` and `lineage_hints` to explain empty lineage results.
+- When upstream lineage is unresolved but dependencies exist, Nova additively
+  returns `definition`, `definition_source`, `definition_confidence`, and
+  `referenced_columns` when the requested column has a select-list expression in
+  compiled SQL or raw SQL.
+- Metadata and test references are exact or tokenized metadata matches. Recipe
+  SQL references are word-boundary textual matches and are labeled
+  `match: "textual"` in `detail`.
 - Requested `depth` is capped by `DBT_NOVA_COLUMN_LINEAGE_MAX_DEPTH` (config `column_lineage.max_depth`).
 
 ```json
 {"name":"get_column_lineage","arguments":{"id_or_name":"model.jaffle_shop.orders","column_name":"customer_id","direction":"upstream","confidence":"high"}}
+```
+
+```json
+{"name":"get_column_lineage","arguments":{"id_or_name":"model.jaffle_shop.orders","column_name":"customer_id","direction":"downstream","include_references":true}}
 ```
 
 ## Code & Schema

--- a/docs/features/column-lineage.md
+++ b/docs/features/column-lineage.md
@@ -53,6 +53,41 @@ Column lineage matching is independent from entity lineage reconstruction. Nova
 uses manifest dependency metadata as the DAG source of truth and applies SQL
 alias/proximity matching only for column-level mapping.
 
+## Unresolved derived columns
+
+Derived and aggregated columns do not always map cleanly to an upstream column.
+When upstream lineage is empty but the model has dependencies, Nova keeps the
+existing `lineage_status` values and additively returns definition evidence when
+available:
+
+- `definition`: the outer select-list expression for the requested output
+  column, from compiled SQL with raw SQL as fallback.
+- `definition_source`: `compiled_sql` or `raw_sql`.
+- `definition_confidence`: `exact` when parsed from SQL, `best_effort` when
+  recovered from a bounded text fallback.
+- `referenced_columns`: identifiers found inside the expression, annotated with
+  direct upstream entities that expose a same-named column.
+
+This is evidence for agent debugging, not a replacement for a full warehouse
+query plan. Wildcard expansion and dialect-specific optimizer behavior remain
+outside the column-lineage contract.
+
+## Column reference evidence
+
+Set `include_references: true` to add metadata-plane references for rename and
+blast-radius planning. The `references` array can include:
+
+- `nova_grain_dimension` for `meta.nova.grain.dimensions` matches.
+- `nova_measure_expression` and `nova_metric_expression` for tokenized Nova
+  measure or metric expression matches.
+- `test` for dbt manifest tests whose `column_name` or structured kwargs match.
+- `recipe_sql` for manifest-backed recipe analysis SQL under `analyses/recipes`
+  (or `DBT_NOVA_RECIPES_DIR`).
+
+Metadata and test references are exact or tokenized metadata matches. Recipe SQL
+references are word-boundary textual matches and are labeled
+`match: "textual"` in the record detail.
+
 ## Nested field matches
 
 When a column is stored inside a struct (e.g., `event_properties._revenue`), the response includes

--- a/src/manifest/lineage_sql.rs
+++ b/src/manifest/lineage_sql.rs
@@ -7,6 +7,13 @@ use sqlparser::ast::{
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SqlColumnDefinition {
+    pub(crate) expression: String,
+    pub(crate) identifiers: Vec<String>,
+    pub(crate) confidence: &'static str,
+}
+
 /// Return the SQL string used for column lineage matching.
 pub(crate) fn sql_for_matching(sql_entity: &JsonValue) -> Option<&str> {
     sql_entity
@@ -79,6 +86,262 @@ pub(crate) fn find_sql_aliases(raw_sql: &str) -> HashMap<String, String> {
     }
 
     aliases
+}
+
+/// Extract the defining select-list expression for a projected column.
+///
+/// This intentionally inspects only the outer projection. It is evidence for
+/// unresolved column lineage, not a full SQL optimizer or semantic lineage graph.
+pub(crate) fn find_select_column_definition(
+    raw_sql: &str,
+    column_name: &str,
+) -> Option<SqlColumnDefinition> {
+    let target = column_name.trim();
+    if target.is_empty() {
+        return None;
+    }
+
+    let dialect = GenericDialect {};
+    let normalized_sql = normalize_sql_for_parser(raw_sql);
+    if let Ok(statements) = Parser::parse_sql(&dialect, &normalized_sql) {
+        for stmt in statements {
+            let mut definition = None;
+            visit_select_items(&stmt, &mut |item| {
+                if definition.is_none() {
+                    definition = definition_from_select_item(item, target, "exact");
+                }
+            });
+            if definition.is_some() {
+                return definition;
+            }
+        }
+    }
+
+    find_select_column_definition_best_effort(raw_sql, target)
+}
+
+fn definition_from_select_item(
+    item: &SelectItem,
+    target: &str,
+    confidence: &'static str,
+) -> Option<SqlColumnDefinition> {
+    match item {
+        SelectItem::ExprWithAlias { expr, alias } if names_equal(&alias.value, target) => {
+            let mut identifiers = Vec::new();
+            collect_identifiers(expr, &mut identifiers);
+            Some(SqlColumnDefinition {
+                expression: expr.to_string(),
+                identifiers: dedupe_identifiers(identifiers),
+                confidence,
+            })
+        }
+        SelectItem::UnnamedExpr(expr) => output_name_for_expr(expr).and_then(|name| {
+            if names_equal(&name, target) {
+                let mut identifiers = Vec::new();
+                collect_identifiers(expr, &mut identifiers);
+                Some(SqlColumnDefinition {
+                    expression: expr.to_string(),
+                    identifiers: dedupe_identifiers(identifiers),
+                    confidence,
+                })
+            } else {
+                None
+            }
+        }),
+        _ => None,
+    }
+}
+
+fn output_name_for_expr(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Identifier(ident) => Some(ident.value.clone()),
+        Expr::CompoundIdentifier(idents) => idents.last().map(|ident| ident.value.clone()),
+        Expr::Nested(expr) | Expr::Cast { expr, .. } => output_name_for_expr(expr),
+        _ => None,
+    }
+}
+
+fn find_select_column_definition_best_effort(
+    raw_sql: &str,
+    target: &str,
+) -> Option<SqlColumnDefinition> {
+    let projection = outer_projection_text(raw_sql)?;
+    for item in split_top_level_commas(projection) {
+        let Some(expression) = expression_before_alias(item, target) else {
+            continue;
+        };
+        let identifiers = identifiers_from_text(expression);
+        return Some(SqlColumnDefinition {
+            expression: expression.trim().to_string(),
+            identifiers,
+            confidence: "best_effort",
+        });
+    }
+    None
+}
+
+fn outer_projection_text(raw_sql: &str) -> Option<&str> {
+    let lower = raw_sql.to_ascii_lowercase();
+    let select_start = lower.find("select")?;
+    let projection_start = select_start + "select".len();
+    let bytes = raw_sql.as_bytes();
+    let mut depth = 0usize;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut cursor = projection_start;
+    while cursor < bytes.len() {
+        let b = bytes[cursor];
+        if in_single {
+            if b == b'\'' {
+                in_single = false;
+            }
+            cursor += 1;
+            continue;
+        }
+        if in_double {
+            if b == b'"' {
+                in_double = false;
+            }
+            cursor += 1;
+            continue;
+        }
+        match b {
+            b'\'' => in_single = true,
+            b'"' => in_double = true,
+            b'(' => depth += 1,
+            b')' => depth = depth.saturating_sub(1),
+            _ if depth == 0 && lower[cursor..].starts_with(" from ") => {
+                return Some(&raw_sql[projection_start..cursor]);
+            }
+            _ => {}
+        }
+        cursor += 1;
+    }
+    None
+}
+
+fn split_top_level_commas(input: &str) -> Vec<&str> {
+    let bytes = input.as_bytes();
+    let mut parts = Vec::new();
+    let mut depth = 0usize;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut start = 0usize;
+    for (idx, b) in bytes.iter().enumerate() {
+        if in_single {
+            if *b == b'\'' {
+                in_single = false;
+            }
+            continue;
+        }
+        if in_double {
+            if *b == b'"' {
+                in_double = false;
+            }
+            continue;
+        }
+        match *b {
+            b'\'' => in_single = true,
+            b'"' => in_double = true,
+            b'(' => depth += 1,
+            b')' => depth = depth.saturating_sub(1),
+            b',' if depth == 0 => {
+                parts.push(input[start..idx].trim());
+                start = idx + 1;
+            }
+            _ => {}
+        }
+    }
+    let tail = input[start..].trim();
+    if !tail.is_empty() {
+        parts.push(tail);
+    }
+    parts
+}
+
+fn expression_before_alias<'a>(item: &'a str, target: &str) -> Option<&'a str> {
+    let trimmed = item.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    let target_lower = target.to_ascii_lowercase();
+    let as_suffix = format!(" as {target_lower}");
+    if lower.ends_with(&as_suffix) {
+        return Some(&trimmed[..trimmed.len().saturating_sub(as_suffix.len())]);
+    }
+
+    let bare_suffix = format!(" {target_lower}");
+    if lower.ends_with(&bare_suffix) {
+        return Some(&trimmed[..trimmed.len().saturating_sub(bare_suffix.len())]);
+    }
+
+    None
+}
+
+fn identifiers_from_text(input: &str) -> Vec<String> {
+    const KEYWORDS: &[&str] = &[
+        "and",
+        "as",
+        "case",
+        "cast",
+        "count",
+        "date",
+        "distinct",
+        "else",
+        "end",
+        "false",
+        "from",
+        "if",
+        "in",
+        "is",
+        "null",
+        "nullif",
+        "or",
+        "over",
+        "partition",
+        "select",
+        "sum",
+        "then",
+        "true",
+        "when",
+    ];
+
+    let mut identifiers = Vec::new();
+    let mut token = String::new();
+    for ch in input.chars().chain(std::iter::once(' ')) {
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == '.' {
+            token.push(ch);
+            continue;
+        }
+        if token
+            .chars()
+            .next()
+            .is_some_and(|first| first.is_ascii_alphabetic() || first == '_')
+        {
+            let normalized = token.trim_matches('.').to_string();
+            let lower = normalized.to_ascii_lowercase();
+            if !normalized.is_empty() && !KEYWORDS.contains(&lower.as_str()) {
+                identifiers.push(normalized);
+            }
+        }
+        token.clear();
+    }
+    dedupe_identifiers(identifiers)
+}
+
+fn dedupe_identifiers(identifiers: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for identifier in identifiers {
+        let key = identifier.to_ascii_lowercase();
+        if seen.insert(key) {
+            out.push(identifier);
+        }
+    }
+    out
+}
+
+fn names_equal(left: &str, right: &str) -> bool {
+    left.trim_matches(|c: char| matches!(c, '`' | '"' | '[' | ']'))
+        .eq_ignore_ascii_case(right.trim_matches(|c: char| matches!(c, '`' | '"' | '[' | ']')))
 }
 
 #[derive(Debug, Clone)]
@@ -409,7 +672,7 @@ fn visit_select_items<F: FnMut(&SelectItem)>(stmt: &Statement, f: &mut F) {
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_ref_calls, find_sql_aliases};
+    use super::{extract_ref_calls, find_select_column_definition, find_sql_aliases};
 
     #[test]
     fn extract_ref_calls_handles_single_and_qualified_refs() {
@@ -441,5 +704,27 @@ mod tests {
             aliases.get("session_conversion_rate").map(String::as_str),
             Some("order_completed")
         );
+    }
+
+    #[test]
+    fn find_select_column_definition_extracts_aggregate_expression() {
+        let sql = "select channel, count(distinct li.order_id) as orders_count from line_items li group by 1";
+        let definition = find_select_column_definition(sql, "orders_count").expect("definition");
+        assert_eq!(definition.expression, "count(DISTINCT li.order_id)");
+        assert_eq!(definition.identifiers, vec!["order_id", "li.order_id"]);
+        assert_eq!(definition.confidence, "exact");
+    }
+
+    #[test]
+    fn find_select_column_definition_extracts_ratio_expression() {
+        let sql = "select sum(gross_amount) / nullif(count(distinct order_id), 0) as average_order_value from orders";
+        let definition =
+            find_select_column_definition(sql, "average_order_value").expect("definition");
+        assert!(
+            definition
+                .expression
+                .contains("sum(gross_amount) / nullif(count(DISTINCT order_id), 0)")
+        );
+        assert_eq!(definition.identifiers, vec!["gross_amount", "order_id"]);
     }
 }

--- a/src/params.rs
+++ b/src/params.rs
@@ -498,6 +498,9 @@ pub struct DiffEntitiesParams {
 pub struct GetImpactParams {
     /// Unique ID or name of the entity to assess
     pub id_or_name: String,
+    /// Optional column name to scope downstream impact and reference counts
+    #[serde(default)]
+    pub column: Option<String>,
 }
 
 /// Parameters for the get_column_lineage tool.
@@ -518,6 +521,9 @@ pub struct GetColumnLineageParams {
     /// Confidence threshold: "high", "medium", or "low"
     #[serde(default)]
     pub confidence: Option<String>,
+    /// Include metadata, test, and recipe SQL references to this column name
+    #[serde(default)]
+    pub include_references: bool,
 }
 
 /// Parameters for the get_test_coverage tool.

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -966,7 +966,7 @@ impl DbtNovaServer {
     /// Analyze the downstream impact of changing an entity.
     #[tool(
         name = "get_impact",
-        description = "Quick blast-radius estimate. Returns downstream count and an impact score to gauge risk before making changes."
+        description = "Quick blast-radius estimate. Returns downstream count and an impact score to gauge risk before making changes. Add column to scope the estimate and include metadata/test/recipe reference counts for rename planning."
     )]
     #[instrument(level = "info", skip(self, params))]
     async fn get_impact(&self, params: Parameters<GetImpactParams>) -> ToolCallResponse {
@@ -1389,7 +1389,7 @@ impl DbtNovaServer {
     /// Trace column lineage upstream or downstream.
     #[tool(
         name = "get_column_lineage",
-        description = "Column-level lineage. Trace a column upstream (origins) or downstream (usage). Uses SQL parsing + heuristics. Use confidence=high for exact matches, medium (default) for SQL-based matches, low for fuzzy."
+        description = "Column-level lineage. Trace a column upstream (origins) or downstream (usage). Uses SQL parsing + heuristics, returns definition evidence when upstream resolution is empty, and can include metadata/test/recipe references."
     )]
     #[instrument(level = "info", skip(self, params))]
     async fn get_column_lineage(

--- a/src/server/mcp/response_budget.rs
+++ b/src/server/mcp/response_budget.rs
@@ -486,6 +486,13 @@ pub(super) fn normalize_budgeted_response_shape(
             .is_some_and(|original_len| original_len > returned_count);
     }
 
+    if let Some(returned_count) = array_len(data.get("references")) {
+        update_data_returned_count(data, "reference_count", returned_count);
+        data_truncated |= original_shape
+            .original_data_array_len("references")
+            .is_some_and(|original_len| original_len > returned_count);
+    }
+
     if !data.contains_key("rows")
         && let Some(returned_count) = array_len(data.get("columns"))
     {

--- a/src/server/mcp/tests.rs
+++ b/src/server/mcp/tests.rs
@@ -439,6 +439,56 @@ fn mcp_response_budget_keeps_lineage_count_when_only_edges_are_truncated() {
 }
 
 #[test]
+fn mcp_response_budget_updates_reference_count_when_references_are_truncated() {
+    let config = crate::config::DbtNovaConfig {
+        mcp_max_response_bytes: 8192,
+        mcp_max_string_chars: 64,
+        ..Default::default()
+    };
+    let references: Vec<_> = (0..100)
+        .map(|idx| {
+            serde_json::json!({
+                "kind": "recipe_sql",
+                "unique_id": format!("analysis.pkg.recipe_{idx:03}"),
+                "detail": {
+                    "match": "textual",
+                    "snippet": "type_of_channel ".repeat(50)
+                }
+            })
+        })
+        .collect();
+    let response = serde_json::json!({
+        "success": true,
+        "count": 0,
+        "data": {
+            "start_entity": "model.pkg.sales_daily_channel",
+            "start_column": "type_of_channel",
+            "lineage": [],
+            "reference_count": references.len(),
+            "references": references
+        }
+    });
+
+    let budgeted = apply_mcp_response_budget(response, &config);
+    let returned_references = budgeted["data"]["references"]
+        .as_array()
+        .map_or(0, Vec::len);
+
+    assert!(
+        returned_references < 100,
+        "references were not truncated: returned_references={returned_references}"
+    );
+    assert!(returned_references > 0);
+    assert_eq!(budgeted["count"], serde_json::json!(0));
+    assert_eq!(
+        budgeted["data"]["reference_count"],
+        serde_json::json!(returned_references)
+    );
+    assert_eq!(budgeted["truncated"], serde_json::json!(true));
+    assert_eq!(budgeted["data"]["truncated"], serde_json::json!(true));
+}
+
+#[test]
 fn mcp_response_budget_updates_undocumented_summary_counts_when_truncated() {
     let config = crate::config::DbtNovaConfig {
         mcp_max_response_bytes: 8192,

--- a/src/tests/column_lineage.rs
+++ b/src/tests/column_lineage.rs
@@ -12,6 +12,7 @@ async fn test_get_column_lineage_entity_not_found() {
         direction: "upstream".to_string(),
         depth: None,
         confidence: Some("medium".to_string()),
+        include_references: false,
     };
     let result = searcher.get_column_lineage(&params).await.json();
     let success = result
@@ -36,6 +37,7 @@ async fn test_get_column_lineage_column_not_found() {
         direction: "upstream".to_string(),
         depth: None,
         confidence: Some("medium".to_string()),
+        include_references: false,
     };
     let result = searcher.get_column_lineage(&params).await.json();
     let success = result
@@ -62,6 +64,7 @@ async fn test_get_column_lineage_invalid_direction() {
         direction: "invalid".to_string(),
         depth: None,
         confidence: Some("medium".to_string()),
+        include_references: false,
     };
     let result = searcher.get_column_lineage(&params).await.json();
     let success = result
@@ -93,6 +96,7 @@ async fn test_get_column_lineage_upstream_high_confidence() {
         direction: "upstream".to_string(),
         depth: Some(1),
         confidence: Some("high".to_string()),
+        include_references: false,
     };
     let result = searcher.get_column_lineage(&params).await.json();
     let success = result
@@ -143,6 +147,7 @@ async fn test_get_column_lineage_downstream() {
         direction: "downstream".to_string(),
         depth: Some(2),
         confidence: Some("medium".to_string()),
+        include_references: false,
     };
     let result = searcher.get_column_lineage(&params).await.json();
     let success = result
@@ -175,6 +180,7 @@ async fn test_get_column_lineage_depth_limit() {
         direction: "upstream".to_string(),
         depth: Some(1),
         confidence: Some("low".to_string()),
+        include_references: false,
     };
     let result = searcher.get_column_lineage(&params).await.json();
     let success = result
@@ -218,6 +224,7 @@ async fn test_get_column_lineage_confidence_levels() {
         direction: "upstream".to_string(),
         depth: Some(3),
         confidence: Some("high".to_string()),
+        include_references: false,
     };
     let result_high = searcher.get_column_lineage(&params_high).await.json();
     // Low confidence
@@ -228,6 +235,7 @@ async fn test_get_column_lineage_confidence_levels() {
         direction: "upstream".to_string(),
         depth: Some(3),
         confidence: Some("low".to_string()),
+        include_references: false,
     };
     let result_low = searcher.get_column_lineage(&params_low).await.json();
     // Low confidence should have >= results than high confidence
@@ -259,6 +267,7 @@ async fn test_get_column_lineage_response_structure() {
         direction: "upstream".to_string(),
         depth: None,
         confidence: Some("low".to_string()),
+        include_references: false,
     };
     let result = searcher.get_column_lineage(&params).await.json();
     let success = result
@@ -319,6 +328,7 @@ async fn test_get_column_lineage_ambiguous_name_returns_error() {
         direction: "upstream".to_string(),
         depth: Some(1),
         confidence: Some("medium".to_string()),
+        include_references: false,
     };
     let result = searcher.get_column_lineage(&params).await;
     match result {

--- a/src/tests/impact.rs
+++ b/src/tests/impact.rs
@@ -7,6 +7,7 @@ async fn test_get_impact() {
     let searcher = get_searcher();
     let params = GetImpactParams {
         id_or_name: "model.nova_test.stg__traffic_sessions".to_string(),
+        column: None,
     };
     let result = searcher.get_impact(&params).await.json();
     let success = result
@@ -30,6 +31,7 @@ async fn test_get_impact_not_found() {
     let searcher = get_searcher();
     let params = GetImpactParams {
         id_or_name: "nonexistent.model".to_string(),
+        column: None,
     };
     let result = searcher.get_impact(&params).await.json();
     let success = result

--- a/src/tests/integration.rs
+++ b/src/tests/integration.rs
@@ -84,6 +84,7 @@ async fn test_full_workflow() {
     // 6. Get impact to validate downstream dependency reporting.
     let impact_params = GetImpactParams {
         id_or_name: unique_id.to_string(),
+        column: None,
     };
     let impact_result = searcher.get_impact(&impact_params).await.json();
     let success = impact_result

--- a/src/tools/catalog.rs
+++ b/src/tools/catalog.rs
@@ -449,6 +449,10 @@ pub const MCP_BUDGETABLE_DATA_ARRAY_FIELDS: &[McpBudgetableDataArrayField] = &[
         returned_count_field: None,
     },
     McpBudgetableDataArrayField {
+        field: "references",
+        returned_count_field: Some("reference_count"),
+    },
+    McpBudgetableDataArrayField {
         field: "not_found",
         returned_count_field: Some("not_found_count"),
     },
@@ -477,7 +481,7 @@ pub const MCP_RESPONSE_BUDGET_CONTRACTS: &[McpResponseBudgetContract] = &[
     },
     McpResponseBudgetContract {
         tool: "get_column_lineage",
-        data_array_fields: &["edges"],
+        data_array_fields: &["lineage", "references"],
     },
     McpResponseBudgetContract {
         tool: "get_undocumented",

--- a/src/tools/column_lineage.rs
+++ b/src/tools/column_lineage.rs
@@ -2,10 +2,13 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::config::ConfidenceTier;
 use crate::error::{DbtNovaError, Result};
-use crate::manifest::lineage_sql::{find_sql_aliases, sql_for_matching};
+use crate::manifest::lineage_sql::{
+    SqlColumnDefinition, find_select_column_definition, find_sql_aliases, sql_for_matching,
+};
 use crate::manifest::search::ManifestSearch;
 use crate::params::GetColumnLineageParams;
 use crate::responses::SuccessResponse;
+use crate::tools::column_references::collect_column_references;
 use crate::tools::helpers::dependency_hints_from_json;
 use crate::utils::levenshtein_similarity;
 use serde::Serialize;
@@ -233,7 +236,7 @@ impl ManifestSearch {
         };
 
         let count = results.len();
-        let payload = json!({
+        let mut payload = json!({
             "start_entity": &start_id,
             "start_column": params.column_name,
             "direction": params.direction,
@@ -241,6 +244,41 @@ impl ManifestSearch {
             "lineage_status": lineage_status,
             "lineage_hints": lineage_hints
         });
+        if params.direction == "upstream"
+            && count == 0
+            && hints_total > 0
+            && let Some((definition_source, definition)) =
+                column_definition_from_entity(&start_entity_json, &params.column_name)
+            && let Some(obj) = payload.as_object_mut()
+        {
+            obj.insert(
+                "definition".to_string(),
+                JsonValue::String(definition.expression.clone()),
+            );
+            obj.insert(
+                "definition_source".to_string(),
+                JsonValue::String(definition_source.to_string()),
+            );
+            obj.insert(
+                "definition_confidence".to_string(),
+                JsonValue::String(definition.confidence.to_string()),
+            );
+            obj.insert(
+                "referenced_columns".to_string(),
+                JsonValue::Array(referenced_columns_for_definition(
+                    self,
+                    &start_id,
+                    &definition,
+                )?),
+            );
+        }
+        if params.include_references
+            && let Some(obj) = payload.as_object_mut()
+        {
+            let references = collect_column_references(self, &params.column_name)?;
+            obj.insert("reference_count".to_string(), json!(references.len()));
+            obj.insert("references".to_string(), JsonValue::Array(references));
+        }
         let response = SuccessResponse::new(payload, count);
         let response = if truncated {
             response.with_truncated(true)
@@ -249,6 +287,86 @@ impl ManifestSearch {
         };
         Ok(serde_json::to_value(response)?)
     }
+}
+
+fn column_definition_from_entity(
+    entity_json: &JsonValue,
+    column_name: &str,
+) -> Option<(&'static str, SqlColumnDefinition)> {
+    if let Some(sql) = entity_json.get("compiled_code").and_then(JsonValue::as_str)
+        && let Some(definition) = find_select_column_definition(sql, column_name)
+    {
+        return Some(("compiled_sql", definition));
+    }
+    if let Some(sql) = entity_json.get("raw_code").and_then(JsonValue::as_str)
+        && let Some(definition) = find_select_column_definition(sql, column_name)
+    {
+        return Some(("raw_sql", definition));
+    }
+    None
+}
+
+fn referenced_columns_for_definition(
+    search: &ManifestSearch,
+    start_id: &str,
+    definition: &SqlColumnDefinition,
+) -> Result<Vec<JsonValue>> {
+    let mut parent_ids = search.parent_map.get(start_id).cloned().unwrap_or_default();
+    parent_ids.sort();
+
+    let mut seen = HashSet::new();
+    let mut references = Vec::new();
+    for identifier in &definition.identifiers {
+        let column_name = identifier_column_name(identifier);
+        if column_name.is_empty() || !seen.insert(column_name.to_ascii_lowercase()) {
+            continue;
+        }
+
+        let mut upstream_entities = Vec::new();
+        for parent_id in &parent_ids {
+            let Some(parent) = search.get_entity_archived(parent_id)? else {
+                continue;
+            };
+            let Some(matched_column) = parent
+                .column_names_iter()
+                .find(|candidate| candidate.eq_ignore_ascii_case(&column_name))
+            else {
+                continue;
+            };
+            let parent_json = parent.to_json_value();
+            upstream_entities.push(json!({
+                "unique_id": parent_id,
+                "name": parent_json.get("name"),
+                "resource_type": parent_json.get("resource_type"),
+                "column": matched_column
+            }));
+        }
+
+        references.push(json!({
+            "name": column_name,
+            "expression_identifier": identifier,
+            "upstream_entities": upstream_entities
+        }));
+    }
+
+    references.sort_by(|a, b| {
+        a.get("name")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("")
+            .cmp(b.get("name").and_then(JsonValue::as_str).unwrap_or(""))
+    });
+    Ok(references)
+}
+
+fn identifier_column_name(identifier: &str) -> String {
+    identifier
+        .trim()
+        .trim_matches(|c: char| matches!(c, '`' | '"' | '[' | ']'))
+        .rsplit('.')
+        .next()
+        .unwrap_or(identifier)
+        .trim_matches(|c: char| matches!(c, '`' | '"' | '[' | ']'))
+        .to_string()
 }
 
 fn confidence_rank(conf: &str, default_conf: &str) -> u8 {

--- a/src/tools/column_references.rs
+++ b/src/tools/column_references.rs
@@ -1,0 +1,542 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Value as JsonValue, json};
+
+use crate::error::Result;
+use crate::manifest::entity::entity_nova_meta_json;
+use crate::manifest::lineage_sql::sql_for_matching;
+use crate::manifest::search::ManifestSearch;
+
+pub(crate) fn collect_column_references(
+    search: &ManifestSearch,
+    column_name: &str,
+) -> Result<Vec<JsonValue>> {
+    let column_name = column_name.trim();
+    if column_name.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut records = Vec::new();
+    collect_nova_meta_references(search, column_name, &mut records)?;
+    collect_test_references(search, column_name, &mut records)?;
+    collect_recipe_sql_references(search, column_name, &mut records)?;
+    records.sort_by(reference_sort_key);
+    Ok(records)
+}
+
+pub(crate) fn reference_counts_by_kind(references: &[JsonValue]) -> BTreeMap<String, usize> {
+    let mut counts = BTreeMap::new();
+    for reference in references {
+        let kind = reference
+            .get("kind")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("unknown");
+        *counts.entry(kind.to_string()).or_default() += 1;
+    }
+    counts
+}
+
+pub(crate) fn identifier_match_positions(text: &str, identifier: &str) -> Vec<usize> {
+    let needle = identifier.trim().to_ascii_lowercase();
+    if needle.is_empty() {
+        return Vec::new();
+    }
+
+    let haystack = text.to_ascii_lowercase();
+    let bytes = haystack.as_bytes();
+    let needle_bytes = needle.as_bytes();
+    let mut positions = Vec::new();
+    let mut cursor = 0usize;
+    while let Some(found) = haystack[cursor..].find(&needle) {
+        let start = cursor + found;
+        let end = start + needle_bytes.len();
+        let before_ok = start == 0 || !is_identifier_byte(bytes[start - 1]);
+        let after_ok = end >= bytes.len() || !is_identifier_byte(bytes[end]);
+        if before_ok && after_ok {
+            positions.push(start);
+        }
+        cursor = end;
+    }
+    positions
+}
+
+fn collect_nova_meta_references(
+    search: &ManifestSearch,
+    column_name: &str,
+    records: &mut Vec<JsonValue>,
+) -> Result<()> {
+    let mut ids: Vec<String> = search.resource_type_by_id.keys().cloned().collect();
+    ids.sort();
+
+    for unique_id in ids {
+        let Some(entity) = search.get_entity_archived(&unique_id)? else {
+            continue;
+        };
+        let entity_json = entity.to_json_value();
+        let Some(nova) = entity_nova_meta_json(&entity_json) else {
+            continue;
+        };
+        let nova = nova.as_ref();
+
+        collect_grain_dimension_references(
+            &unique_id,
+            &entity_json,
+            nova.get("grain"),
+            "meta.nova.grain",
+            None,
+            column_name,
+            records,
+        );
+        collect_measure_references(&unique_id, &entity_json, nova, column_name, records);
+        collect_metric_references(&unique_id, &entity_json, nova, column_name, records);
+    }
+
+    Ok(())
+}
+
+fn collect_grain_dimension_references(
+    unique_id: &str,
+    entity_json: &JsonValue,
+    grain: Option<&JsonValue>,
+    path: &str,
+    metric_name: Option<&str>,
+    column_name: &str,
+    records: &mut Vec<JsonValue>,
+) {
+    let Some(dimensions) = grain
+        .and_then(|grain| grain.get("dimensions"))
+        .and_then(JsonValue::as_array)
+    else {
+        return;
+    };
+
+    for (index, dimension) in dimensions.iter().enumerate() {
+        let Some(dimension) = dimension.as_str() else {
+            continue;
+        };
+        if !names_equal(dimension, column_name) {
+            continue;
+        }
+
+        let mut detail = json!({
+            "path": format!("{path}.dimensions[{index}]"),
+            "field": "dimensions",
+            "match": "exact"
+        });
+        if let Some(metric_name) = metric_name
+            && let Some(obj) = detail.as_object_mut()
+        {
+            obj.insert(
+                "metric_name".to_string(),
+                JsonValue::String(metric_name.to_string()),
+            );
+        }
+        records.push(reference_record(
+            "nova_grain_dimension",
+            unique_id,
+            entity_json,
+            detail,
+        ));
+    }
+}
+
+fn collect_measure_references(
+    unique_id: &str,
+    entity_json: &JsonValue,
+    nova: &JsonValue,
+    column_name: &str,
+    records: &mut Vec<JsonValue>,
+) {
+    let Some(measures) = nova.get("measures").and_then(JsonValue::as_array) else {
+        return;
+    };
+
+    for (index, measure) in measures.iter().enumerate() {
+        let field_match = measure
+            .get("field")
+            .and_then(JsonValue::as_str)
+            .is_some_and(|field| names_equal(field, column_name));
+        let expression = measure
+            .get("expression")
+            .or_else(|| measure.get("expr"))
+            .and_then(JsonValue::as_str);
+        let expression_match = expression
+            .is_some_and(|expr| !identifier_match_positions(expr, column_name).is_empty());
+
+        if !field_match && !expression_match {
+            continue;
+        }
+
+        records.push(reference_record(
+            "nova_measure_expression",
+            unique_id,
+            entity_json,
+            json!({
+                "path": format!("meta.nova.measures[{index}]"),
+                "measure_name": measure.get("name").and_then(JsonValue::as_str),
+                "field_match": field_match,
+                "expression_match": expression_match,
+                "expression": expression,
+                "match": if field_match { "exact" } else { "tokenized_expression" }
+            }),
+        ));
+    }
+}
+
+fn collect_metric_references(
+    unique_id: &str,
+    entity_json: &JsonValue,
+    nova: &JsonValue,
+    column_name: &str,
+    records: &mut Vec<JsonValue>,
+) {
+    if let Some(metric) = nova.get("metric") {
+        collect_single_metric_reference(
+            unique_id,
+            entity_json,
+            metric,
+            "meta.nova.metric",
+            column_name,
+            records,
+        );
+    }
+
+    let Some(metrics) = nova.get("metrics").and_then(JsonValue::as_array) else {
+        return;
+    };
+    for (index, metric) in metrics.iter().enumerate() {
+        collect_single_metric_reference(
+            unique_id,
+            entity_json,
+            metric,
+            &format!("meta.nova.metrics[{index}]"),
+            column_name,
+            records,
+        );
+    }
+}
+
+fn collect_single_metric_reference(
+    unique_id: &str,
+    entity_json: &JsonValue,
+    metric: &JsonValue,
+    path: &str,
+    column_name: &str,
+    records: &mut Vec<JsonValue>,
+) {
+    let metric_name = metric.get("name").and_then(JsonValue::as_str);
+    let expression = metric
+        .get("expression")
+        .or_else(|| metric.get("expr"))
+        .and_then(JsonValue::as_str);
+    if expression.is_some_and(|expr| !identifier_match_positions(expr, column_name).is_empty()) {
+        records.push(reference_record(
+            "nova_metric_expression",
+            unique_id,
+            entity_json,
+            json!({
+                "path": path,
+                "metric_name": metric_name,
+                "expression": expression,
+                "match": "tokenized_expression"
+            }),
+        ));
+    }
+
+    collect_grain_dimension_references(
+        unique_id,
+        entity_json,
+        metric.get("grain"),
+        &format!("{path}.grain"),
+        metric_name,
+        column_name,
+        records,
+    );
+}
+
+fn collect_test_references(
+    search: &ManifestSearch,
+    column_name: &str,
+    records: &mut Vec<JsonValue>,
+) -> Result<()> {
+    let Some(test_ids) = search.by_resource_type.get("test") else {
+        return Ok(());
+    };
+    let mut test_ids = test_ids.clone();
+    test_ids.sort();
+
+    for unique_id in test_ids {
+        let Some(test) = search.get_entity_archived(&unique_id)? else {
+            continue;
+        };
+        let test_json = test.to_json_value();
+        let mut matches = Vec::new();
+        if test_json
+            .get("column_name")
+            .and_then(JsonValue::as_str)
+            .is_some_and(|column| names_equal(column, column_name))
+        {
+            matches.push(json!({"path": "column_name", "match": "exact"}));
+        }
+        if let Some(kwargs) = test_json
+            .get("test_metadata")
+            .and_then(|metadata| metadata.get("kwargs"))
+        {
+            collect_json_exact_matches(kwargs, "$.test_metadata.kwargs", column_name, &mut matches);
+        }
+
+        if matches.is_empty() {
+            continue;
+        }
+
+        records.push(reference_record(
+            "test",
+            &unique_id,
+            &test_json,
+            json!({
+                "test_name": test_json
+                    .get("test_metadata")
+                    .and_then(|metadata| metadata.get("name"))
+                    .and_then(JsonValue::as_str),
+                "matches": matches,
+                "depends_on": dependency_nodes(&test_json),
+                "match": "exact"
+            }),
+        ));
+    }
+
+    Ok(())
+}
+
+fn collect_recipe_sql_references(
+    search: &ManifestSearch,
+    column_name: &str,
+    records: &mut Vec<JsonValue>,
+) -> Result<()> {
+    let Some(analysis_ids) = search.by_resource_type.get("analysis") else {
+        return Ok(());
+    };
+    let mut analysis_ids = analysis_ids.clone();
+    analysis_ids.sort();
+
+    for unique_id in analysis_ids {
+        let Some(analysis) = search.get_entity_archived(&unique_id)? else {
+            continue;
+        };
+        let analysis_json = analysis.to_json_value();
+        if !is_recipe_analysis(search, &analysis_json) {
+            continue;
+        }
+        let Some(sql) = sql_for_matching(&analysis_json) else {
+            continue;
+        };
+        let positions = identifier_match_positions(sql, column_name);
+        if positions.is_empty() {
+            continue;
+        }
+
+        records.push(reference_record(
+            "recipe_sql",
+            &unique_id,
+            &analysis_json,
+            json!({
+                "match": "textual",
+                "occurrences": positions.len(),
+                "snippet": snippet_around(sql, positions[0], column_name.len()),
+                "depends_on": dependency_nodes(&analysis_json)
+            }),
+        ));
+    }
+
+    Ok(())
+}
+
+fn collect_json_exact_matches(
+    value: &JsonValue,
+    path: &str,
+    column_name: &str,
+    matches: &mut Vec<JsonValue>,
+) {
+    match value {
+        JsonValue::String(value) if names_equal(value, column_name) => {
+            matches.push(json!({"path": path, "match": "exact"}));
+        }
+        JsonValue::Array(values) => {
+            for (index, item) in values.iter().enumerate() {
+                collect_json_exact_matches(item, &format!("{path}[{index}]"), column_name, matches);
+            }
+        }
+        JsonValue::Object(map) => {
+            for (key, item) in map {
+                collect_json_exact_matches(item, &format!("{path}.{key}"), column_name, matches);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn reference_record(
+    kind: &str,
+    unique_id: &str,
+    entity_json: &JsonValue,
+    detail: JsonValue,
+) -> JsonValue {
+    let mut record = serde_json::Map::new();
+    record.insert("kind".to_string(), JsonValue::String(kind.to_string()));
+    record.insert(
+        "unique_id".to_string(),
+        JsonValue::String(unique_id.to_string()),
+    );
+    record.insert(
+        "name".to_string(),
+        entity_json
+            .get("name")
+            .and_then(JsonValue::as_str)
+            .map_or(JsonValue::Null, |name| JsonValue::String(name.to_string())),
+    );
+    record.insert(
+        "resource_type".to_string(),
+        entity_json
+            .get("resource_type")
+            .and_then(JsonValue::as_str)
+            .map_or(JsonValue::Null, |resource_type| {
+                JsonValue::String(resource_type.to_string())
+            }),
+    );
+    record.insert(
+        "original_file_path".to_string(),
+        entity_json
+            .get("original_file_path")
+            .or_else(|| entity_json.get("path"))
+            .and_then(JsonValue::as_str)
+            .map_or(JsonValue::Null, |path| JsonValue::String(path.to_string())),
+    );
+    record.insert("detail".to_string(), detail);
+    JsonValue::Object(record)
+}
+
+fn reference_sort_key(left: &JsonValue, right: &JsonValue) -> std::cmp::Ordering {
+    let left_key = (
+        left.get("kind").and_then(JsonValue::as_str).unwrap_or(""),
+        left.get("unique_id")
+            .and_then(JsonValue::as_str)
+            .unwrap_or(""),
+        left.get("original_file_path")
+            .and_then(JsonValue::as_str)
+            .unwrap_or(""),
+    );
+    let right_key = (
+        right.get("kind").and_then(JsonValue::as_str).unwrap_or(""),
+        right
+            .get("unique_id")
+            .and_then(JsonValue::as_str)
+            .unwrap_or(""),
+        right
+            .get("original_file_path")
+            .and_then(JsonValue::as_str)
+            .unwrap_or(""),
+    );
+    left_key.cmp(&right_key)
+}
+
+fn dependency_nodes(entity_json: &JsonValue) -> Vec<String> {
+    entity_json
+        .get("depends_on")
+        .and_then(|depends_on| depends_on.get("nodes"))
+        .and_then(JsonValue::as_array)
+        .map(|nodes| {
+            nodes
+                .iter()
+                .filter_map(JsonValue::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn is_recipe_analysis(search: &ManifestSearch, entity_json: &JsonValue) -> bool {
+    let Some(path) = entity_json
+        .get("original_file_path")
+        .or_else(|| entity_json.get("path"))
+        .and_then(JsonValue::as_str)
+    else {
+        return false;
+    };
+
+    let configured = search.config.recipes_dir.trim();
+    let prefix = if configured.is_empty() {
+        "analyses/recipes"
+    } else {
+        configured
+    };
+    let mut prefix = normalize_path(prefix);
+    if !prefix.ends_with('/') {
+        prefix.push('/');
+    }
+
+    normalize_path(path).starts_with(&prefix)
+}
+
+fn normalize_path(path: &str) -> String {
+    path.replace('\\', "/").trim_start_matches("./").to_string()
+}
+
+fn snippet_around(sql: &str, start: usize, len: usize) -> String {
+    let snippet_start = char_boundary_before(sql, start.saturating_sub(60));
+    let snippet_end = char_boundary_after(sql, (start + len + 60).min(sql.len()));
+    sql[snippet_start..snippet_end]
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn char_boundary_before(value: &str, mut index: usize) -> usize {
+    while index > 0 && !value.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+fn char_boundary_after(value: &str, mut index: usize) -> usize {
+    while index < value.len() && !value.is_char_boundary(index) {
+        index += 1;
+    }
+    index
+}
+
+fn names_equal(left: &str, right: &str) -> bool {
+    normalize_name(left).eq_ignore_ascii_case(&normalize_name(right))
+}
+
+fn normalize_name(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches(|c: char| matches!(c, '`' | '"' | '[' | ']'))
+        .rsplit('.')
+        .next()
+        .unwrap_or(value)
+        .to_string()
+}
+
+fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::identifier_match_positions;
+
+    #[test]
+    fn identifier_match_positions_respects_boundaries() {
+        assert_eq!(
+            identifier_match_positions("type_of_channel", "type_of_channel"),
+            vec![0]
+        );
+        assert!(identifier_match_positions("new_type_of_channel", "type_of_channel").is_empty());
+        assert!(identifier_match_positions("type_of_channel_v2", "type_of_channel").is_empty());
+        assert_eq!(
+            identifier_match_positions("select t.type_of_channel from table t", "type_of_channel"),
+            vec![9]
+        );
+    }
+}

--- a/src/tools/lineage.rs
+++ b/src/tools/lineage.rs
@@ -4,8 +4,9 @@ use serde_json::Value as JsonValue;
 
 use crate::error::{DbtNovaError, Result};
 use crate::manifest::search::ManifestSearch;
-use crate::params::{DetailLevel, GetImpactParams, GetLineageParams};
+use crate::params::{DetailLevel, GetColumnLineageParams, GetImpactParams, GetLineageParams};
 use crate::responses::SuccessResponse;
+use crate::tools::column_references::{collect_column_references, reference_counts_by_kind};
 use crate::tools::helpers::dependency_hints_from_json;
 use tracing::{debug, instrument};
 
@@ -269,7 +270,37 @@ impl ManifestSearch {
     #[instrument(skip(self, params), fields(tool = "get_impact", id_or_name = %params.id_or_name))]
     pub async fn get_impact(&self, params: &GetImpactParams) -> Result<JsonValue> {
         let (unique_id, entity) = self.resolve_entity(&params.id_or_name, None).await?;
-        let column_count = entity.column_names().len();
+        let entity_column_count = entity.column_names().len();
+
+        if let Some(column) = params
+            .column
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            if !entity
+                .column_names_iter()
+                .any(|candidate| candidate.eq_ignore_ascii_case(column))
+            {
+                return Err(DbtNovaError::InvalidParams(format!(
+                    "column '{column}' was not found on {unique_id}"
+                )));
+            }
+
+            return self
+                .get_column_impact(unique_id, column, entity_column_count)
+                .await;
+        }
+
+        if params
+            .column
+            .as_deref()
+            .is_some_and(|column| column.trim().is_empty())
+        {
+            return Err(DbtNovaError::InvalidParams(
+                "column cannot be empty".to_string(),
+            ));
+        }
 
         let lineage_params = GetLineageParams {
             id_or_name: unique_id.clone(),
@@ -298,15 +329,78 @@ impl ManifestSearch {
         }
 
         #[allow(clippy::cast_precision_loss)]
-        let impact_score = (downstream_count as f64) * (column_count as f64);
+        let impact_score = (downstream_count as f64) * (entity_column_count as f64);
 
         Ok(serde_json::to_value(SuccessResponse::new(
             serde_json::json!({
                 "unique_id": unique_id,
                 "downstream_count": downstream_count,
-                "column_count": column_count,
+                "column_count": entity_column_count,
                 "by_type": by_type,
                 "impact_score": impact_score
+            }),
+            1,
+        ))?)
+    }
+
+    async fn get_column_impact(
+        &self,
+        unique_id: String,
+        column: &str,
+        entity_column_count: usize,
+    ) -> Result<JsonValue> {
+        let column_lineage_params = GetColumnLineageParams {
+            id_or_name: unique_id.clone(),
+            resource_type: None,
+            column_name: column.to_string(),
+            direction: "downstream".to_string(),
+            depth: None,
+            confidence: Some(self.config.column_lineage.default_confidence.clone()),
+            include_references: false,
+        };
+        let column_lineage = self.get_column_lineage(&column_lineage_params).await?;
+        let lineage_data = column_lineage.get("data").unwrap_or(&JsonValue::Null);
+        let lineage_rows = lineage_data
+            .get("lineage")
+            .and_then(JsonValue::as_array)
+            .cloned()
+            .unwrap_or_default();
+
+        let mut downstream_ids = std::collections::BTreeSet::new();
+        let mut by_type: HashMap<String, usize> = HashMap::new();
+        for row in lineage_rows {
+            let Some(row_id) = row.get("unique_id").and_then(JsonValue::as_str) else {
+                continue;
+            };
+            if downstream_ids.insert(row_id.to_string()) {
+                let resource_type = row
+                    .get("resource_type")
+                    .and_then(JsonValue::as_str)
+                    .unwrap_or("unknown");
+                *by_type.entry(resource_type.to_string()).or_default() += 1;
+            }
+        }
+        let downstream_count = downstream_ids.len();
+        let references = collect_column_references(self, column)?;
+        let references_by_kind = reference_counts_by_kind(&references);
+
+        #[allow(clippy::cast_precision_loss)]
+        let impact_score = downstream_count as f64;
+
+        Ok(serde_json::to_value(SuccessResponse::new(
+            serde_json::json!({
+                "unique_id": unique_id,
+                "column": column,
+                "downstream_count": downstream_count,
+                "column_count": 1,
+                "entity_column_count": entity_column_count,
+                "by_type": by_type,
+                "impact_score": impact_score,
+                "column_lineage_status": lineage_data
+                    .get("lineage_status")
+                    .and_then(JsonValue::as_str),
+                "reference_count": references.len(),
+                "references_by_kind": references_by_kind
             }),
             1,
         ))?)

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,5 +1,6 @@
 pub mod catalog;
 pub mod column_lineage;
+pub(crate) mod column_references;
 pub mod context;
 pub mod coverage;
 pub mod diff;

--- a/tests/column_lineage.rs
+++ b/tests/column_lineage.rs
@@ -6,9 +6,124 @@ mod support_fixtures;
 #[path = "support/json.rs"]
 mod support_json;
 
-use dbt_nova::params::GetColumnLineageParams;
-use support_fixtures::load_fixture;
+use dbt_nova::params::{GetColumnLineageParams, GetImpactParams};
+use support_fixtures::{FixtureSearchEnv, load_fixture, load_manifest_path};
 use support_json::json;
+
+fn load_column_reference_fixture() -> (tempfile::TempDir, FixtureSearchEnv) {
+    let manifest = r#"{
+      "metadata": {"dbt_version": "1.10.0"},
+      "nodes": {
+        "model.pkg.base_orders": {
+          "unique_id": "model.pkg.base_orders",
+          "name": "base_orders",
+          "resource_type": "model",
+          "package_name": "pkg",
+          "original_file_path": "models/base_orders.sql",
+          "columns": {
+            "order_id": {"name": "order_id", "data_type": "integer"},
+            "type_of_channel": {"name": "type_of_channel", "data_type": "string"}
+          },
+          "depends_on": {"nodes": [], "macros": []},
+          "compiled_code": "select order_id, type_of_channel from raw.orders"
+        },
+        "model.pkg.sales_daily_channel": {
+          "unique_id": "model.pkg.sales_daily_channel",
+          "name": "sales_daily_channel",
+          "resource_type": "model",
+          "package_name": "pkg",
+          "original_file_path": "models/sales_daily_channel.sql",
+          "columns": {
+            "type_of_channel": {"name": "type_of_channel", "data_type": "string"},
+            "orders_count": {"name": "orders_count", "data_type": "integer"}
+          },
+          "meta": {
+            "nova": {
+              "grain": {"dimensions": ["type_of_channel"]},
+              "measures": [
+                {
+                  "name": "channel_order_count",
+                  "expression": "count(distinct case when type_of_channel is not null then order_id end)",
+                  "field": "order_id"
+                }
+              ],
+              "metrics": [
+                {
+                  "name": "paid_channel_order_share",
+                  "expression": "sum(case when type_of_channel = 'paid' then orders_count else 0 end) / nullif(sum(orders_count), 0)"
+                }
+              ]
+            }
+          },
+          "depends_on": {"nodes": ["model.pkg.base_orders"], "macros": []},
+          "compiled_code": "select type_of_channel, count(distinct order_id) as orders_count from analytics.base_orders group by 1"
+        },
+        "model.pkg.sales_channel_rollup": {
+          "unique_id": "model.pkg.sales_channel_rollup",
+          "name": "sales_channel_rollup",
+          "resource_type": "model",
+          "package_name": "pkg",
+          "original_file_path": "models/sales_channel_rollup.sql",
+          "columns": {
+            "type_of_channel": {"name": "type_of_channel", "data_type": "string"},
+            "orders_count": {"name": "orders_count", "data_type": "integer"}
+          },
+          "depends_on": {"nodes": ["model.pkg.sales_daily_channel"], "macros": []},
+          "compiled_code": "select type_of_channel, sum(orders_count) as orders_count from analytics.sales_daily_channel group by 1"
+        },
+        "test.pkg.accepted_values_sales_daily_channel_type_of_channel": {
+          "unique_id": "test.pkg.accepted_values_sales_daily_channel_type_of_channel",
+          "name": "accepted_values_sales_daily_channel_type_of_channel",
+          "resource_type": "test",
+          "package_name": "pkg",
+          "original_file_path": "models/schema.yml",
+          "column_name": "type_of_channel",
+          "test_metadata": {"name": "accepted_values", "kwargs": {"column_name": "type_of_channel"}},
+          "depends_on": {"nodes": ["model.pkg.sales_daily_channel"], "macros": []}
+        },
+        "analysis.pkg.channel_recipe": {
+          "unique_id": "analysis.pkg.channel_recipe",
+          "name": "channel_recipe",
+          "resource_type": "analysis",
+          "package_name": "pkg",
+          "original_file_path": "analyses/recipes/channel_recipe/query.sql",
+          "depends_on": {"nodes": ["model.pkg.sales_daily_channel"], "macros": []},
+          "compiled_code": "select type_of_channel, sum(orders_count) as orders_count from analytics.sales_daily_channel group by 1"
+        }
+      },
+      "sources": {},
+      "macros": {},
+      "docs": {},
+      "groups": {},
+      "exposures": {},
+      "metrics": {},
+      "saved_queries": {},
+      "semantic_models": {},
+      "unit_tests": {},
+      "parent_map": {
+        "model.pkg.sales_daily_channel": ["model.pkg.base_orders"],
+        "model.pkg.sales_channel_rollup": ["model.pkg.sales_daily_channel"],
+        "test.pkg.accepted_values_sales_daily_channel_type_of_channel": ["model.pkg.sales_daily_channel"],
+        "analysis.pkg.channel_recipe": ["model.pkg.sales_daily_channel"]
+      },
+      "child_map": {
+        "model.pkg.base_orders": ["model.pkg.sales_daily_channel"],
+        "model.pkg.sales_daily_channel": [
+          "model.pkg.sales_channel_rollup",
+          "test.pkg.accepted_values_sales_daily_channel_type_of_channel",
+          "analysis.pkg.channel_recipe"
+        ],
+        "model.pkg.sales_channel_rollup": [],
+        "test.pkg.accepted_values_sales_daily_channel_type_of_channel": [],
+        "analysis.pkg.channel_recipe": []
+      }
+    }"#;
+    let temp = tempfile::tempdir().expect("tempdir");
+    let manifest_path = temp.path().join("column_reference_manifest.json");
+    std::fs::write(&manifest_path, manifest).expect("write manifest");
+    let searcher = load_manifest_path(&manifest_path).expect("load manifest");
+    (temp, searcher)
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn sql_alias_detection_matches_downstream_column() {
@@ -21,6 +136,7 @@ async fn sql_alias_detection_matches_downstream_column() {
         direction: "downstream".into(),
         depth: Some(1),
         confidence: Some("medium".into()),
+        include_references: false,
     };
     let result = json(searcher.get_column_lineage(&params).await);
     let lineage = result
@@ -38,6 +154,146 @@ async fn sql_alias_detection_matches_downstream_column() {
         reason
     );
     assert_eq!(item.get("column").and_then(|v| v.as_str()), Some("new_col"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unresolved_aggregate_column_returns_definition_and_upstream_candidates() {
+    let (_temp, searcher) = load_column_reference_fixture();
+    let params = GetColumnLineageParams {
+        id_or_name: "model.pkg.sales_daily_channel".into(),
+        resource_type: None,
+        column_name: "orders_count".into(),
+        direction: "upstream".into(),
+        depth: Some(1),
+        confidence: Some("high".into()),
+        include_references: false,
+    };
+
+    let result = json(searcher.get_column_lineage(&params).await);
+    let data = result.get("data").expect("data");
+    assert_eq!(
+        data.get("lineage_status").and_then(|value| value.as_str()),
+        Some("dependencies_unresolved_or_filtered")
+    );
+    assert_eq!(
+        data.get("lineage")
+            .and_then(|value| value.as_array())
+            .map(Vec::len),
+        Some(0)
+    );
+    assert_eq!(
+        data.get("definition_source")
+            .and_then(|value| value.as_str()),
+        Some("compiled_sql")
+    );
+    assert_eq!(
+        data.get("definition_confidence")
+            .and_then(|value| value.as_str()),
+        Some("exact")
+    );
+    assert_eq!(
+        data.get("definition").and_then(|value| value.as_str()),
+        Some("count(DISTINCT order_id)")
+    );
+
+    let referenced_columns = data
+        .get("referenced_columns")
+        .and_then(|value| value.as_array())
+        .expect("referenced_columns");
+    let order_id = referenced_columns
+        .iter()
+        .find(|item| item.get("name").and_then(|value| value.as_str()) == Some("order_id"))
+        .expect("order_id reference");
+    assert!(
+        order_id
+            .get("upstream_entities")
+            .and_then(|value| value.as_array())
+            .is_some_and(|entities| entities.iter().any(|entity| {
+                entity.get("unique_id").and_then(|value| value.as_str())
+                    == Some("model.pkg.base_orders")
+                    && entity.get("column").and_then(|value| value.as_str()) == Some("order_id")
+            }))
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn column_references_include_metadata_tests_and_recipe_sql_when_requested() {
+    let (_temp, searcher) = load_column_reference_fixture();
+    let params = GetColumnLineageParams {
+        id_or_name: "model.pkg.sales_daily_channel".into(),
+        resource_type: None,
+        column_name: "type_of_channel".into(),
+        direction: "downstream".into(),
+        depth: Some(2),
+        confidence: Some("high".into()),
+        include_references: true,
+    };
+
+    let result = json(searcher.get_column_lineage(&params).await);
+    let data = result.get("data").expect("data");
+    let references = data
+        .get("references")
+        .and_then(|value| value.as_array())
+        .expect("references");
+    for expected in [
+        "nova_grain_dimension",
+        "nova_measure_expression",
+        "nova_metric_expression",
+        "recipe_sql",
+        "test",
+    ] {
+        assert!(
+            references.iter().any(|reference| reference
+                .get("kind")
+                .and_then(|value| value.as_str())
+                == Some(expected)),
+            "missing {expected} in {references:#?}"
+        );
+    }
+    assert!(
+        references.iter().any(|reference| {
+            reference.get("kind").and_then(|value| value.as_str()) == Some("recipe_sql")
+                && reference
+                    .get("detail")
+                    .and_then(|detail| detail.get("match"))
+                    .and_then(|value| value.as_str())
+                    == Some("textual")
+        }),
+        "recipe SQL references should be labeled textual"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn impact_column_scopes_downstream_and_counts_references_by_kind() {
+    let (_temp, searcher) = load_column_reference_fixture();
+    let params = GetImpactParams {
+        id_or_name: "model.pkg.sales_daily_channel".into(),
+        column: Some("type_of_channel".into()),
+    };
+
+    let result = json(searcher.get_impact(&params).await);
+    let data = result.get("data").expect("data");
+    assert_eq!(
+        data.get("column").and_then(|value| value.as_str()),
+        Some("type_of_channel")
+    );
+    assert_eq!(
+        data.get("downstream_count")
+            .and_then(|value| value.as_u64()),
+        Some(1)
+    );
+    assert_eq!(
+        data.get("references_by_kind")
+            .and_then(|counts| counts.get("recipe_sql"))
+            .and_then(|value| value.as_u64()),
+        Some(1)
+    );
+    assert_eq!(
+        data.get("references_by_kind")
+            .and_then(|counts| counts.get("test"))
+            .and_then(|value| value.as_u64()),
+        Some(1)
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -63,6 +319,7 @@ async fn column_lineage_depth_clamps_to_config_max() {
         direction: "downstream".into(),
         depth: Some(10),
         confidence: Some("medium".into()),
+        include_references: false,
     };
     let result = json(searcher.get_column_lineage(&params).await);
     let lineage = result
@@ -88,6 +345,7 @@ async fn type_mismatch_blocks_match() {
         direction: "downstream".into(),
         depth: Some(1),
         confidence: Some("low".into()),
+        include_references: false,
     };
     let result = json(searcher.get_column_lineage(&params).await);
     let lineage = result
@@ -177,6 +435,7 @@ async fn truncated_column_lineage_returns_deterministic_subset() {
                     direction: "downstream".to_string(),
                     depth: Some(1),
                     confidence: Some("medium".to_string()),
+                    include_references: false,
                 })
                 .await,
         );


### PR DESCRIPTION
## Summary

- Add unresolved upstream column-lineage evidence for derived/aggregated columns: defining select-list expression, SQL source/confidence, and candidate upstream columns exposed by direct dependencies.
- Add optional `include_references` on `get_column_lineage` for metadata-plane rename evidence across Nova grain dimensions, Nova measure/metric expressions, dbt tests, and manifest-backed recipe SQL.
- Add optional `column` on `get_impact` to scope downstream impact and return reference counts by kind.
- Budget the new `references` array in MCP responses so large rename scans remain bounded.

## Grounding

Before the fix, a synthetic aggregate `orders_count` returned `lineage_status: dependencies_unresolved_or_filtered`, empty `lineage`, and no definition/reference fallback. `include_references` and `get_impact.column` were rejected as unknown params on `master`.

## Validation

- `cargo test --locked --test column_lineage -- --nocapture`
- `cargo test --locked --lib manifest::lineage_sql::tests -- --nocapture`
- `cargo test --locked --lib tests::column_lineage -- --nocapture`
- `cargo test --locked --lib tests::impact -- --nocapture`
- `cargo test --locked --lib mcp_response_budget_updates_reference_count_when_references_are_truncated -- --nocapture`
- `cargo test --locked --lib response_budget_contracts_reference_valid_tools_and_fields -- --nocapture`
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `uv run mkdocs build --strict` (passes; existing MkDocs Material upstream warning emitted)
- `scripts/check_module_size.sh`
- `git diff --check`

Closes #284
Closes #285
