### PR TITLE
Add search ranking regression eval suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,16 @@ jobs:
             --fail-under 1.0 \
             --json
 
+      - name: Run Search Ranking Regression Eval
+        run: |
+          cargo run --locked --no-default-features -- eval run \
+            --suite evals/search-ranking-regressions.yml \
+            --manifest-path tests/fixtures/keyword_phrase_ranking.json \
+            --storage-instance-id search-ranking-regressions-ci \
+            --cleanup-storage-on-start \
+            --fail-under 1.0 \
+            --json
+
   check-no-default:
     runs-on: ubuntu-22.04
     timeout-minutes: 45

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `modelling_consistency_report` applies a bounded default overlap threshold
   with explicit raw/filtered counts, and `execute_sql` provider-configuration
   errors now explain the selected/default provider and provider-selection knobs.
-- Added fixture-backed keyword/phrase ranking regressions for business-term and
-  indicator discovery queries.
+- Added a bundled `evals/search-ranking-regressions.yml` suite and CI guard for
+  business-term and indicator discovery ranking regressions.
 - Hardened Databricks and BigQuery SQL execution so local poll timeouts attempt
   provider-side cancellation, and Databricks now enforces local row/byte caps
   while merging inline and fetched result chunks.

--- a/docs/features/search-ranking.md
+++ b/docs/features/search-ranking.md
@@ -194,6 +194,12 @@ DBT_NOVA_SEARCH_ENGINEER_EXACT_MATCH_MULTIPLIER=2.0
 12) **Analyst near-tie hinting** emits `analysis_hints` when top candidates are within a small score
    gap, prompting `get_entity`/`get_context` validation before SQL generation.
 
+The executable guard for the first ranking tier is
+`evals/search-ranking-regressions.yml`. It runs against the synthetic
+`tests/fixtures/keyword_phrase_ranking.json` manifest and fails if exact entity
+names, two-token metric names, or declared multi-word metric synonyms no longer
+rank first with lexical search.
+
 ## Persona Candidate Metadata
 
 Use `meta.nova.search.candidates` when a model should remain searchable but

--- a/evals/search-ranking-regressions.yml
+++ b/evals/search-ranking-regressions.yml
@@ -1,0 +1,42 @@
+version: 1
+name: search-ranking-regressions
+purpose: Guard keyword and phrase ranking behavior for entity names, metric names, and declared synonyms.
+manifest_scope: tests/fixtures/keyword_phrase_ranking.json synthetic keyword/phrase ranking manifest
+known_gaps:
+  - Does not execute warehouse SQL.
+  - Covers deterministic lexical ranking only; vector, sparse, and reranker behavior are intentionally out of scope.
+gate:
+  threshold: 1.0
+defaults:
+  persona: analyst
+  top_k: 5
+
+cases:
+  - id: exact_entity_name_ranks_first
+    question: Exact normalized entity-name queries should keep the matching model first.
+    assertions:
+      - type: search_rank
+        query: mart customer cohort monthly
+        expected_unique_id: model.pkg.mart__customer_cohort_monthly
+        max_rank: 1
+        resource_types: [model]
+
+  - id: two_token_metric_query_ranks_declaring_entity_first
+    question: Two-token metric-name queries should rank the declaring entity above broad rate collisions.
+    assertions:
+      - type: search_indicator_rank
+        query: retention rate
+        expected: customer_retention_rate
+        max_rank: 1
+        resource_types: [model]
+        indicator_types: [metric]
+
+  - id: exact_metric_synonym_ranks_first
+    question: Declared multi-word metric synonyms should rank the owning metric first.
+    assertions:
+      - type: search_indicator_rank
+        query: availability rate
+        expected: stock_availability_rate
+        max_rank: 1
+        resource_types: [model]
+        indicator_types: [metric]


### PR DESCRIPTION
## Summary

- Add `evals/search-ranking-regressions.yml` to lock the keyword/phrase ranking regressions from GitHub #298.
- Run the suite in CI against `tests/fixtures/keyword_phrase_ranking.json` with vector/sparse/reranker out of scope.
- Document the suite from the search ranking guide and update the changelog.

## Validation

- `cargo run --locked --no-default-features -- eval validate --suite evals/search-ranking-regressions.yml`
- `cargo run --locked --no-default-features -- eval run --suite evals/search-ranking-regressions.yml --manifest-path tests/fixtures/keyword_phrase_ranking.json --storage-instance-id search-ranking-regressions-local --cleanup-storage-on-start --fail-under 1.0 --json`
- `for suite in evals/*.yml; do target/debug/dbt-nova eval validate --suite "$suite"; done`
- `actionlint .github/workflows/ci.yml`
- `uv run mkdocs build --strict`
- `git diff --check`

Part of #298.