### PR TITLE
Extend entity diff sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added opt-in `diff_entities` sections for manifest-native modelling
+  comparison: `grain`, `indicators`, `governance`, `tests`, and `all`, while
+  preserving the columns-only default.
 - Hardened agent-facing defaults: `get_context` now counts lineage test nodes
   without letting them consume upstream/downstream entity slots by default,
   `modelling_consistency_report` applies a bounded default overlap threshold

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -39,7 +39,7 @@ machine-checked stability tier, profile, and safety-gate matrix.
 |------|---------|----------------|
 | `get_columns` | Inspect column names, types, metadata | `id_or_name` |
 | `get_sql` | Return raw or compiled SQL | `id_or_name`, `compiled` |
-| `diff_entities` | Compare two entities side-by-side | `entity1`, `entity2`, `entity1_resource_type`, `entity2_resource_type`, `compare_fields` |
+| `diff_entities` | Compare two entities side-by-side | `entity1`, `entity2`, `entity1_resource_type`, `entity2_resource_type`, `compare_fields` (`columns` default; `all` for built-in modelling sections) |
 
 ## Analysis
 

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -717,13 +717,21 @@ Required:
 - `entity2`
 
 Optional:
-- `compare_fields`
+- `compare_fields` (default: `["columns"]`; built-ins: `columns`, `tags`,
+  `grain`, `indicators`, `governance`, `tests`, or `all`)
 - `entity1_resource_type` (disambiguates `entity1` when passed as a name)
 - `entity2_resource_type` (disambiguates `entity2` when passed as a name)
 
 ```json
 {"name":"diff_entities","arguments":{"entity1":"model.pkg.orders_v1","entity2":"model.pkg.orders_v2","compare_fields":["columns","sql","config"]}}
 ```
+
+Use `grain`, `indicators`, `governance`, and `tests` when comparing candidate
+model consolidations. These sections are manifest-native and additive: they
+report shared grain dimensions/primary keys, shared or conflicting
+measures/metrics, identical-expression near duplicates, owner/governance drift,
+and schema-test count or shared-column coverage differences. Omit
+`compare_fields` to keep the legacy columns-only response.
 
 ## Analysis
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -487,7 +487,7 @@ pub struct DiffEntitiesParams {
     /// Optional resource_type to disambiguate entity2 when using name
     #[serde(default)]
     pub entity2_resource_type: Option<String>,
-    /// Fields to compare (default: columns)
+    /// Fields to compare (default: columns). Built-ins: columns, tags, grain, indicators, governance, tests, all.
     #[serde(default)]
     pub compare_fields: Vec<String>,
 }

