### PR TITLE
Harden Nova metadata contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added opt-in `diff_entities` sections for manifest-native modelling
   comparison: `grain`, `indicators`, `governance`, `tests`, and `all`, while
   preserving the columns-only default.
+- Added project-scope `validate_nova_meta` warnings for duplicate global
+  canonical indicators, plus `canonical_scope: grain` for intentional
+  grain-scoped canonical measure/metric definitions.
+- Added typed MCP aliases for metadata-audit and agent-readiness JSON inputs
+  while keeping the existing `*_json` fields compatible.
 - Hardened agent-facing defaults: `get_context` now counts lineage test nodes
   without letting them consume upstream/downstream entity slots by default,
   `modelling_consistency_report` applies a bounded default overlap threshold

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -47,8 +47,8 @@ machine-checked stability tier, profile, and safety-gate matrix.
 |------|---------|----------------|
 | `get_test_coverage` | Schema/data test coverage | `id_or_name`, `resource_type`, `include_full`, `columns_limit` |
 | `get_metadata_score` | Metadata quality score | `id_or_name`, `persona`, `scope` |
-| `get_metadata_audit` | Metadata audit report and gate | `selection_mode`, `changed_files`/`changed_files_json`, `entity_ids`/`entity_ids_json`, `personas`/`personas_json`, `thresholds_json` |
-| `get_agent_readiness` | Agent-readiness report | `personas_json`, `thresholds_json`, `eval_gate_json` |
+| `get_metadata_audit` | Metadata audit report and gate | `selection_mode`, `changed_files`/`changed_files_json`, `entity_ids`/`entity_ids_json`, `personas`/`personas_json`, `thresholds`/`thresholds_json` |
+| `get_agent_readiness` | Agent-readiness report | `personas`/`personas_json`, `thresholds`/`thresholds_json`, `eval_gate`/`eval_gate_json` |
 | `get_undocumented` | Find entities missing descriptions | `resource_type`, `include_columns`, `package`, `path_prefix` |
 | `search_recipes` | Find analysis recipe templates + parameter contracts | `topic`, `query`, `include_queries`, `limit`, `offset` |
 | `get_recipe` | Load a recipe, SQL, and parameter requirements | `recipe_id`, `include_sql`, `include_queries`, `parameters`, `placeholder_types` |

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -894,6 +894,7 @@ Optional:
 - `personas_json`: JSON array, defaulting to `["engineer"]`
 - `personas`: typed array alias for `personas_json`
 - `thresholds_json`: JSON required/advisory threshold configuration
+- `thresholds`: typed object alias for `thresholds_json`
 - `include_breakdown`, `include_recommendations`
 - `fail_on_no_targets`
 
@@ -904,11 +905,12 @@ category weak spots, repeated recommendation fields with estimated impact, and
 drill-down hints.
 
 ```json
-{"name":"get_metadata_audit","arguments":{"selection_mode":"changed","changed_files_json":"[\"models/marts/orders.sql\"]"}}
+{"name":"get_metadata_audit","arguments":{"selection_mode":"changed","changed_files":["models/marts/orders.sql"],"resource_types":["model"]}}
 ```
 
-Unknown top-level tool parameters are rejected instead of ignored. Use either a
-typed array alias or its `*_json` form for the same setting, not both.
+Unknown top-level tool parameters are rejected instead of ignored. Prefer typed
+aliases for MCP calls. The older `*_json` string fields remain accepted; if both
+forms are supplied for one setting, they must represent the same value.
 
 See `docs/features/metadata-audit.md` for report fields and threshold examples.
 
@@ -918,8 +920,11 @@ Manifest-level readiness report for agent workflows.
 Optional:
 - `personas_json`: JSON array of personas, defaulting to
   `["engineer","analyst","governance"]`
+- `personas`: typed array alias for `personas_json`
 - `thresholds_json`: JSON readiness threshold configuration
+- `thresholds`: typed object alias for `thresholds_json`
 - `eval_gate_json`: raw `eval gate` report JSON or the full CLI JSON envelope
+- `eval_gate`: typed object alias for `eval_gate_json`
 
 The tool returns the same `agent_readiness.v1` report contract as
 `dbt-nova audit agent-readiness --json`, without writing report files or applying
@@ -942,7 +947,7 @@ Large reports use the standard MCP response-budget behavior; check
 `_nova_result_meta.truncated` when response budgeting is enabled.
 
 ```json
-{"name":"get_agent_readiness","arguments":{"personas_json":"[\"engineer\",\"analyst\"]"}}
+{"name":"get_agent_readiness","arguments":{"personas":["engineer","analyst"]}}
 ```
 
 See `docs/features/agent-readiness.md` for report fields and threshold examples.

