### PR TITLE
Harden runtime and release safeguards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,7 +340,7 @@ jobs:
         run: scripts/check_dependency_watchlist.sh
 
       - name: Cargo Deny
-        run: cargo deny check advisories licenses sources
+        run: cargo deny check
 
   reusable-assets-producer:
     name: reusable-assets-producer

--- a/.github/workflows/nova-build-assets.yml
+++ b/.github/workflows/nova-build-assets.yml
@@ -598,6 +598,11 @@ jobs:
                 echo "gcp_workload_identity_provider and gcp_service_account must both be set when using OIDC-backed GCS publish."
                 exit 1
               fi
+              if [[ "${dbt_generate_manifest}" == "true" ]]; then
+                echo "OIDC-backed GCS publish cannot run in the same reusable workflow job that generates a manifest from caller dbt code."
+                echo "Generate and validate the manifest before invoking this workflow, or publish with non-OIDC credentials until publish is split into a separate job."
+                exit 1
+              fi
             fi
           fi
           if [[ ",${publish_targets_normalized}," == *,dbfs,* ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,6 @@ on:
   push:
     tags:
       - "v*"
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Existing release tag to publish (for example: v0.0.1)"
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -27,14 +21,13 @@ jobs:
       - name: Resolve tag
         id: resolve_tag
         shell: bash
-        env:
-          INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          release_tag="${GITHUB_REF_NAME}"
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            release_tag="${INPUT_TAG}"
+          if [[ "${GITHUB_REF}" != refs/tags/* ]]; then
+            echo "Release workflow must run from a tag ref."
+            exit 1
           fi
+          release_tag="${GITHUB_REF_NAME}"
           if ! [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid release tag: ${release_tag}"
             exit 1
@@ -319,7 +312,7 @@ jobs:
             COSIGN_EXPERIMENTAL=1 cosign verify-blob \
               --certificate "${asset}.tar.gz.crt" \
               --signature "${asset}.tar.gz.sig" \
-              --certificate-identity-regexp "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/(tags/${RELEASE_TAG}|heads/master)" \
+              --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/tags/${RELEASE_TAG}" \
               --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
               "${asset}.tar.gz"
           done
@@ -394,7 +387,7 @@ jobs:
           scanners: vuln
           vuln-type: os,library
           severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
-          ignore-unfixed: true
+          ignore-unfixed: false
           trivyignores: .trivyignore.yaml
           format: json
           output: dbt-nova-oci-trivy.json
@@ -409,7 +402,7 @@ jobs:
           scanners: vuln
           vuln-type: os,library
           severity: HIGH,CRITICAL
-          ignore-unfixed: true
+          ignore-unfixed: false
           trivyignores: .trivyignore.yaml
           format: table
           exit-code: "1"
@@ -430,14 +423,17 @@ jobs:
           set -euo pipefail
           docker push "${AMD64_IMAGE}"
 
-      - name: Build and push ARM64 image
+      - name: Build ARM64 image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
           file: Dockerfile.oci
           platforms: linux/arm64
-          push: true
-          tags: ${{ steps.image.outputs.arm64_tag }}
+          load: true
+          push: false
+          tags: |
+            dbt-nova:release-smoke-arm64
+            ${{ steps.image.outputs.arm64_tag }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: TARGETARCH=arm64
           provenance: false
@@ -445,7 +441,7 @@ jobs:
       - name: Smoke ARM64 HTTP container
         shell: bash
         env:
-          ARM64_IMAGE: ${{ steps.image.outputs.arm64_tag }}
+          ARM64_IMAGE: dbt-nova:release-smoke-arm64
         run: |
           set -euo pipefail
           docker rm -f dbt-nova-arm64-release-smoke >/dev/null 2>&1 || true
@@ -480,6 +476,50 @@ jobs:
 
           test "$health_ok" -eq 1
           test "$ready_ok" -eq 1
+
+      - name: Scan smoke-tested ARM64 image report
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: image
+          image-ref: dbt-nova:release-smoke-arm64
+          scanners: vuln
+          vuln-type: os,library
+          severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+          ignore-unfixed: false
+          trivyignores: .trivyignore.yaml
+          format: json
+          output: dbt-nova-oci-arm64-trivy.json
+          exit-code: "0"
+          timeout: 10m
+
+      - name: Gate smoke-tested ARM64 image vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: image
+          image-ref: dbt-nova:release-smoke-arm64
+          scanners: vuln
+          vuln-type: os,library
+          severity: HIGH,CRITICAL
+          ignore-unfixed: false
+          trivyignores: .trivyignore.yaml
+          format: table
+          exit-code: "1"
+          timeout: 10m
+
+      - name: Publish ARM64 OCI scan report
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
+        with:
+          tag_name: ${{ needs.validate.outputs.release_tag }}
+          overwrite_files: true
+          files: dbt-nova-oci-arm64-trivy.json
+
+      - name: Push smoke-tested ARM64 image
+        shell: bash
+        env:
+          ARM64_IMAGE: ${{ steps.image.outputs.arm64_tag }}
+        run: |
+          set -euo pipefail
+          docker push "${ARM64_IMAGE}"
 
       - name: Publish multi-arch manifest
         id: manifest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Hardened Databricks and BigQuery SQL execution so local poll timeouts attempt
+  provider-side cancellation, and Databricks now enforces local row/byte caps
+  while merging inline and fetched result chunks.
+- Enforced `manifest_max_bytes` for local manifest paths and auto-discovered
+  sibling `catalog.json` files before parsing.
+- Tightened release and reusable-workflow supply-chain posture: releases are
+  tag-triggered only, release asset verification now requires tag-scoped
+  identities, ARM64 images are smoked and Trivy-gated before push, Trivy no
+  longer globally ignores unfixed HIGH/CRITICAL findings, OIDC-backed GCS
+  publish cannot run alongside caller dbt manifest generation, and CI now runs
+  the full `cargo deny check` with yanked/unknown sources denied.
 - Bumped the metadata scoring contract to v2 with resource-shape-aware declared
   grain scoring: aggregate marts can earn primary-key quality credit from
   `time_field` + `dimensions` plus matching uniqueness tests, and raw sources no

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5076,9 +5076,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,7 @@
 [advisories]
 db-path = "$CARGO_HOME/advisory-dbs"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-yanked = "warn"
+yanked = "deny"
 unmaintained = "transitive"
 unsound = "transitive"
 ignore = [
@@ -37,6 +37,6 @@ allow = [
 confidence-threshold = 0.8
 
 [sources]
-unknown-registry = "warn"
-unknown-git = "warn"
+unknown-registry = "deny"
+unknown-git = "deny"
 allow-git = []

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -130,7 +130,7 @@ Operational defaults:
 ### Release Build
 
 - **File:** `.github/workflows/release.yml`
-- **Trigger:** `v*` tag push (or manual `workflow_dispatch` with `tag` input)
+- **Trigger:** `v*` tag push
 - **Action:**
   - validates tag is on `master`
   - validates `Cargo.toml` and `CHANGELOG.md` match the release tag version

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -59,12 +59,12 @@ Before tagging:
 - [ ] `CHANGELOG.md` updated for the version
 - [ ] `Cargo.toml` version bumped
 - [ ] `Cargo.toml` version matches the intended tag exactly
-- [ ] `cargo test --all-features` passes
+- [ ] `cargo test --locked --all-features` passes
 - [ ] `cargo clippy --locked --all-targets --all-features -- -D warnings` passes
 - [ ] `cargo fmt --check` passes
-- [ ] Docs build clean (`mkdocs build --strict`)
-- [ ] Config defaults are current (`scripts/check_config_reference.sh`)
-- [ ] Module-size exceptions are current (`scripts/check_module_size.sh`)
+- [ ] Docs build clean (`uv run mkdocs build --strict`)
+- [ ] Config defaults are current (`bash scripts/check_config_reference.sh`)
+- [ ] Module-size exceptions are current (`bash scripts/check_module_size.sh`)
 - [ ] Workflow changes have been linted with `actionlint`
 - [ ] Supply-chain changes have `cargo deny check` and dependency watchlist
       review where applicable
@@ -97,8 +97,6 @@ This repo uses four GitHub Actions workflows for releases and documentation:
 
 3. **Release Build** (`.github/workflows/release.yml`)
    - Trigger: `v*` tag push
-   - Manual fallback: `workflow_dispatch` with `tag` input (useful when a tag exists
-     but was pushed in a way that did not trigger downstream workflows)
    - Actions:
      - validates tag is on `master`
      - validates the crate version and changelog entry match the tag

--- a/docs/operations/prebuilt-assets.md
+++ b/docs/operations/prebuilt-assets.md
@@ -183,6 +183,10 @@ Publish target auth requirements:
 | `gcs` | Token via one of `DBT_NOVA_GCP_ACCESS_TOKEN`, `DBT_NOVA_BIGQUERY_ACCESS_TOKEN`, `GCP_ACCESS_TOKEN`, `GOOGLE_OAUTH_ACCESS_TOKEN`, or GitHub OIDC via `gcp_workload_identity_provider` + `gcp_service_account` |
 | `dbfs` | `DATABRICKS_HOST` and `DATABRICKS_ACCESS_TOKEN` |
 
+OIDC-backed GCS publish is intentionally not allowed in the same reusable job
+that generates a manifest from caller dbt code. Generate the manifest before
+calling the reusable workflow, or use token-based GCS credentials for that run.
+
 Common downstream pattern: keep a repo-local `workflow_dispatch` wrapper and
 call this reusable workflow from it. This lets each repo set its own target
 defaults, storage instance naming, and publish prefixes without forking Nova's
@@ -277,6 +281,8 @@ GitHub OIDC notes for GCS:
 - pass `gcp_workload_identity_provider` and `gcp_service_account`
 - optional `gcp_project_id` is forwarded to `google-github-actions/auth`
 - if OIDC is configured, you do not need a static `DBT_NOVA_GCP_ACCESS_TOKEN`
+- OIDC-backed GCS publish requires an existing `manifest_path` or
+  `manifest_uri`; it cannot be combined with `dbt_generate_manifest=true`
 
 Installer mode guidance:
 

--- a/src/manifest/loader.rs
+++ b/src/manifest/loader.rs
@@ -393,11 +393,13 @@ fn resolve_catalog(
     if !sibling_catalog.exists() {
         return Ok(None);
     }
-    Ok(Some(ManifestResolution {
-        local_path: sibling_catalog.clone(),
-        source_uri: sibling_catalog.to_string_lossy().to_string(),
-        cached: false,
-    }))
+    let mut catalog_config = config.clone();
+    catalog_config.manifest_uri = String::new();
+    catalog_config.manifest_path = sibling_catalog.to_string_lossy().to_string();
+    catalog_config.manifest_path_explicit = true;
+    resolve_manifest(&catalog_config).map(Some).map_err(|err| {
+        DbtNovaError::ManifestError(format!("Failed to resolve sibling catalog: {err}"))
+    })
 }
 
 fn apply_catalog_signature(
@@ -1424,6 +1426,34 @@ mod tests {
         assert_ne!(
             scoped_manifest_hash(&pruned),
             scoped_manifest_hash(&search_scoped)
+        );
+    }
+
+    #[test]
+    fn resolve_catalog_rejects_oversized_sibling_catalog() {
+        let temp = tempdir().unwrap_or_else(|err| panic!("tempdir failed: {err}"));
+        let manifest_path = temp.path().join("manifest.json");
+        let catalog_path = temp.path().join("catalog.json");
+        std::fs::write(&manifest_path, br"{}").expect("write manifest");
+        std::fs::write(&catalog_path, br#"{"too_large":true}"#).expect("write catalog");
+
+        let config = DbtNovaConfig {
+            manifest_path: manifest_path.to_string_lossy().to_string(),
+            manifest_max_bytes: 4,
+            ..DbtNovaConfig::default()
+        };
+        let manifest_resolution = ManifestResolution {
+            local_path: manifest_path,
+            source_uri: "manifest.json".to_string(),
+            cached: false,
+        };
+
+        let err = resolve_catalog(&config, &manifest_resolution)
+            .expect_err("oversized sibling catalog should fail");
+
+        assert!(
+            err.to_string().contains("exceeded size limit"),
+            "unexpected error: {err}"
         );
     }
 

--- a/src/manifest/source/file.rs
+++ b/src/manifest/source/file.rs
@@ -1,16 +1,41 @@
 use crate::config::DbtNovaConfig;
-use crate::error::Result;
+use crate::error::{DbtNovaError, Result};
 
 use super::{ManifestLocator, ManifestResolution};
 
-#[allow(clippy::unnecessary_wraps)]
 pub(crate) fn resolve_file(
     locator: &ManifestLocator,
-    _config: &DbtNovaConfig,
+    config: &DbtNovaConfig,
 ) -> Result<ManifestResolution> {
+    let local_path = std::path::PathBuf::from(&locator.rest);
+    enforce_local_size_limit(&local_path, config.manifest_max_bytes)?;
     Ok(ManifestResolution {
-        local_path: std::path::PathBuf::from(&locator.rest),
+        local_path,
         source_uri: locator.raw.clone(),
         cached: false,
     })
+}
+
+fn enforce_local_size_limit(path: &std::path::Path, max_bytes: u64) -> Result<()> {
+    if max_bytes == 0 {
+        return Ok(());
+    }
+    let metadata = match std::fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => {
+            return Err(DbtNovaError::ManifestError(format!(
+                "Failed to inspect local manifest file {}: {err}",
+                path.display()
+            )));
+        }
+    };
+    let len = metadata.len();
+    if len > max_bytes {
+        return Err(DbtNovaError::ManifestError(format!(
+            "Local manifest file {} exceeded size limit ({len} > {max_bytes})",
+            path.display()
+        )));
+    }
+    Ok(())
 }

--- a/src/warehouse/bigquery.rs
+++ b/src/warehouse/bigquery.rs
@@ -10,6 +10,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Value};
 use tokio::sync::RwLock;
+use tracing::warn;
 
 use crate::error::{DbtNovaError, Result};
 use crate::params::ExecuteSqlParams;
@@ -436,6 +437,10 @@ fn query_page_url(api_base_url: &str, project_id: &str, job_id: &str) -> String 
     format!("{api_base_url}/bigquery/v2/projects/{project_id}/queries/{job_id}")
 }
 
+fn job_cancel_url(api_base_url: &str, project_id: &str, job_id: &str) -> String {
+    format!("{api_base_url}/bigquery/v2/projects/{project_id}/jobs/{job_id}/cancel")
+}
+
 async fn send_json<T: DeserializeOwned>(builder: reqwest::RequestBuilder) -> Result<T> {
     let response = builder
         .send()
@@ -496,6 +501,20 @@ async fn get_query_page(
         .bearer_auth(&config.access_token)
         .query(&params);
     send_json(builder).await
+}
+
+async fn cancel_query_job(
+    client: &Client,
+    config: &BigQueryConfig,
+    job_id: &str,
+    location: Option<&str>,
+) -> Result<()> {
+    let url = job_cancel_url(&config.api_base_url, &config.project_id, job_id);
+    let mut builder = client.post(url).bearer_auth(&config.access_token);
+    if let Some(location) = location {
+        builder = builder.query(&[("location", location)]);
+    }
+    send_json::<Value>(builder).await.map(|_| ())
 }
 
 fn infer_parameter_type(value: &Value) -> Result<&'static str> {
@@ -686,13 +705,31 @@ async fn run_query(
         let poll_started = Instant::now();
         loop {
             if poll_started.elapsed() > settings.max_poll {
-                return Err(bq_err(format!(
-                    "query polling timed out after {}s (job_id={job_id})",
-                    settings.max_poll.as_secs()
-                )));
+                return Err(query_poll_timeout_error(
+                    client,
+                    config,
+                    &job_id,
+                    location.as_deref(),
+                    settings.max_poll,
+                )
+                .await);
             }
 
-            tokio::time::sleep(settings.poll_interval).await;
+            let remaining = settings
+                .max_poll
+                .checked_sub(poll_started.elapsed())
+                .unwrap_or_else(|| Duration::from_secs(0));
+            tokio::time::sleep(settings.poll_interval.min(remaining)).await;
+            if poll_started.elapsed() >= settings.max_poll {
+                return Err(query_poll_timeout_error(
+                    client,
+                    config,
+                    &job_id,
+                    location.as_deref(),
+                    settings.max_poll,
+                )
+                .await);
+            }
             response = get_query_page(
                 client,
                 config,
@@ -712,6 +749,26 @@ async fn run_query(
     }
 
     Ok((response, job_id, location))
+}
+
+async fn query_poll_timeout_error(
+    client: &Client,
+    config: &BigQueryConfig,
+    job_id: &str,
+    location: Option<&str>,
+    max_poll: Duration,
+) -> DbtNovaError {
+    if let Err(err) = cancel_query_job(client, config, job_id, location).await {
+        warn!(
+            job_id,
+            error = %err,
+            "failed to cancel BigQuery job after local poll timeout"
+        );
+    }
+    bq_err(format!(
+        "query polling timed out after {}s (job_id={job_id})",
+        max_poll.as_secs()
+    ))
 }
 
 #[derive(Debug)]
@@ -1203,6 +1260,63 @@ mod tests {
         assert_eq!(result.total_row_count, Some(2));
         assert_eq!(result.total_byte_count, Some(128));
         assert!(!result.truncated);
+    }
+
+    #[tokio::test]
+    async fn bigquery_query_cancels_job_on_local_poll_timeout() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/bigquery/v2/projects/test-project/queries"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "jobComplete": false,
+                "jobReference": {
+                    "jobId": "job_slow",
+                    "location": "US"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path(
+                "/bigquery/v2/projects/test-project/jobs/job_slow/cancel",
+            ))
+            .and(query_param("location", "US"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "kind": "bigquery#jobCancelResponse"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let config = BigQueryConfig {
+            project_id: "test-project".to_string(),
+            location: Some("US".to_string()),
+            access_token: "test-token".to_string(),
+            timeout: Duration::from_secs(5),
+            api_base_url: server.uri(),
+        };
+        let client = build_bigquery_client(config.timeout).expect("client");
+        let settings = ExecuteSettings {
+            row_limit: 10,
+            byte_limit: 1_000,
+            wait_timeout_s: Some(1),
+            poll_interval: Duration::from_millis(10),
+            max_poll: Duration::from_millis(1),
+            fetch_all_chunks: true,
+            max_chunks: 5,
+            parameters: Vec::new(),
+        };
+
+        let err = execute_bigquery_statement_with_runtime(&client, &config, "select 1", &settings)
+            .await
+            .expect_err("poll timeout should fail");
+
+        assert!(
+            err.to_string().contains("timed out"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/src/warehouse/databricks.rs
+++ b/src/warehouse/databricks.rs
@@ -350,19 +350,36 @@ impl DatabricksSqlClient {
     ) -> Result<StatementResponse> {
         let start = Instant::now();
         loop {
-            if start.elapsed() > max_poll {
-                return Err(dbx_err(format!(
-                    "Statement polling timed out after {max_poll:?} (id={statement_id})"
-                )));
+            if start.elapsed() >= max_poll {
+                return Err(self.poll_timeout_error(statement_id, max_poll).await);
             }
 
-            tokio::time::sleep(poll_interval).await;
+            let remaining = max_poll
+                .checked_sub(start.elapsed())
+                .unwrap_or_else(|| Duration::from_secs(0));
+            tokio::time::sleep(poll_interval.min(remaining)).await;
+            if start.elapsed() >= max_poll {
+                return Err(self.poll_timeout_error(statement_id, max_poll).await);
+            }
 
             let resp = self.sql_get_statement(statement_id).await?;
             if is_terminal_state(&resp.status.state) {
                 return Ok(resp);
             }
         }
+    }
+
+    async fn poll_timeout_error(&self, statement_id: &str, max_poll: Duration) -> DbtNovaError {
+        if let Err(err) = self.sql_cancel_statement(statement_id).await {
+            warn!(
+                statement_id,
+                error = %err,
+                "failed to cancel Databricks statement after local poll timeout"
+            );
+        }
+        dbx_err(format!(
+            "Statement polling timed out after {max_poll:?} (id={statement_id})"
+        ))
     }
 
     async fn process_success(
@@ -372,7 +389,8 @@ impl DatabricksSqlClient {
         opts: ExecuteOptions,
     ) -> Result<QueryResult> {
         let manifest = resp.manifest.as_ref();
-        let truncated = manifest.and_then(|m| m.truncated).unwrap_or(false);
+        let provider_truncated = manifest.and_then(|m| m.truncated).unwrap_or(false);
+        let mut local_truncated = false;
 
         // Columns/types (be tolerant: DDL can return no manifest).
         let (columns, column_types, stats, chunk_indices) = if let Some(m) = manifest {
@@ -407,12 +425,18 @@ impl DatabricksSqlClient {
             (vec![], vec![], QueryStats::default(), vec![])
         };
 
-        // Rows: start with whatever chunk we got inline.
-        let mut rows: Vec<Vec<Value>> = resp
-            .result
-            .as_ref()
-            .and_then(|r| r.data_array.clone())
-            .unwrap_or_default();
+        let mut rows: Vec<Vec<Value>> = Vec::new();
+        let mut approx_bytes = 0u64;
+        if let Some(data) = resp.result.as_ref().and_then(|r| r.data_array.as_ref()) {
+            append_limited_rows(
+                &mut rows,
+                data,
+                opts.row_limit,
+                opts.byte_limit,
+                &mut approx_bytes,
+                &mut local_truncated,
+            )?;
+        }
 
         let mut included_chunks: HashSet<u32> = HashSet::new();
         if let Some(r) = resp.result.as_ref()
@@ -424,15 +448,25 @@ impl DatabricksSqlClient {
         let mut fetched_chunks = included_chunks.len() as u64;
 
         // Optionally fetch remaining chunks (kept small + bounded).
-        if opts.fetch_all_chunks && !chunk_indices.is_empty() {
+        if opts.fetch_all_chunks && !chunk_indices.is_empty() && !local_truncated {
             let max_chunks = opts.max_chunks.unwrap_or(50);
             for idx in chunk_indices.into_iter().take(max_chunks) {
+                if local_truncated {
+                    break;
+                }
                 if included_chunks.contains(&idx) {
                     continue;
                 }
                 let chunk = self.sql_get_result_chunk(statement_id, idx).await?;
-                if let Some(data) = chunk.data_array {
-                    rows.extend(data);
+                if let Some(data) = chunk.data_array.as_ref() {
+                    append_limited_rows(
+                        &mut rows,
+                        data,
+                        opts.row_limit,
+                        opts.byte_limit,
+                        &mut approx_bytes,
+                        &mut local_truncated,
+                    )?;
                 }
                 included_chunks.insert(idx);
                 fetched_chunks += 1;
@@ -442,7 +476,7 @@ impl DatabricksSqlClient {
         Ok(QueryResult {
             statement_id: statement_id.to_string(),
             state: "SUCCEEDED".to_string(),
-            truncated,
+            truncated: provider_truncated || local_truncated,
 
             columns,
             column_types,
@@ -849,6 +883,43 @@ fn backoff_delay(attempt_1_based: usize) -> Duration {
     let pow = u32::try_from((attempt_1_based.saturating_sub(1)).min(6)).unwrap_or(0);
     let ms = base_ms.saturating_mul(2u64.saturating_pow(pow)).min(5_000);
     Duration::from_millis(ms)
+}
+
+fn append_limited_rows(
+    rows: &mut Vec<Vec<Value>>,
+    chunk_rows: &[Vec<Value>],
+    row_limit: Option<u64>,
+    byte_limit: Option<u64>,
+    approx_bytes: &mut u64,
+    truncated: &mut bool,
+) -> Result<()> {
+    for row in chunk_rows {
+        if let Some(limit) = row_limit {
+            let row_count = u64::try_from(rows.len()).unwrap_or(u64::MAX);
+            if row_count >= limit {
+                *truncated = true;
+                break;
+            }
+        }
+
+        let row_bytes = u64::try_from(
+            serde_json::to_vec(row)
+                .map_err(|err| dbx_err(format!("failed to serialize result row: {err}")))?
+                .len(),
+        )
+        .unwrap_or(u64::MAX);
+
+        if let Some(limit) = byte_limit
+            && approx_bytes.saturating_add(row_bytes) > limit
+        {
+            *truncated = true;
+            break;
+        }
+
+        *approx_bytes = approx_bytes.saturating_add(row_bytes);
+        rows.push(row.clone());
+    }
+    Ok(())
 }
 
 /// Build Databricks SQL statement parameters from values and optional types.

--- a/tests/databricks_client.rs
+++ b/tests/databricks_client.rs
@@ -20,6 +20,45 @@ fn test_config(host: String) -> DatabricksSqlConfig {
 }
 
 #[tokio::test]
+async fn databricks_query_cancels_on_local_poll_timeout() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "stmt-timeout",
+            "status": { "state": "RUNNING" }
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements/stmt-timeout/cancel"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = DatabricksSqlClient::new(test_config(server.uri())).unwrap();
+    let err = client
+        .execute(
+            "select sleep(60)",
+            ExecuteOptions {
+                poll_interval: Some(Duration::from_millis(10)),
+                max_poll: Some(Duration::from_millis(1)),
+                ..ExecuteOptions::default()
+            },
+        )
+        .await
+        .expect_err("poll timeout should fail");
+
+    assert!(
+        err.to_string().contains("timed out"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
 async fn databricks_query_succeeds_inline() {
     // Mock a one-shot SQL response where results are embedded inline.
     let server = MockServer::start().await;
@@ -109,6 +148,137 @@ async fn databricks_query_polls_and_fetches_chunks() {
     assert_eq!(result.columns, vec!["c1".to_string()]);
     assert_eq!(result.rows.len(), 2);
     assert_eq!(result.fetched_chunks, 2);
+}
+
+#[tokio::test]
+async fn databricks_query_fetches_available_chunks_when_provider_truncated() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "stmt-provider-truncated",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": {
+                "schema": { "columns": [{ "name": "c1", "type_name": "LONG" }] },
+                "chunks": [{ "chunk_index": 0 }, { "chunk_index": 1 }],
+                "truncated": true,
+                "total_chunk_count": 2,
+                "total_row_count": 2,
+                "total_byte_count": 20
+            },
+            "result": { "chunk_index": 0, "data_array": [[1]] }
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(
+            "/api/2.0/sql/statements/stmt-provider-truncated/result/chunks/1",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "chunk_index": 1,
+            "data_array": [[2]]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = DatabricksSqlClient::new(test_config(server.uri())).unwrap();
+    let result = client
+        .execute(
+            "select 1 union all select 2",
+            ExecuteOptions {
+                row_limit: Some(100),
+                byte_limit: Some(1_000),
+                ..ExecuteOptions::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.rows, vec![vec![json!(1)], vec![json!(2)]]);
+    assert!(result.truncated);
+    assert_eq!(result.fetched_chunks, 2);
+}
+
+#[tokio::test]
+async fn databricks_query_applies_local_row_limit_before_fetching_more_chunks() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "stmt-local-row-limit",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": {
+                "schema": { "columns": [{ "name": "c1", "type_name": "LONG" }] },
+                "chunks": [{ "chunk_index": 0 }, { "chunk_index": 1 }],
+                "truncated": false,
+                "total_chunk_count": 2,
+                "total_row_count": 3,
+                "total_byte_count": 30
+            },
+            "result": { "chunk_index": 0, "data_array": [[1], [2]] }
+        })))
+        .mount(&server)
+        .await;
+
+    let client = DatabricksSqlClient::new(test_config(server.uri())).unwrap();
+    let result = client
+        .execute(
+            "select 1 union all select 2 union all select 3",
+            ExecuteOptions {
+                row_limit: Some(1),
+                byte_limit: Some(1_000),
+                ..ExecuteOptions::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.rows, vec![vec![json!(1)]]);
+    assert!(result.truncated);
+    assert_eq!(result.fetched_chunks, 1);
+}
+
+#[tokio::test]
+async fn databricks_query_applies_local_byte_limit() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "stmt-local-byte-limit",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": {
+                "schema": { "columns": [{ "name": "payload", "type_name": "STRING" }] },
+                "chunks": [{ "chunk_index": 0 }],
+                "truncated": false,
+                "total_chunk_count": 1,
+                "total_row_count": 1,
+                "total_byte_count": 128
+            },
+            "result": { "chunk_index": 0, "data_array": [["too large for local byte cap"]] }
+        })))
+        .mount(&server)
+        .await;
+
+    let client = DatabricksSqlClient::new(test_config(server.uri())).unwrap();
+    let result = client
+        .execute(
+            "select 'too large for local byte cap'",
+            ExecuteOptions {
+                row_limit: Some(100),
+                byte_limit: Some(4),
+                ..ExecuteOptions::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(result.rows.is_empty());
+    assert!(result.truncated);
 }
 
 #[tokio::test]

--- a/tests/manifest_source.rs
+++ b/tests/manifest_source.rs
@@ -73,6 +73,43 @@ fn file_manifest_resolves_local_path() {
 }
 
 #[test]
+fn file_manifest_rejects_local_path_over_size_limit() {
+    let temp = TempDir::new().expect("temp dir");
+    let manifest_path = temp.path().join("manifest-file.json");
+    fs::write(&manifest_path, br#"{"too_large":true}"#).expect("write manifest");
+
+    let cfg = DbtNovaConfig {
+        manifest_path: manifest_path.to_string_lossy().to_string(),
+        manifest_uri: String::new(),
+        manifest_max_bytes: 4,
+        ..Default::default()
+    };
+
+    let err = resolve_manifest(&cfg).expect_err("oversized local manifest should fail");
+    assert!(
+        err.to_string().contains("exceeded size limit"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn file_manifest_size_limit_can_be_disabled() {
+    let temp = TempDir::new().expect("temp dir");
+    let manifest_path = temp.path().join("manifest-file.json");
+    fs::write(&manifest_path, br#"{"large":true}"#).expect("write manifest");
+
+    let cfg = DbtNovaConfig {
+        manifest_path: manifest_path.to_string_lossy().to_string(),
+        manifest_uri: String::new(),
+        manifest_max_bytes: 0,
+        ..Default::default()
+    };
+
+    let res = resolve_manifest(&cfg).expect("size limit disabled");
+    assert_eq!(res.local_path, manifest_path);
+}
+
+#[test]
 fn http_manifest_rejected_by_default() {
     let cfg = DbtNovaConfig {
         manifest_uri: "http://example.com/manifest-http-default-check.json".to_string(),


### PR DESCRIPTION
## Summary

Hardens the runtime and release/supply-chain guardrails identified in the audit pass:

- cancel Databricks and BigQuery remote work when Nova hits a local poll timeout
- enforce Databricks local row/byte caps across inline and fetched result chunks without conflating provider truncation with local truncation
- apply `manifest_max_bytes` to local manifest paths and auto-discovered sibling `catalog.json` files, while preserving the established missing-file error path
- tighten release publishing by removing manual dispatch, requiring tag-scoped Sigstore identities, scanning/gating ARM64 images before push, and no longer globally ignoring unfixed Trivy HIGH/CRITICAL findings
- prevent OIDC-backed GCS publish from sharing a reusable workflow job with caller dbt manifest generation
- run full `cargo deny check` in CI and deny yanked/unknown dependency sources
- refresh the affected release, CI, prebuilt asset docs, and changelog

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --test databricks_client --quiet`
- `cargo test --locked warehouse::bigquery::tests --quiet`
- `cargo test --locked --test manifest_source --quiet`
- `cargo test --locked --test loader --quiet`
- `cargo test --locked manifest::loader::tests::resolve_catalog_rejects_oversized_sibling_catalog --quiet`
- `cargo test --locked --all-features --quiet`
- `uv run mkdocs build --strict`
- `bash scripts/check_config_reference.sh`
- `bash scripts/check_dependency_watchlist.sh`
- `cargo deny check`
- `actionlint .github/workflows/release.yml .github/workflows/nova-build-assets.yml .github/workflows/ci.yml`
- `git diff --check`