--- a/src/tests/diff.rs
+++ b/src/tests/diff.rs
@@ -78,3 +78,104 @@ async fn test_diff_entities_ambiguous_name_returns_error() {
         other => panic!("expected AmbiguousName error, got: {other:?}"),
     }
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_diff_entities_default_remains_columns_only() {
+    let searcher = get_searcher_with_fixture("diff_sections.json");
+    let params = DiffEntitiesParams {
+        entity1: "model.pkg.sales_monthly_store".to_string(),
+        entity1_resource_type: None,
+        entity2: "model.pkg.store_productivity_monthly".to_string(),
+        entity2_resource_type: None,
+        compare_fields: vec![],
+    };
+    let result = searcher.diff_entities(&params).await.json();
+
+    assert_eq!(result["success"].as_bool(), Some(true), "{result:#?}");
+    let differences = result["data"]["differences"]
+        .as_object()
+        .expect("differences object");
+    assert_eq!(
+        differences.keys().collect::<Vec<_>>(),
+        vec!["columns"],
+        "empty compare_fields must preserve the columns-only default"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_diff_entities_all_reports_manifest_native_modelling_sections() {
+    let searcher = get_searcher_with_fixture("diff_sections.json");
+    let params = DiffEntitiesParams {
+        entity1: "model.pkg.sales_monthly_store".to_string(),
+        entity1_resource_type: None,
+        entity2: "model.pkg.store_productivity_monthly".to_string(),
+        entity2_resource_type: None,
+        compare_fields: vec!["all".to_string()],
+    };
+    let result = searcher.diff_entities(&params).await.json();
+
+    assert_eq!(result["success"].as_bool(), Some(true), "{result:#?}");
+    let data = &result["data"];
+    let differences = &data["differences"];
+
+    assert_eq!(
+        differences["grain"]["same_time_field"].as_bool(),
+        Some(true)
+    );
+    assert_eq!(
+        differences["grain"]["shared"].as_array(),
+        Some(&vec![JsonValue::String("store_id".to_string())])
+    );
+    assert_eq!(
+        data["summary"]["grain"]["shared_primary_key"].as_u64(),
+        Some(2)
+    );
+
+    let indicators = &differences["indicators"];
+    assert_eq!(indicators["counts"]["canonical_in_both"].as_u64(), Some(3));
+    assert!(
+        indicators["in_both"].as_array().is_some_and(|values| values
+            .contains(&JsonValue::String("gross_sales".to_string()))
+            && values.contains(&JsonValue::String("orders_count".to_string()))
+            && values.contains(&JsonValue::String("customers_count".to_string()))),
+        "shared canonical indicators missing: {indicators:#?}"
+    );
+    assert!(
+        indicators["near_duplicates"]
+            .as_array()
+            .is_some_and(|rows| rows.iter().any(|row| {
+                row["name1"] == "avg_order_value"
+                    && row["name2"] == "revenue_per_order"
+                    && row["reason"] == "identical_expression"
+            })),
+        "identical-expression near duplicate missing: {indicators:#?}"
+    );
+
+    assert_eq!(
+        differences["governance"]["sensitivity"]["equal"].as_bool(),
+        Some(false)
+    );
+    assert_eq!(
+        differences["governance"]["compliance"]["only_in_second"].as_array(),
+        Some(&vec![JsonValue::String("internal".to_string())])
+    );
+    assert_eq!(
+        data["summary"]["governance"]["changed_fields"].as_u64(),
+        Some(3)
+    );
+
+    let tests = &differences["tests"];
+    assert_eq!(tests["entity1_total"].as_u64(), Some(2));
+    assert_eq!(tests["entity2_total"].as_u64(), Some(2));
+    assert!(
+        tests["shared_column_differences"]
+            .as_array()
+            .is_some_and(|rows| rows.iter().any(|row| {
+                row["column"] == "month_start"
+                    && row["only_in_second"].as_array().is_some_and(|types| {
+                        types.contains(&JsonValue::String("not_null".to_string()))
+                    })
+            })),
+        "shared-column test differences missing: {tests:#?}"
+    );
+}

--- a/src/tools/diff.rs
+++ b/src/tools/diff.rs
@@ -1,12 +1,31 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde_json::Value as JsonValue;
 
 use crate::error::Result;
+use crate::manifest::entity::{Entity, NovaMeta, normalized_entity_meta_json};
 use crate::manifest::search::ManifestSearch;
 use crate::params::DiffEntitiesParams;
 use crate::responses::SuccessResponse;
+use crate::tools::helpers::test_type_from_json;
 use tracing::instrument;
+
+const DIFF_ALL_FIELDS: &[&str] = &[
+    "columns",
+    "tags",
+    "grain",
+    "indicators",
+    "governance",
+    "tests",
+];
+
+#[derive(Clone)]
+struct IndicatorSnapshot {
+    name: String,
+    indicator_type: &'static str,
+    expression: Option<String>,
+    canonical: bool,
+}
 
 impl ManifestSearch {
     /// Diff two entities across selected fields.
@@ -34,72 +53,66 @@ impl ManifestSearch {
         let mut diffs = serde_json::Map::new();
 
         let mut summary = serde_json::Map::new();
-        let compare_fields = if params.compare_fields.is_empty() {
-            vec!["columns".to_string()]
-        } else {
-            params.compare_fields.clone()
-        };
+        let compare_fields = expanded_compare_fields(&params.compare_fields);
         for field in &compare_fields {
             match field.as_str() {
                 "columns" => {
-                    let cols1: HashSet<String> = entity1.column_names().into_iter().collect();
-                    let cols2: HashSet<String> = entity2.column_names().into_iter().collect();
-                    let only_in_first: Vec<_> = cols1.difference(&cols2).collect();
-                    let only_in_second: Vec<_> = cols2.difference(&cols1).collect();
-                    let in_both: Vec<_> = cols1.intersection(&cols2).collect();
-                    let counts = (only_in_first.len(), only_in_second.len(), in_both.len());
+                    let cols1 = string_set(entity1.column_names());
+                    let cols2 = string_set(entity2.column_names());
+                    let (diff, counts) = set_diff_json(&cols1, &cols2);
 
-                    diffs.insert(
-                        "columns".to_string(),
-                        serde_json::json!({
-                            "only_in_first": only_in_first,
-                            "only_in_second": only_in_second,
-                            "in_both": in_both,
-                            "counts": {
-                                "only_in_first": counts.0,
-                                "only_in_second": counts.1,
-                                "in_both": counts.2
-                            }
-                        }),
-                    );
+                    diffs.insert("columns".to_string(), diff);
                     summary.insert(
                         "columns".to_string(),
                         serde_json::json!({
-                            "only_in_first": counts.0,
-                            "only_in_second": counts.1,
-                            "in_both": counts.2
+                            "only_in_first": counts.only_in_first,
+                            "only_in_second": counts.only_in_second,
+                            "in_both": counts.in_both
                         }),
                     );
                 }
                 "tags" => {
-                    let tags1: HashSet<String> = entity1.tags.iter().cloned().collect();
-                    let tags2: HashSet<String> = entity2.tags.iter().cloned().collect();
-                    let only_in_first: Vec<_> = tags1.difference(&tags2).collect();
-                    let only_in_second: Vec<_> = tags2.difference(&tags1).collect();
-                    let in_both: Vec<_> = tags1.intersection(&tags2).collect();
-                    let counts = (only_in_first.len(), only_in_second.len(), in_both.len());
+                    let tags1 = string_set(entity1.tags.iter().cloned());
+                    let tags2 = string_set(entity2.tags.iter().cloned());
+                    let (diff, counts) = set_diff_json(&tags1, &tags2);
 
-                    diffs.insert(
-                        "tags".to_string(),
-                        serde_json::json!({
-                            "only_in_first": only_in_first,
-                            "only_in_second": only_in_second,
-                            "in_both": in_both,
-                            "counts": {
-                                "only_in_first": counts.0,
-                                "only_in_second": counts.1,
-                                "in_both": counts.2
-                            }
-                        }),
-                    );
+                    diffs.insert("tags".to_string(), diff);
                     summary.insert(
                         "tags".to_string(),
                         serde_json::json!({
-                            "only_in_first": counts.0,
-                            "only_in_second": counts.1,
-                            "in_both": counts.2
+                            "only_in_first": counts.only_in_first,
+                            "only_in_second": counts.only_in_second,
+                            "in_both": counts.in_both
                         }),
                     );
+                }
+                "grain" => {
+                    let (diff, summary_value) =
+                        diff_grain(entity1.nova_meta.as_ref(), entity2.nova_meta.as_ref());
+                    diffs.insert("grain".to_string(), diff);
+                    summary.insert("grain".to_string(), summary_value);
+                }
+                "indicators" => {
+                    let (diff, summary_value) =
+                        diff_indicators(entity1.nova_meta.as_ref(), entity2.nova_meta.as_ref());
+                    diffs.insert("indicators".to_string(), diff);
+                    summary.insert("indicators".to_string(), summary_value);
+                }
+                "governance" => {
+                    let (diff, summary_value) = diff_governance(
+                        entity1.nova_meta.as_ref(),
+                        entity2.nova_meta.as_ref(),
+                        &entity1_json,
+                        &entity2_json,
+                    );
+                    diffs.insert("governance".to_string(), diff);
+                    summary.insert("governance".to_string(), summary_value);
+                }
+                "tests" => {
+                    let (diff, summary_value) =
+                        self.diff_tests(&key1, &key2, &entity1, &entity2)?;
+                    diffs.insert("tests".to_string(), diff);
+                    summary.insert("tests".to_string(), summary_value);
                 }
                 _ => {
                     let val1 = entity1_json.get(field);
@@ -126,4 +139,449 @@ impl ManifestSearch {
             1,
         ))?)
     }
+
+    fn diff_tests(
+        &self,
+        key1: &str,
+        key2: &str,
+        entity1: &Entity,
+        entity2: &Entity,
+    ) -> Result<(JsonValue, JsonValue)> {
+        let counts1 = self.test_counts_by_type(key1)?;
+        let counts2 = self.test_counts_by_type(key2)?;
+        let total1 = counts1.values().sum::<usize>();
+        let total2 = counts2.values().sum::<usize>();
+        let shared_columns = string_set(entity1.column_names())
+            .intersection(&string_set(entity2.column_names()))
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut shared_column_differences = Vec::new();
+
+        for column in shared_columns {
+            let tests1 = self.test_types_for_column(key1, &column)?;
+            let tests2 = self.test_types_for_column(key2, &column)?;
+            let only_in_first = sorted_difference(&tests1, &tests2);
+            let only_in_second = sorted_difference(&tests2, &tests1);
+            if !only_in_first.is_empty() || !only_in_second.is_empty() {
+                shared_column_differences.push(serde_json::json!({
+                    "column": column,
+                    "only_in_first": only_in_first,
+                    "only_in_second": only_in_second
+                }));
+            }
+        }
+
+        let diff = serde_json::json!({
+            "entity1_total": total1,
+            "entity2_total": total2,
+            "by_type": {
+                "entity1": counts1,
+                "entity2": counts2
+            },
+            "shared_column_differences": shared_column_differences
+        });
+        let summary = serde_json::json!({
+            "entity1_total": total1,
+            "entity2_total": total2,
+            "shared_column_differences": shared_column_differences.len()
+        });
+
+        Ok((diff, summary))
+    }
+
+    fn test_counts_by_type(&self, entity_id: &str) -> Result<BTreeMap<String, usize>> {
+        let mut counts = BTreeMap::new();
+        for test_id in self.tests_by_entity.get(entity_id).into_iter().flatten() {
+            if let Some(test) = self.get_entity_archived(test_id)? {
+                let test_json = test.to_json_value();
+                *counts
+                    .entry(test_type_from_json(&test_json).to_string())
+                    .or_default() += 1;
+            }
+        }
+        Ok(counts)
+    }
+
+    fn test_types_for_column(&self, entity_id: &str, column: &str) -> Result<BTreeSet<String>> {
+        let mut types = BTreeSet::new();
+        let key = format!("{entity_id}:{column}");
+        for test_id in self.tests_by_column.get(&key).into_iter().flatten() {
+            if let Some(test) = self.get_entity_archived(test_id)? {
+                let test_json = test.to_json_value();
+                types.insert(test_type_from_json(&test_json).to_string());
+            }
+        }
+        Ok(types)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SetDiffCounts {
+    only_in_first: usize,
+    only_in_second: usize,
+    in_both: usize,
+}
+
+fn expanded_compare_fields(fields: &[String]) -> Vec<String> {
+    if fields.is_empty() {
+        return vec!["columns".to_string()];
+    }
+
+    let mut expanded = Vec::new();
+    let mut seen = BTreeSet::new();
+    for field in fields {
+        if field == "all" {
+            for built_in in DIFF_ALL_FIELDS {
+                push_unique(&mut expanded, &mut seen, built_in);
+            }
+        } else {
+            push_unique(&mut expanded, &mut seen, field);
+        }
+    }
+    expanded
+}
+
+fn push_unique(expanded: &mut Vec<String>, seen: &mut BTreeSet<String>, field: &str) {
+    if seen.insert(field.to_string()) {
+        expanded.push(field.to_string());
+    }
+}
+
+fn string_set<I>(values: I) -> BTreeSet<String>
+where
+    I: IntoIterator<Item = String>,
+{
+    values.into_iter().collect()
+}
+
+fn sorted_difference(left: &BTreeSet<String>, right: &BTreeSet<String>) -> Vec<String> {
+    left.difference(right).cloned().collect()
+}
+
+fn sorted_intersection(left: &BTreeSet<String>, right: &BTreeSet<String>) -> Vec<String> {
+    left.intersection(right).cloned().collect()
+}
+
+fn set_diff_json(left: &BTreeSet<String>, right: &BTreeSet<String>) -> (JsonValue, SetDiffCounts) {
+    let only_in_first = sorted_difference(left, right);
+    let only_in_second = sorted_difference(right, left);
+    let in_both = sorted_intersection(left, right);
+    let counts = SetDiffCounts {
+        only_in_first: only_in_first.len(),
+        only_in_second: only_in_second.len(),
+        in_both: in_both.len(),
+    };
+
+    (
+        serde_json::json!({
+            "only_in_first": only_in_first,
+            "only_in_second": only_in_second,
+            "in_both": in_both,
+            "counts": {
+                "only_in_first": counts.only_in_first,
+                "only_in_second": counts.only_in_second,
+                "in_both": counts.in_both
+            }
+        }),
+        counts,
+    )
+}
+
+fn diff_grain(nova1: Option<&NovaMeta>, nova2: Option<&NovaMeta>) -> (JsonValue, JsonValue) {
+    let grain1 = nova1.and_then(|nova| nova.grain.as_ref());
+    let grain2 = nova2.and_then(|nova| nova.grain.as_ref());
+    let time1 = grain1.and_then(|grain| grain.time_field.as_deref());
+    let time2 = grain2.and_then(|grain| grain.time_field.as_deref());
+    let dimensions1 = string_set(
+        grain1
+            .map(|grain| grain.dimensions.clone())
+            .unwrap_or_default(),
+    );
+    let dimensions2 = string_set(
+        grain2
+            .map(|grain| grain.dimensions.clone())
+            .unwrap_or_default(),
+    );
+    let primary_key1 = string_set(
+        grain1
+            .map(|grain| grain.primary_key.clone())
+            .unwrap_or_default(),
+    );
+    let primary_key2 = string_set(
+        grain2
+            .map(|grain| grain.primary_key.clone())
+            .unwrap_or_default(),
+    );
+    let (dimensions_diff, dimensions_counts) = set_diff_json(&dimensions1, &dimensions2);
+    let (primary_key_diff, primary_key_counts) = set_diff_json(&primary_key1, &primary_key2);
+    let same_time_field = time1 == time2;
+
+    (
+        serde_json::json!({
+            "same_time_field": same_time_field,
+            "entity1_time_field": time1,
+            "entity2_time_field": time2,
+            "entity1_dimensions": sorted_strings(&dimensions1),
+            "entity2_dimensions": sorted_strings(&dimensions2),
+            "shared": sorted_intersection(&dimensions1, &dimensions2),
+            "only_in_first": sorted_difference(&dimensions1, &dimensions2),
+            "only_in_second": sorted_difference(&dimensions2, &dimensions1),
+            "dimensions": dimensions_diff,
+            "primary_key": primary_key_diff
+        }),
+        serde_json::json!({
+            "entity1_has_grain": grain1.is_some(),
+            "entity2_has_grain": grain2.is_some(),
+            "same_time_field": same_time_field,
+            "shared_dimensions": dimensions_counts.in_both,
+            "only_in_first_dimensions": dimensions_counts.only_in_first,
+            "only_in_second_dimensions": dimensions_counts.only_in_second,
+            "shared_primary_key": primary_key_counts.in_both,
+            "only_in_first_primary_key": primary_key_counts.only_in_first,
+            "only_in_second_primary_key": primary_key_counts.only_in_second
+        }),
+    )
+}
+
+fn sorted_strings(values: &BTreeSet<String>) -> Vec<String> {
+    values.iter().cloned().collect()
+}
+
+fn diff_indicators(nova1: Option<&NovaMeta>, nova2: Option<&NovaMeta>) -> (JsonValue, JsonValue) {
+    let left_map = collect_indicators(nova1);
+    let right_map = collect_indicators(nova2);
+    let names1 = left_map.keys().cloned().collect::<BTreeSet<_>>();
+    let names2 = right_map.keys().cloned().collect::<BTreeSet<_>>();
+    let in_both_keys = sorted_intersection(&names1, &names2);
+    let only_in_first = sorted_difference(&names1, &names2)
+        .into_iter()
+        .filter_map(|key| left_map.get(&key).map(|snapshot| snapshot.name.clone()))
+        .collect::<Vec<_>>();
+    let only_in_second = sorted_difference(&names2, &names1)
+        .into_iter()
+        .filter_map(|key| right_map.get(&key).map(|snapshot| snapshot.name.clone()))
+        .collect::<Vec<_>>();
+    let mut in_both = Vec::new();
+    let mut canonical_in_both = Vec::new();
+    let mut expression_conflicts = Vec::new();
+
+    for key in &in_both_keys {
+        let Some(left_snapshot) = left_map.get(key) else {
+            continue;
+        };
+        let Some(right_snapshot) = right_map.get(key) else {
+            continue;
+        };
+        in_both.push(left_snapshot.name.clone());
+        if left_snapshot.canonical && right_snapshot.canonical {
+            canonical_in_both.push(left_snapshot.name.clone());
+        }
+        if let (Some(expr1), Some(expr2)) = (&left_snapshot.expression, &right_snapshot.expression)
+            && normalize_indicator_expression(expr1) != normalize_indicator_expression(expr2)
+        {
+            expression_conflicts.push(serde_json::json!({
+                "name": left_snapshot.name,
+                "type1": left_snapshot.indicator_type,
+                "type2": right_snapshot.indicator_type,
+                "expr1": expr1,
+                "expr2": expr2
+            }));
+        }
+    }
+
+    let near_duplicates = identical_expression_near_duplicates(&left_map, &right_map);
+
+    (
+        serde_json::json!({
+            "in_both": in_both,
+            "only_in_first": only_in_first,
+            "only_in_second": only_in_second,
+            "canonical_in_both": canonical_in_both,
+            "expression_conflicts": expression_conflicts,
+            "near_duplicates": near_duplicates,
+            "counts": {
+                "in_both": in_both_keys.len(),
+                "only_in_first": only_in_first.len(),
+                "only_in_second": only_in_second.len(),
+                "canonical_in_both": canonical_in_both.len(),
+                "expression_conflicts": expression_conflicts.len(),
+                "near_duplicates": near_duplicates.len()
+            }
+        }),
+        serde_json::json!({
+            "in_both": in_both_keys.len(),
+            "only_in_first": only_in_first.len(),
+            "only_in_second": only_in_second.len(),
+            "canonical_in_both": canonical_in_both.len(),
+            "expression_conflicts": expression_conflicts.len(),
+            "near_duplicates": near_duplicates.len()
+        }),
+    )
+}
+
+fn collect_indicators(nova: Option<&NovaMeta>) -> BTreeMap<String, IndicatorSnapshot> {
+    let mut indicators = BTreeMap::new();
+    let Some(nova) = nova else {
+        return indicators;
+    };
+
+    for measure in &nova.measures {
+        indicators.insert(
+            normalize_indicator_name(&measure.name),
+            IndicatorSnapshot {
+                name: measure.name.clone(),
+                indicator_type: "measure",
+                expression: measure.expression.clone().or_else(|| measure.field.clone()),
+                canonical: measure.canonical,
+            },
+        );
+    }
+    if let Some(metric) = nova.metric.as_ref() {
+        indicators.insert(
+            normalize_indicator_name(&metric.name),
+            IndicatorSnapshot {
+                name: metric.name.clone(),
+                indicator_type: "metric",
+                expression: metric.expression.clone(),
+                canonical: metric.canonical,
+            },
+        );
+    }
+    for metric in &nova.metrics {
+        indicators.insert(
+            normalize_indicator_name(&metric.name),
+            IndicatorSnapshot {
+                name: metric.name.clone(),
+                indicator_type: "metric",
+                expression: metric.expression.clone(),
+                canonical: metric.canonical,
+            },
+        );
+    }
+
+    indicators
+}
+
+fn identical_expression_near_duplicates(
+    indicators1: &BTreeMap<String, IndicatorSnapshot>,
+    indicators2: &BTreeMap<String, IndicatorSnapshot>,
+) -> Vec<JsonValue> {
+    let mut rows = Vec::new();
+    let mut seen = BTreeSet::new();
+    for (key1, indicator1) in indicators1 {
+        let Some(expr1) = indicator1.expression.as_ref() else {
+            continue;
+        };
+        let normalized1 = normalize_indicator_expression(expr1);
+        if normalized1.is_empty() {
+            continue;
+        }
+        for (key2, indicator2) in indicators2 {
+            if key1 == key2 {
+                continue;
+            }
+            let Some(expr2) = indicator2.expression.as_ref() else {
+                continue;
+            };
+            if normalized1 != normalize_indicator_expression(expr2) {
+                continue;
+            }
+            let pair_key = format!("{key1}\u{0}{key2}");
+            if !seen.insert(pair_key) {
+                continue;
+            }
+            rows.push(serde_json::json!({
+                "name1": indicator1.name,
+                "name2": indicator2.name,
+                "type1": indicator1.indicator_type,
+                "type2": indicator2.indicator_type,
+                "reason": "identical_expression",
+                "expression": expr1
+            }));
+        }
+    }
+    rows
+}
+
+fn normalize_indicator_name(name: &str) -> String {
+    name.trim().to_ascii_lowercase()
+}
+
+fn normalize_indicator_expression(expression: &str) -> String {
+    expression
+        .chars()
+        .filter(|ch| !ch.is_whitespace() && !matches!(ch, '`' | '"' | '\''))
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn diff_governance(
+    nova1: Option<&NovaMeta>,
+    nova2: Option<&NovaMeta>,
+    entity1_json: &JsonValue,
+    entity2_json: &JsonValue,
+) -> (JsonValue, JsonValue) {
+    let sensitivity1 = nova1
+        .and_then(|nova| nova.governance.as_ref())
+        .and_then(|governance| governance.sensitivity.as_deref());
+    let sensitivity2 = nova2
+        .and_then(|nova| nova.governance.as_ref())
+        .and_then(|governance| governance.sensitivity.as_deref());
+    let pii1 = nova1
+        .and_then(|nova| nova.governance.as_ref())
+        .and_then(|governance| governance.pii.as_deref());
+    let pii2 = nova2
+        .and_then(|nova| nova.governance.as_ref())
+        .and_then(|governance| governance.pii.as_deref());
+    let compliance1 = string_set(
+        nova1
+            .and_then(|nova| nova.governance.as_ref())
+            .map(|governance| governance.compliance.clone())
+            .unwrap_or_default(),
+    );
+    let compliance2 = string_set(
+        nova2
+            .and_then(|nova| nova.governance.as_ref())
+            .map(|governance| governance.compliance.clone())
+            .unwrap_or_default(),
+    );
+    let owner1 =
+        normalized_entity_meta_json(entity1_json).and_then(|meta| meta.get("owner").cloned());
+    let owner2 =
+        normalized_entity_meta_json(entity2_json).and_then(|meta| meta.get("owner").cloned());
+    let (compliance_diff, compliance_counts) = set_diff_json(&compliance1, &compliance2);
+    let changed_fields = usize::from(sensitivity1 != sensitivity2)
+        + usize::from(pii1 != pii2)
+        + usize::from(owner1 != owner2)
+        + usize::from(compliance_counts.only_in_first > 0 || compliance_counts.only_in_second > 0);
+
+    (
+        serde_json::json!({
+            "sensitivity": {
+                "first": sensitivity1,
+                "second": sensitivity2,
+                "equal": sensitivity1 == sensitivity2
+            },
+            "pii": {
+                "first": pii1,
+                "second": pii2,
+                "equal": pii1 == pii2
+            },
+            "owner": {
+                "first": owner1,
+                "second": owner2,
+                "equal": owner1 == owner2
+            },
+            "compliance": compliance_diff
+        }),
+        serde_json::json!({
+            "changed_fields": changed_fields,
+            "same_sensitivity": sensitivity1 == sensitivity2,
+            "same_pii": pii1 == pii2,
+            "same_owner": owner1 == owner2,
+            "shared_compliance": compliance_counts.in_both,
+            "only_in_first_compliance": compliance_counts.only_in_first,
+            "only_in_second_compliance": compliance_counts.only_in_second
+        }),
+    )
 }

--- a/tests/fixtures/diff_sections.json
+++ b/tests/fixtures/diff_sections.json
@@ -1,0 +1,126 @@
+{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    "dbt_version": "1.10.0",
+    "project_name": "diff_sections"
+  },
+  "nodes": {
+    "model.pkg.sales_monthly_store": {
+      "name": "sales_monthly_store",
+      "resource_type": "model",
+      "package_name": "pkg",
+      "relation_name": "analytics.pkg.sales_monthly_store",
+      "columns": {
+        "store_id": {"name": "store_id", "data_type": "string"},
+        "month_start": {"name": "month_start", "data_type": "date"},
+        "gross_sales": {"name": "gross_sales", "data_type": "numeric"},
+        "orders_count": {"name": "orders_count", "data_type": "integer"},
+        "customers_count": {"name": "customers_count", "data_type": "integer"},
+        "avg_order_value": {"name": "avg_order_value", "data_type": "numeric"},
+        "region": {"name": "region", "data_type": "string"}
+      },
+      "meta": {
+        "owner": "finance_analytics",
+        "nova": {
+          "grain": {
+            "primary_key": ["store_id", "month_start"],
+            "time_field": "month_start",
+            "dimensions": ["store_id"]
+          },
+          "measures": [
+            {"name": "gross_sales", "expression": "sum(gross_sales)", "canonical": true},
+            {"name": "orders_count", "expression": "count(order_id)", "canonical": true},
+            {"name": "customers_count", "expression": "count(distinct customer_id)", "canonical": true},
+            {"name": "avg_order_value", "expression": "gross_sales / orders_count"}
+          ],
+          "governance": {
+            "sensitivity": "low",
+            "pii": "none",
+            "compliance": ["sox"]
+          }
+        }
+      },
+      "depends_on": {"nodes": [], "macros": []}
+    },
+    "model.pkg.store_productivity_monthly": {
+      "name": "store_productivity_monthly",
+      "resource_type": "model",
+      "package_name": "pkg",
+      "relation_name": "analytics.pkg.store_productivity_monthly",
+      "columns": {
+        "store_id": {"name": "store_id", "data_type": "string"},
+        "month_start": {"name": "month_start", "data_type": "date"},
+        "gross_sales": {"name": "gross_sales", "data_type": "numeric"},
+        "orders_count": {"name": "orders_count", "data_type": "integer"},
+        "customers_count": {"name": "customers_count", "data_type": "integer"},
+        "revenue_per_order": {"name": "revenue_per_order", "data_type": "numeric"},
+        "labor_hours": {"name": "labor_hours", "data_type": "numeric"}
+      },
+      "meta": {
+        "owner": "ops_analytics",
+        "nova": {
+          "grain": {
+            "primary_key": ["store_id", "month_start"],
+            "time_field": "month_start",
+            "dimensions": ["store_id"]
+          },
+          "measures": [
+            {"name": "gross_sales", "expression": "sum(gross_sales)", "canonical": true},
+            {"name": "orders_count", "expression": "count(order_id)", "canonical": true},
+            {"name": "customers_count", "expression": "count(distinct customer_id)", "canonical": true},
+            {"name": "revenue_per_order", "expression": "gross_sales/orders_count"}
+          ],
+          "governance": {
+            "sensitivity": "medium",
+            "pii": "none",
+            "compliance": ["sox", "internal"]
+          }
+        }
+      },
+      "depends_on": {"nodes": [], "macros": []}
+    },
+    "test.pkg.not_null_sales_store_id": {
+      "name": "not_null_sales_store_id",
+      "resource_type": "test",
+      "package_name": "pkg",
+      "attached_node": "model.pkg.sales_monthly_store",
+      "column_name": "store_id",
+      "test_metadata": {"name": "not_null"}
+    },
+    "test.pkg.unique_sales_store_id": {
+      "name": "unique_sales_store_id",
+      "resource_type": "test",
+      "package_name": "pkg",
+      "attached_node": "model.pkg.sales_monthly_store",
+      "column_name": "store_id",
+      "test_metadata": {"name": "unique"}
+    },
+    "test.pkg.not_null_productivity_store_id": {
+      "name": "not_null_productivity_store_id",
+      "resource_type": "test",
+      "package_name": "pkg",
+      "attached_node": "model.pkg.store_productivity_monthly",
+      "column_name": "store_id",
+      "test_metadata": {"name": "not_null"}
+    },
+    "test.pkg.not_null_productivity_month_start": {
+      "name": "not_null_productivity_month_start",
+      "resource_type": "test",
+      "package_name": "pkg",
+      "attached_node": "model.pkg.store_productivity_monthly",
+      "column_name": "month_start",
+      "test_metadata": {"name": "not_null"}
+    }
+  },
+  "sources": {},
+  "macros": {},
+  "docs": {},
+  "groups": {},
+  "exposures": {},
+  "metrics": {},
+  "saved_queries": {},
+  "semantic_models": {},
+  "unit_tests": {},
+  "parent_map": {},
+  "child_map": {}
+}


### PR DESCRIPTION
## Summary

Part of #298. This ships the conservative `diff_entities` slice: richer comparison sections for manifest-native modelling evidence without changing the columns-only default.

- keeps omitted `compare_fields` as the existing columns-only response
- adds built-in `compare_fields` values: `grain`, `indicators`, `governance`, `tests`, and `all`
- reports shared grain dimensions/primary keys/time fields, shared canonical indicators, expression conflicts, identical-expression near duplicates, governance/owner drift, and schema-test deltas on shared columns
- adds a focused synthetic fixture covering model-consolidation evidence from the field-test pattern
- updates API docs, quick reference, params schema docs, and changelog

## Validation

- `cargo fmt --check`
- `cargo test --locked diff_entities --lib`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --quiet`
- `uv run mkdocs build --strict` (passes; upstream Material/MkDocs 2.0 warning only)
- `bash scripts/check_module_size.sh`
- `git diff --check`

## Notes

Canonical/project-scope validation and catalog-backed grain type checks from #298 are intentionally left for separate PRs. They touch validation/readiness contracts rather than this opt-in comparison tool surface.