--- a/docs/features/agent-readiness.md
+++ b/docs/features/agent-readiness.md
@@ -9,9 +9,10 @@ Use it before enabling a manifest for production agent analysis, launch reviews,
 or recurring CI evidence.
 
 MCP clients can request the same JSON report with `get_agent_readiness`.
-The MCP tool accepts inline `personas_json`, `thresholds_json`, and
-`eval_gate_json`, and returns the report without writing files or applying CLI
-exit semantics.
+The MCP tool accepts typed `personas`, `thresholds`, and `eval_gate` fields, or
+the compatible `personas_json`, `thresholds_json`, and `eval_gate_json` string
+fields. It returns the report without writing files or applying CLI exit
+semantics.
 
 ## Local Command
 
@@ -394,11 +395,12 @@ cases should be anchored manually with explicit dates before becoming CI gates.
 ## MCP Tool
 
 ```json
-{"name":"get_agent_readiness","arguments":{"personas_json":"[\"engineer\",\"analyst\"]"}}
+{"name":"get_agent_readiness","arguments":{"personas":["engineer","analyst"]}}
 ```
 
 To include eval gate evidence, pass either the raw gate report or the full
-`eval gate --json` CLI envelope as `eval_gate_json`.
+`eval gate --json` CLI envelope as `eval_gate`. The older `eval_gate_json`
+string field remains accepted for clients that cannot send nested JSON objects.
 
 See also:
 

--- a/docs/features/metadata-audit.md
+++ b/docs/features/metadata-audit.md
@@ -45,13 +45,15 @@ dbt-nova audit metadata-score \
 ## MCP Tool
 
 ```json
-{"name":"get_metadata_audit","arguments":{"selection_mode":"changed","changed_files_json":"[\"models/marts/orders.sql\"]","resource_types_json":"[\"model\"]"}}
+{"name":"get_metadata_audit","arguments":{"selection_mode":"changed","changed_files":["models/marts/orders.sql"],"resource_types":["model"]}}
 ```
 
 The MCP tool returns the same JSON report contract as the CLI audit command,
 but does not write JSON/Markdown files and does not convert required threshold
 failures into transport errors. Check `data.gate_status` and `data.summary` for
-gate results.
+gate results. Prefer typed MCP fields such as `changed_files`, `resource_types`,
+`personas`, and `thresholds`; compatible `*_json` string fields remain accepted
+for clients that cannot send nested JSON values.
 
 ## Threshold Contract
 

--- a/docs/features/nova-meta-metrics.md
+++ b/docs/features/nova-meta-metrics.md
@@ -194,6 +194,8 @@ models:
 
 - `name`: Canonical metric name.
 - `canonical`: Mark the preferred definition when the same KPI exists on multiple models.
+- `canonical_scope`: Optional `grain` escape hatch when the metric is
+  intentionally canonical only at its declared grain.
 - `template`: Set `true` to signal this model is a reusable template (analysts adapt time/filters).
 - `description`: Business definition.
 - `expression`: Plain‑text formula (not parsed).

--- a/docs/features/nova-meta-models.md
+++ b/docs/features/nova-meta-models.md
@@ -73,7 +73,9 @@ to additional domains.
 - `grain`: both `primary_key` and `time_field` are populated.
 - `measures`: each measure uses `name`, `expression`, `description`, `type`, `field`,
   `synonyms`, and can optionally set `canonical: true` when the same business
-  term exists on multiple models.
+  term exists on multiple models. Use `canonical_scope: grain` only when a
+  measure is intentionally canonical for that model grain instead of globally
+  canonical for the measure name.
 - `governance`: `sensitivity` is `low` or `medium`; `pii` is `none` or `possible`;
   `compliance` includes `gdpr`.
 
@@ -138,6 +140,11 @@ Measures are **model‑bound**: they belong to the model where the underlying da
 
 Use `canonical: true` on a measure when the same business term exists on multiple
 models but one definition should surface first in analyst search.
+
+If the same measure name is intentionally canonical at multiple grains, add
+`canonical_scope: grain` on those measure entries. This keeps project validation
+from treating the definitions as competing global canonicals while preserving the
+metadata-bridge signal that each parent owns the measure at its declared grain.
 
 ### How to Detect Measures in a Model
 

--- a/docs/features/nova-meta-overview.md
+++ b/docs/features/nova-meta-overview.md
@@ -94,14 +94,14 @@ columns:
 | `search.candidates` | object | Persona-specific ranking hints (`analyst`, `engineer`, `governance`) |
 
 `measures[]` fields:
-- `name` (required), `type` (required), `expression`, `description`, `field`, `synonyms`, `canonical`
+- `name` (required), `type` (required), `expression`, `description`, `field`, `synonyms`, `canonical`, `canonical_scope`
 
 ### Metric fields (metric models)
 
 Use **either** `metric` (single KPI) or `metrics` (array).
 
 `metric`/`metrics[]` fields:
-- `name` (required), `description`, `expression`, `synonyms`, `template`, `canonical`
+- `name` (required), `description`, `expression`, `synonyms`, `template`, `canonical`, `canonical_scope`
 - `grain`: `time_field`, `dimensions`, and optional `primary_key`
 - `recommended_filters`: `field`, `operator`, `values`, `label`
 
@@ -180,7 +180,8 @@ The validator enforces both:
 
 - schema conformance against `schemas/nova/v0.json`
 - local semantic checks such as field existence, duplicate semantic names,
-  grain overlap, and invalid `recommended_filters` value combinations
+  grain overlap, invalid `recommended_filters` value combinations, and
+  duplicate canonical indicator declarations across the scanned project
 
 Project-wide scans skip common generated and vendor directories by default,
 including `.git`, `.venv`, `venv`, `target`, `dbt_packages`, and
@@ -197,6 +198,9 @@ behind the same authentication posture used for the rest of the MCP surface.
 
 - Keep meta **small and stable** (avoid high‑churn data).
 - Use **canonical** for exactly one model per concept.
+- Use `canonical_scope: grain` only when a measure or metric is intentionally
+  canonical for its own grain rather than globally canonical for the indicator
+  name.
 - Prefer 2–8 high‑signal synonyms over exhaustive lists.
 - Use `grain.dimensions` only for **default** breakdowns.
 

--- a/schemas/nova/v0.json
+++ b/schemas/nova/v0.json
@@ -45,7 +45,8 @@
         "description": { "type": "string" },
         "field": { "type": "string" },
         "synonyms": { "type": "array", "items": { "type": "string" } },
-        "canonical": { "type": "boolean" }
+        "canonical": { "type": "boolean" },
+        "canonical_scope": { "enum": ["grain"] }
       },
       "required": ["name", "type"]
     },
@@ -58,6 +59,7 @@
         "synonyms": { "type": "array", "items": { "type": "string" } },
         "template": { "type": "boolean" },
         "canonical": { "type": "boolean" },
+        "canonical_scope": { "enum": ["grain"] },
         "grain": { "$ref": "#/$defs/NovaGrain" },
         "recommended_filters": {
           "type": "array",

--- a/src/cli/agent_readiness_cmd.rs
+++ b/src/cli/agent_readiness_cmd.rs
@@ -23,6 +23,7 @@ use crate::responses::SuccessResponse;
 use crate::tools::metadata_score::{grade_from_score, metadata_score_scoring_contract};
 use crate::utils::{SearchPersona, sanitize_uri};
 
+use super::tool_param_aliases::{typed_array_or_json, typed_json_or_json};
 use super::{DispatchError, DispatchResult};
 
 const DEFAULT_PERSONAS_JSON: &str = r#"["engineer","analyst","governance"]"#;
@@ -246,12 +247,31 @@ fn parse_readiness_inputs(args: &AgentReadinessArgs) -> Result<ReadinessInputs> 
 }
 
 fn parse_readiness_tool_inputs(params: &GetAgentReadinessParams) -> Result<ReadinessInputs> {
-    parse_readiness_inputs_from_sources(
+    let personas_json = typed_array_or_json(
+        "personas",
+        &params.personas,
+        "personas_json",
         params.personas_json.as_deref(),
-        None,
+    )?;
+    let thresholds_json = typed_json_or_json(
+        "thresholds",
+        params.thresholds.as_ref(),
+        "thresholds_json",
         params.thresholds_json.as_deref(),
-        None,
+    )?;
+    let eval_gate_json = typed_json_or_json(
+        "eval_gate",
+        params.eval_gate.as_ref(),
+        "eval_gate_json",
         params.eval_gate_json.as_deref(),
+    )?;
+
+    parse_readiness_inputs_from_sources(
+        personas_json.as_deref(),
+        None,
+        thresholds_json.as_deref(),
+        None,
+        eval_gate_json.as_deref(),
         None,
     )
 }

--- a/src/cli/agent_readiness_cmd/tests.rs
+++ b/src/cli/agent_readiness_cmd/tests.rs
@@ -440,6 +440,57 @@ fn parse_readiness_inputs_preserves_persona_order() {
 }
 
 #[test]
+fn parse_readiness_tool_inputs_accepts_typed_aliases() {
+    let inputs = super::parse_readiness_tool_inputs(&GetAgentReadinessParams {
+        personas: vec!["engineer".to_string(), "analyst".to_string()],
+        thresholds: Some(json!({
+            "modelling": {
+                "max_high": {"value": 2, "severity": "advisory"}
+            }
+        })),
+        eval_gate: Some(json!({
+            "allowed": true,
+            "blocked": false,
+            "message": "gate passed"
+        })),
+        ..GetAgentReadinessParams::default()
+    })
+    .expect("typed params");
+
+    assert_eq!(
+        inputs.personas,
+        vec!["engineer".to_string(), "analyst".to_string()]
+    );
+    assert_eq!(
+        inputs
+            .thresholds
+            .modelling
+            .max_high
+            .expect("max high")
+            .value,
+        2
+    );
+    assert_eq!(inputs.eval_status.status, "allowed");
+}
+
+#[test]
+fn parse_readiness_tool_inputs_rejects_conflicting_aliases() {
+    let error = super::parse_readiness_tool_inputs(&GetAgentReadinessParams {
+        personas_json: Some(r#"["engineer"]"#.to_string()),
+        personas: vec!["analyst".to_string()],
+        ..GetAgentReadinessParams::default()
+    })
+    .expect_err("conflicting aliases should fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("personas and personas_json differ"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
 fn evaluate_threshold_supports_required_and_advisory() {
     let required = ThresholdRule {
         min_score: Some(80),

--- a/src/cli/audit_cmd/tool_params.rs
+++ b/src/cli/audit_cmd/tool_params.rs
@@ -1,5 +1,6 @@
 use crate::cli::args::{MetadataAuditArgs, MetadataAuditSelectionModeArg};
-use crate::error::{DbtNovaError, Result};
+use crate::cli::tool_param_aliases::{typed_array_or_json, typed_json_or_json};
+use crate::error::Result;
 use crate::params::{GetMetadataAuditParams, MetadataAuditSelectionModeParam};
 
 pub(super) fn metadata_audit_args_from_tool_params(
@@ -11,51 +12,37 @@ pub(super) fn metadata_audit_args_from_tool_params(
             "changed_files",
             &params.changed_files,
             "changed_files_json",
-            params.changed_files_json.as_ref(),
+            params.changed_files_json.as_deref(),
         )?,
         entity_ids_json: typed_array_or_json(
             "entity_ids",
             &params.entity_ids,
             "entity_ids_json",
-            params.entity_ids_json.as_ref(),
+            params.entity_ids_json.as_deref(),
         )?,
         resource_types_json: typed_array_or_json(
             "resource_types",
             &params.resource_types,
             "resource_types_json",
-            params.resource_types_json.as_ref(),
+            params.resource_types_json.as_deref(),
         )?,
         personas_json: typed_array_or_json(
             "personas",
             &params.personas,
             "personas_json",
-            params.personas_json.as_ref(),
+            params.personas_json.as_deref(),
         )?,
-        thresholds_json: params.thresholds_json.clone(),
+        thresholds_json: typed_json_or_json(
+            "thresholds",
+            params.thresholds.as_ref(),
+            "thresholds_json",
+            params.thresholds_json.as_deref(),
+        )?,
         include_breakdown: params.include_breakdown,
         include_recommendations: params.include_recommendations,
         fail_on_no_targets: params.fail_on_no_targets,
         ..MetadataAuditArgs::default()
     })
-}
-
-fn typed_array_or_json(
-    typed_name: &str,
-    typed_values: &[String],
-    json_name: &str,
-    json_value: Option<&String>,
-) -> Result<Option<String>> {
-    if typed_values.is_empty() {
-        return Ok(json_value.cloned());
-    }
-    if json_value.is_some() {
-        return Err(DbtNovaError::InvalidParams(format!(
-            "use only one of {typed_name} or {json_name}"
-        )));
-    }
-    serde_json::to_string(typed_values)
-        .map(Some)
-        .map_err(|error| DbtNovaError::InvalidParams(format!("invalid {typed_name}: {error}")))
 }
 
 fn metadata_audit_selection_mode_from_param(
@@ -65,5 +52,71 @@ fn metadata_audit_selection_mode_from_param(
         MetadataAuditSelectionModeParam::Project => MetadataAuditSelectionModeArg::Project,
         MetadataAuditSelectionModeParam::Changed => MetadataAuditSelectionModeArg::Changed,
         MetadataAuditSelectionModeParam::Entities => MetadataAuditSelectionModeArg::Entities,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{Value as JsonValue, json};
+
+    #[test]
+    fn metadata_audit_tool_params_accept_typed_aliases() {
+        let args = metadata_audit_args_from_tool_params(&GetMetadataAuditParams {
+            selection_mode: MetadataAuditSelectionModeParam::Changed,
+            changed_files: vec!["models/marts/orders.sql".to_string()],
+            changed_files_json: Some(r#"["models/marts/orders.sql"]"#.to_string()),
+            resource_types: vec!["model".to_string()],
+            personas: vec!["governance".to_string()],
+            thresholds: Some(json!({
+                "entity": {
+                    "governance": {"min_score": 80, "severity": "advisory"}
+                }
+            })),
+            include_recommendations: Some(false),
+            ..GetMetadataAuditParams::default()
+        })
+        .expect("typed aliases");
+
+        assert_eq!(args.selection_mode, MetadataAuditSelectionModeArg::Changed);
+        assert_eq!(
+            args.changed_files_json.as_deref(),
+            Some(r#"["models/marts/orders.sql"]"#)
+        );
+        assert_eq!(args.resource_types_json.as_deref(), Some(r#"["model"]"#));
+        assert_eq!(args.personas_json.as_deref(), Some(r#"["governance"]"#));
+        assert_eq!(args.include_recommendations, Some(false));
+        assert_eq!(
+            serde_json::from_str::<JsonValue>(args.thresholds_json.as_deref().expect("thresholds"))
+                .expect("thresholds json"),
+            json!({
+                "entity": {
+                    "governance": {"min_score": 80, "severity": "advisory"}
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn metadata_audit_tool_params_reject_conflicting_aliases() {
+        let error = metadata_audit_args_from_tool_params(&GetMetadataAuditParams {
+            thresholds_json: Some(
+                r#"{"entity":{"engineer":{"min_score":70,"severity":"required"}}}"#.to_string(),
+            ),
+            thresholds: Some(json!({
+                "entity": {
+                    "engineer": {"min_score": 80, "severity": "required"}
+                }
+            })),
+            ..GetMetadataAuditParams::default()
+        })
+        .expect_err("conflicting aliases should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("thresholds and thresholds_json differ"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -16,6 +16,7 @@ pub mod output;
 pub mod server_cmd;
 pub mod storage_cmd;
 pub mod tool;
+mod tool_param_aliases;
 pub mod trace_cmd;
 
 pub struct DispatchError {

--- a/src/cli/tool_param_aliases.rs
+++ b/src/cli/tool_param_aliases.rs
@@ -1,0 +1,55 @@
+use serde_json::Value as JsonValue;
+
+use crate::error::{DbtNovaError, Result};
+
+pub(crate) fn typed_array_or_json(
+    typed_name: &str,
+    typed_values: &[String],
+    json_name: &str,
+    json_value: Option<&str>,
+) -> Result<Option<String>> {
+    if typed_values.is_empty() {
+        return Ok(json_value.map(ToOwned::to_owned));
+    }
+
+    if let Some(raw_json) = json_value {
+        let parsed: Vec<String> = serde_json::from_str(raw_json).map_err(|error| {
+            DbtNovaError::InvalidParams(format!("invalid {json_name}: {error}"))
+        })?;
+        if parsed != typed_values {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "{typed_name} and {json_name} differ; pass only one representation or matching values"
+            )));
+        }
+    }
+
+    serde_json::to_string(typed_values)
+        .map(Some)
+        .map_err(|error| DbtNovaError::InvalidParams(format!("invalid {typed_name}: {error}")))
+}
+
+pub(crate) fn typed_json_or_json(
+    typed_name: &str,
+    typed_value: Option<&JsonValue>,
+    json_name: &str,
+    json_value: Option<&str>,
+) -> Result<Option<String>> {
+    let Some(value) = typed_value else {
+        return Ok(json_value.map(ToOwned::to_owned));
+    };
+
+    if let Some(raw_json) = json_value {
+        let parsed: JsonValue = serde_json::from_str(raw_json).map_err(|error| {
+            DbtNovaError::InvalidParams(format!("invalid {json_name}: {error}"))
+        })?;
+        if parsed != *value {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "{typed_name} and {json_name} differ; pass only one representation or matching values"
+            )));
+        }
+    }
+
+    serde_json::to_string(value)
+        .map(Some)
+        .map_err(|error| DbtNovaError::InvalidParams(format!("invalid {typed_name}: {error}")))
+}

--- a/src/nova_meta/canonical.rs
+++ b/src/nova_meta/canonical.rs
@@ -1,0 +1,257 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::{Map as JsonMap, Value as JsonValue};
+
+use super::{
+    NovaMetaFinding, NovaMetaTarget, NovaMetaTargetScope, ResourceDefinition, normalize_name,
+    semantic_warning, string_array,
+};
+
+struct CanonicalIndicator<'a> {
+    target: &'a NovaMetaTarget,
+    name: String,
+    indicator_type: &'static str,
+    field_path: String,
+    grain_signature: String,
+    scoped_to_grain: bool,
+}
+
+pub(super) fn validate_project_canonical_indicators(
+    targets: &[&NovaMetaTarget],
+) -> Vec<NovaMetaFinding> {
+    let mut by_name = BTreeMap::<String, Vec<CanonicalIndicator<'_>>>::new();
+    for target in targets {
+        if target.scope != NovaMetaTargetScope::Entity {
+            continue;
+        }
+        let Some(nova) = target.nova.as_object() else {
+            continue;
+        };
+        for indicator in canonical_indicators_for_target(target, nova) {
+            by_name
+                .entry(normalize_name(&indicator.name))
+                .or_default()
+                .push(indicator);
+        }
+    }
+
+    let mut findings = Vec::new();
+    for indicators in by_name.values() {
+        if indicators.len() <= 1 {
+            continue;
+        }
+        findings.extend(duplicate_canonical_surface_findings(indicators));
+        if let Some(finding) = canonical_indicator_conflict_finding(indicators) {
+            findings.push(finding);
+        }
+    }
+    findings
+}
+
+fn canonical_indicators_for_target<'a>(
+    target: &'a NovaMetaTarget,
+    nova: &'a JsonMap<String, JsonValue>,
+) -> Vec<CanonicalIndicator<'a>> {
+    let mut indicators = Vec::new();
+    let entity_grain = nova.get("grain").and_then(JsonValue::as_object);
+
+    for (index, measure) in nova
+        .get("measures")
+        .and_then(JsonValue::as_array)
+        .into_iter()
+        .flatten()
+        .enumerate()
+    {
+        let Some(measure) = measure.as_object() else {
+            continue;
+        };
+        if measure.get("canonical").and_then(JsonValue::as_bool) != Some(true) {
+            continue;
+        }
+        if let Some(name) = indicator_name(measure) {
+            indicators.push(CanonicalIndicator {
+                target,
+                name,
+                indicator_type: "measure",
+                field_path: format!("meta.nova.measures[{index}].canonical"),
+                grain_signature: grain_signature(entity_grain),
+                scoped_to_grain: canonical_scope_is_grain(measure),
+            });
+        }
+    }
+
+    if let Some(metric) = nova.get("metric").and_then(JsonValue::as_object)
+        && metric.get("canonical").and_then(JsonValue::as_bool) == Some(true)
+        && let Some(name) = indicator_name(metric)
+    {
+        indicators.push(CanonicalIndicator {
+            target,
+            name,
+            indicator_type: "metric",
+            field_path: "meta.nova.metric.canonical".to_string(),
+            grain_signature: grain_signature(
+                metric
+                    .get("grain")
+                    .and_then(JsonValue::as_object)
+                    .or(entity_grain),
+            ),
+            scoped_to_grain: canonical_scope_is_grain(metric),
+        });
+    }
+
+    for (index, metric) in nova
+        .get("metrics")
+        .and_then(JsonValue::as_array)
+        .into_iter()
+        .flatten()
+        .enumerate()
+    {
+        let Some(metric) = metric.as_object() else {
+            continue;
+        };
+        if metric.get("canonical").and_then(JsonValue::as_bool) != Some(true) {
+            continue;
+        }
+        if let Some(name) = indicator_name(metric) {
+            indicators.push(CanonicalIndicator {
+                target,
+                name,
+                indicator_type: "metric",
+                field_path: format!("meta.nova.metrics[{index}].canonical"),
+                grain_signature: grain_signature(
+                    metric
+                        .get("grain")
+                        .and_then(JsonValue::as_object)
+                        .or(entity_grain),
+                ),
+                scoped_to_grain: canonical_scope_is_grain(metric),
+            });
+        }
+    }
+
+    indicators
+}
+
+fn indicator_name(indicator: &JsonMap<String, JsonValue>) -> Option<String> {
+    indicator
+        .get("name")
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn duplicate_canonical_surface_findings(
+    indicators: &[CanonicalIndicator<'_>],
+) -> Vec<NovaMetaFinding> {
+    let mut by_grain = BTreeMap::<&str, Vec<&CanonicalIndicator<'_>>>::new();
+    for indicator in indicators {
+        by_grain
+            .entry(indicator.grain_signature.as_str())
+            .or_default()
+            .push(indicator);
+    }
+
+    let mut findings = Vec::new();
+    for matching_grain in by_grain.values().filter(|values| values.len() > 1) {
+        let first = matching_grain[0];
+        findings.push(semantic_warning(
+            first.target,
+            "duplicate_canonical_surface",
+            format!(
+                "canonical indicator '{}' is declared on multiple parents with the same grain ({}): {}",
+                first.name,
+                first.grain_signature,
+                canonical_indicator_locations(matching_grain)
+            ),
+            Some(first.field_path.clone()),
+        ));
+    }
+    findings
+}
+
+fn canonical_indicator_conflict_finding(
+    indicators: &[CanonicalIndicator<'_>],
+) -> Option<NovaMetaFinding> {
+    let unscoped = indicators
+        .iter()
+        .filter(|indicator| !indicator.scoped_to_grain)
+        .collect::<Vec<_>>();
+    if unscoped.len() <= 1 {
+        return None;
+    }
+
+    let unique_grains = unscoped
+        .iter()
+        .map(|indicator| indicator.grain_signature.as_str())
+        .collect::<BTreeSet<_>>();
+    if unique_grains.len() <= 1 {
+        return None;
+    }
+
+    let first = unscoped[0];
+    Some(semantic_warning(
+        first.target,
+        "canonical_indicator_conflict",
+        format!(
+            "canonical indicator '{}' is declared on multiple parents with different grains: {}. Use canonical_scope: grain only for definitions that are intentionally canonical within their own grain.",
+            first.name,
+            canonical_indicator_locations(&unscoped)
+        ),
+        Some(first.field_path.clone()),
+    ))
+}
+
+fn canonical_indicator_locations(indicators: &[&CanonicalIndicator<'_>]) -> String {
+    indicators
+        .iter()
+        .map(|indicator| {
+            format!(
+                "{} {} ({}, grain: {})",
+                indicator.target.definition.resource_kind.as_str(),
+                display_resource_name(&indicator.target.definition),
+                indicator.indicator_type,
+                indicator.grain_signature
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+fn display_resource_name(definition: &ResourceDefinition) -> String {
+    if let Some(parent) = definition.parent_name.as_deref() {
+        format!("{parent}.{}", definition.resource_name)
+    } else {
+        definition.resource_name.clone()
+    }
+}
+
+fn canonical_scope_is_grain(indicator: &JsonMap<String, JsonValue>) -> bool {
+    indicator.get("canonical_scope").and_then(JsonValue::as_str) == Some("grain")
+}
+
+fn grain_signature(grain: Option<&JsonMap<String, JsonValue>>) -> String {
+    let Some(grain) = grain else {
+        return "unspecified".to_string();
+    };
+    let primary_key = sorted_string_array(grain.get("primary_key"));
+    let dimensions = sorted_string_array(grain.get("dimensions"));
+    let time_field = grain
+        .get("time_field")
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("none");
+    format!(
+        "time={time_field}; dimensions=[{}]; primary_key=[{}]",
+        dimensions.join(","),
+        primary_key.join(",")
+    )
+}
+
+fn sorted_string_array(value: Option<&JsonValue>) -> Vec<String> {
+    let mut values = string_array(value);
+    values.sort();
+    values.dedup();
+    values
+}

--- a/src/nova_meta/mod.rs
+++ b/src/nova_meta/mod.rs
@@ -11,6 +11,8 @@ use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 
 use crate::error::{DbtNovaError, Result};
 
+mod canonical;
+
 const NOVA_META_SCHEMA_VERSION: &str = "v0";
 const ENTITY_ONLY_FIELDS: [&str; 8] = [
     "canonical",
@@ -178,6 +180,7 @@ pub fn validate_nova_meta(options: &NovaMetaValidationOptions) -> NovaMetaValida
     match selected_targets {
         Ok(selected) => {
             let selected_count = selected.len();
+            findings.extend(canonical::validate_project_canonical_indicators(&selected));
             for target in selected {
                 findings.extend(validate_target_schema(target));
                 findings.extend(validate_target_semantics(target));

--- a/src/nova_meta/tests.rs
+++ b/src/nova_meta/tests.rs
@@ -363,6 +363,157 @@ models:
 }
 
 #[test]
+fn validate_nova_meta_warns_on_project_scope_canonical_indicator_conflicts() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    write_fixture(
+        &temp_dir,
+        "models/canonical-conflicts.yml",
+        r#"
+version: 2
+models:
+  - name: mart_orders_monthly
+    meta:
+      nova:
+        grain:
+          time_field: month_start
+          dimensions: ["store_id"]
+        measures:
+          - name: gross_sales
+            type: sum
+            expression: "sum(gross_sales)"
+            description: "Gross sales."
+            canonical: true
+    columns:
+      - name: month_start
+      - name: store_id
+      - name: gross_sales
+  - name: mart_orders_daily
+    meta:
+      nova:
+        grain:
+          time_field: order_date
+          dimensions: ["store_id"]
+        measures:
+          - name: gross_sales
+            type: sum
+            expression: "sum(gross_sales)"
+            description: "Gross sales."
+            canonical: true
+    columns:
+      - name: order_date
+      - name: store_id
+      - name: gross_sales
+  - name: mart_orders_monthly_copy
+    meta:
+      nova:
+        grain:
+          time_field: month_start
+          dimensions: ["store_id"]
+        measures:
+          - name: gross_sales
+            type: sum
+            expression: "sum(gross_sales)"
+            description: "Gross sales."
+            canonical: true
+    columns:
+      - name: month_start
+      - name: store_id
+      - name: gross_sales
+"#,
+    );
+
+    let report = validate_nova_meta(&NovaMetaValidationOptions {
+        project_dir: temp_dir.path().to_path_buf(),
+        paths: Vec::new(),
+        selector: NovaMetaTargetSelector::default(),
+    });
+
+    assert_eq!(report.error_count, 0);
+    assert!(
+        report.findings.iter().any(|finding| {
+            finding.code == "canonical_indicator_conflict"
+                && finding.severity == NovaMetaFindingSeverity::Warning
+                && finding.message.contains("mart_orders_daily")
+                && finding.message.contains("mart_orders_monthly")
+        }),
+        "{:#?}",
+        report.findings
+    );
+    assert!(
+        report
+            .findings
+            .iter()
+            .any(|finding| finding.code == "duplicate_canonical_surface"
+                && finding.message.contains("mart_orders_monthly_copy")),
+        "{:#?}",
+        report.findings
+    );
+}
+
+#[test]
+fn validate_nova_meta_allows_grain_scoped_canonical_indicators() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    write_fixture(
+        &temp_dir,
+        "models/canonical-scope.yml",
+        r#"
+version: 2
+models:
+  - name: mart_orders_monthly
+    meta:
+      nova:
+        grain:
+          time_field: month_start
+          dimensions: ["store_id"]
+        measures:
+          - name: gross_sales
+            type: sum
+            expression: "sum(gross_sales)"
+            description: "Gross sales."
+            canonical: true
+            canonical_scope: grain
+    columns:
+      - name: month_start
+      - name: store_id
+      - name: gross_sales
+  - name: mart_orders_daily
+    meta:
+      nova:
+        grain:
+          time_field: order_date
+          dimensions: ["store_id"]
+        measures:
+          - name: gross_sales
+            type: sum
+            expression: "sum(gross_sales)"
+            description: "Gross sales."
+            canonical: true
+            canonical_scope: grain
+    columns:
+      - name: order_date
+      - name: store_id
+      - name: gross_sales
+"#,
+    );
+
+    let report = validate_nova_meta(&NovaMetaValidationOptions {
+        project_dir: temp_dir.path().to_path_buf(),
+        paths: Vec::new(),
+        selector: NovaMetaTargetSelector::default(),
+    });
+
+    assert_eq!(report.error_count, 0);
+    assert!(
+        !report
+            .findings
+            .iter()
+            .any(|finding| finding.code == "canonical_indicator_conflict"),
+        "{:#?}",
+        report.findings
+    );
+}
+
+#[test]
 fn validate_nova_meta_skips_field_existence_checks_for_metric_resources() {
     let temp_dir = TempDir::new().expect("temp dir");
     write_fixture(

--- a/src/params.rs
+++ b/src/params.rs
@@ -723,12 +723,21 @@ pub struct GetAgentReadinessParams {
     /// JSON array of personas to score. Defaults to `["engineer","analyst","governance"]`.
     #[serde(default)]
     pub personas_json: Option<String>,
+    /// Typed alias for `personas_json`.
+    #[serde(default)]
+    pub personas: Vec<String>,
     /// JSON threshold configuration. Defaults to advisory readiness thresholds.
     #[serde(default)]
     pub thresholds_json: Option<String>,
+    /// Typed alias for `thresholds_json`.
+    #[serde(default)]
+    pub thresholds: Option<JsonValue>,
     /// Inline JSON from `dbt-nova eval gate <SUITE> --json` or the raw gate report.
     #[serde(default)]
     pub eval_gate_json: Option<String>,
+    /// Typed alias for `eval_gate_json`.
+    #[serde(default)]
+    pub eval_gate: Option<JsonValue>,
 }
 
 /// Selection mode for the get_metadata_audit tool.
@@ -778,6 +787,9 @@ pub struct GetMetadataAuditParams {
     /// JSON threshold configuration for required/advisory gates.
     #[serde(default)]
     pub thresholds_json: Option<String>,
+    /// Typed alias for `thresholds_json`.
+    #[serde(default)]
+    pub thresholds: Option<JsonValue>,
     /// Include per-check metadata score breakdowns. Defaults to true.
     #[serde(default)]
     pub include_breakdown: Option<bool>,


### PR DESCRIPTION
## Summary

Part of #298.

- add project-scope `validate_nova_meta` warnings for duplicate/conflicting canonical indicators across the scanned project
- add `canonical_scope: grain` to the public Nova schema and docs for intentionally grain-scoped canonical measures/metrics
- add typed MCP aliases for metadata-audit and agent-readiness JSON inputs while preserving compatible `*_json` fields

## Validation

- `cargo fmt --check`
- `bash scripts/check_module_size.sh`
- `cargo test --locked parse_readiness_tool_inputs --lib`
- `cargo test --locked metadata_audit_tool_params --lib`
- `cargo test --locked nova_meta --lib`
- `uv run mkdocs build --strict`
- `git diff --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --quiet`