### PR TITLE
JOE-687 Serve storage readers during builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   while merging inline and fetched result chunks.
 - Enforced `manifest_max_bytes` for local manifest paths and auto-discovered
   sibling `catalog.json` files before parsing.
+- Fixed storage loading so readers reuse complete published versions without
+  taking the build lock, and fall back to `manifest.current.json` while another
+  process builds a newer version.
 - Tightened release and reusable-workflow supply-chain posture: releases are
   tag-triggered only, release asset verification now requires tag-scoped
   identities, ARM64 images are smoked and Trivy-gated before push, Trivy no

--- a/docs/configuration/manifest-sources.md
+++ b/docs/configuration/manifest-sources.md
@@ -173,6 +173,10 @@ When `DBT_NOVA_MANIFEST_REFRESH_SECS` is enabled, Nova:
 4. Atomically swaps the active version once ready (no downtime).
 5. Keeps the previous version available for in-flight requests.
 
+Concurrent loaders do not need the build lock when a complete matching version
+already exists. If another process is building a newer version, Nova serves the
+published `manifest.current.json` version until the new build is complete.
+
 ## Multi‑repo / Multi‑manifest Workflow
 
 Nova isolates indexes by manifest path or URI. If you work across multiple repos or

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -270,7 +270,8 @@ cache (`.fastembed_cache`) and per-manifest instances:
 
 Key behaviors:
 - **Manifest hash instance IDs**: the same manifest path reuses the same instance dir.
-- **Build lock**: only one process builds indexes; others wait (configurable) or reuse.
+- **Build lock**: only one process builds indexes; readers reuse a complete
+  published version without taking the writer lock.
 - **In-use lock**: active instances are protected from pruning/cleanup.
 - **Versioned swaps**: refreshed manifests build into a new version directory and swap atomically.
 - **Pruning**: old instances/versions are removed by count and/or size limits.

--- a/docs/operations/ops.md
+++ b/docs/operations/ops.md
@@ -193,6 +193,8 @@ To test fallback behavior:
 
 - **`manifest.current.json`** points at the active version.
 - **`versions/`** contains immutable, content-addressed index builds.
+- **`.build.lock`** serializes writers; readers use a complete published
+  version without taking this lock.
 - **`.in_use.lock`** protects active versions from pruning.
 
 ## Pruning Behavior

--- a/src/manifest/loader.rs
+++ b/src/manifest/loader.rs
@@ -40,10 +40,12 @@ use runtime::has_apparent_malformed_ref;
 use runtime::{
     build_column_lineage_aliases, build_manifest_health, combine_index_build_results, panic_message,
 };
+#[cfg(test)]
+use storage::acquire_build_lock;
 use storage::{
-    MANIFEST_SIGNATURE_FILENAME, acquire_build_lock, acquire_in_use_locks, current_time_ms,
+    MANIFEST_SIGNATURE_FILENAME, acquire_in_use_locks, current_time_ms,
     manifest_signature_matches_for_reuse, read_current_version, read_manifest_signature,
-    write_current_version, write_manifest_signature,
+    select_storage_version_or_lock, write_current_version, write_manifest_signature,
 };
 
 /// Structured output from manifest loading/index build.
@@ -202,7 +204,8 @@ impl ManifestSearch {
             cached_indexes,
             indexes_reused,
         } = prepared_manifest_data;
-        let update_current_version = !needs_build
+        let update_current_version = storage.build_lock.is_some()
+            && !needs_build
             && !config.storage_read_only
             && reused.storage_dir == storage.storage_dir
             && reused.current_version.as_deref() != Some(storage.version_id.as_str());
@@ -239,6 +242,7 @@ impl ManifestSearch {
             accumulator: &accumulator,
             cached_indexes: &cached_indexes,
         };
+        let manifest_source_uri = storage.signature.source_uri.clone();
         persist_storage_outputs(&mut storage, &persist_context)?;
         Ok(ManifestLoadResult {
             search: assemble_manifest_search(AssembleContext {
@@ -250,7 +254,7 @@ impl ManifestSearch {
                 cached_indexes,
                 search_backends,
                 in_use_locks,
-                manifest_source_uri: sources.manifest_resolution.source_uri.clone(),
+                manifest_source_uri,
             }),
             entity_store_reused,
             tantivy_reused,
@@ -327,48 +331,66 @@ fn prepare_storage(
         version_id = "unknown".to_string();
     }
 
+    let target_version_hash = version_hash.clone();
     let storage_dir = versions_root.join(&version_id);
     let signature_path = storage_dir.join(MANIFEST_SIGNATURE_FILENAME);
-    let build_lock = Some(acquire_build_lock(
+    let selected = select_storage_version_or_lock(
+        config,
         &instance_root,
-        config.storage_build_lock_wait_secs,
-    )?);
-
-    let mut artifact_consumer_status = build_artifact_consumer_status(config, None, None);
-    if config.remote_artifact_mode_enabled() {
-        let evaluated_at_ms = current_time_ms();
-        let materialization = materialize_file_artifacts(config, &version_hash)?;
-        if let Some(outcome) = materialization {
-            let last_materialized_at_ms =
-                if outcome.storage_materialized || outcome.models_materialized {
-                    Some(evaluated_at_ms)
-                } else {
-                    None
-                };
-            artifact_consumer_status = build_artifact_consumer_status(
-                config,
-                Some(&outcome),
-                Some((evaluated_at_ms, last_materialized_at_ms)),
-            );
-            info!(
-                storage_materialized = outcome.storage_materialized,
-                models_materialized = outcome.models_materialized,
-                "evaluated remote artifact materialization"
-            );
-        }
-    }
-
-    Ok(StoragePreparation {
-        instance_root,
-        versions_root,
+        &versions_root,
         signature,
         version_id,
         storage_dir,
         signature_path,
-        build_lock,
+    )?;
+    let can_materialize = selected.build_lock.is_some();
+    let artifact_consumer_status =
+        evaluate_artifact_consumer_status(config, can_materialize, &target_version_hash)?;
+
+    Ok(StoragePreparation {
+        instance_root,
+        versions_root,
+        signature: selected.signature,
+        version_id: selected.version_id,
+        storage_dir: selected.storage_dir,
+        signature_path: selected.signature_path,
+        build_lock: selected.build_lock,
         artifact_consumer_status,
         bootstrap_status,
     })
+}
+
+fn evaluate_artifact_consumer_status(
+    config: &DbtNovaConfig,
+    can_materialize: bool,
+    target_version_hash: &str,
+) -> Result<JsonValue> {
+    let mut artifact_consumer_status = build_artifact_consumer_status(config, None, None);
+    if !can_materialize || !config.remote_artifact_mode_enabled() {
+        return Ok(artifact_consumer_status);
+    }
+
+    let evaluated_at_ms = current_time_ms();
+    let materialization = materialize_file_artifacts(config, target_version_hash)?;
+    if let Some(outcome) = materialization {
+        let last_materialized_at_ms = if outcome.storage_materialized || outcome.models_materialized
+        {
+            Some(evaluated_at_ms)
+        } else {
+            None
+        };
+        artifact_consumer_status = build_artifact_consumer_status(
+            config,
+            Some(&outcome),
+            Some((evaluated_at_ms, last_materialized_at_ms)),
+        );
+        info!(
+            storage_materialized = outcome.storage_materialized,
+            models_materialized = outcome.models_materialized,
+            "evaluated remote artifact materialization"
+        );
+    }
+    Ok(artifact_consumer_status)
 }
 
 fn resolve_catalog(
@@ -504,12 +526,14 @@ fn prepare_reuse_state(
         &storage.storage_dir,
         &storage.signature_path,
     )?;
-    prune_storage_versions(
-        config,
-        &storage.versions_root,
-        reused.current_version.as_deref(),
-        &storage.version_id,
-    )?;
+    if storage.build_lock.is_some() {
+        prune_storage_versions(
+            config,
+            &storage.versions_root,
+            reused.current_version.as_deref(),
+            &storage.version_id,
+        )?;
+    }
     Ok(reused)
 }
 
@@ -1552,7 +1576,7 @@ mod tests {
     }
 
     #[test]
-    fn manifest_search_updates_current_pointer_after_scoped_fallback_reuse() {
+    fn manifest_search_reuses_scoped_fallback_without_republishing_current() {
         let temp = tempdir().unwrap_or_else(|err| panic!("tempdir failed: {err}"));
         let manifest_path = temp.path().join("manifest.json");
         std::fs::copy(
@@ -1587,7 +1611,7 @@ mod tests {
         assert_ne!(allow_version, deny_version);
         assert_eq!(
             read_current_version(&instance_root).expect("read current after alternate"),
-            Some(deny_version)
+            Some(deny_version.clone())
         );
 
         let allow_second =
@@ -1596,9 +1620,55 @@ mod tests {
         assert!(allow_second.entity_store_reused);
         assert_eq!(allow_second.search.manifest_version, allow_version);
         assert_eq!(
-            read_current_version(&instance_root).expect("read refreshed current"),
-            Some(allow_version)
+            read_current_version(&instance_root).expect("read current after lockless reuse"),
+            Some(deny_version)
         );
+    }
+
+    #[test]
+    fn manifest_search_serves_current_version_when_build_lock_is_busy() {
+        let temp = tempdir().unwrap_or_else(|err| panic!("tempdir failed: {err}"));
+        let manifest_path = temp.path().join("manifest.json");
+        std::fs::copy(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/minimal.json"),
+            &manifest_path,
+        )
+        .expect("copy fixture manifest");
+
+        let config = DbtNovaConfig {
+            manifest_path: manifest_path.to_string_lossy().to_string(),
+            storage_dir: temp.path().join("storage").to_string_lossy().to_string(),
+            storage_instance_id: "lock-busy-current".to_string(),
+            storage_build_lock_wait_secs: 0,
+            ..DbtNovaConfig::default()
+        };
+
+        let first = ManifestSearch::new(config.clone()).expect("initial manifest load");
+        let first_version = first.search.manifest_version.clone();
+        let first_hash = first.search.manifest_hash.clone();
+        drop(first);
+
+        let instance_root = config.storage_instance_root_dir().expect("instance root");
+        let _held_lock = acquire_build_lock(&instance_root, 0).expect("hold build lock");
+
+        let mut manifest_json: JsonValue =
+            serde_json::from_slice(&std::fs::read(&manifest_path).expect("read manifest"))
+                .expect("parse manifest");
+        manifest_json["metadata"]["generated_at"] =
+            JsonValue::String("2026-01-01T00:00:00Z".to_string());
+        std::fs::write(
+            &manifest_path,
+            serde_json::to_vec(&manifest_json).expect("serialize manifest"),
+        )
+        .expect("write changed manifest");
+
+        let loaded = ManifestSearch::new(config).expect("serve current version while lock is busy");
+
+        assert!(loaded.entity_store_reused);
+        assert!(loaded.tantivy_reused);
+        assert!(loaded.indexes_reused);
+        assert_eq!(loaded.search.manifest_version, first_version);
+        assert_eq!(loaded.search.manifest_hash, first_hash);
     }
 
     #[test]

--- a/src/manifest/loader/storage.rs
+++ b/src/manifest/loader/storage.rs
@@ -1,18 +1,44 @@
 use std::fs::{self, File};
+use std::io::ErrorKind;
 use std::io::{BufReader, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use fs4::FileExt;
 use serde::{Deserialize, Serialize};
 
+use crate::config::DbtNovaConfig;
 use crate::error::{DbtNovaError, Result};
+use crate::manifest::rkyv_indexes;
 use crate::manifest::search::InUseLocks;
 use crate::manifest::source::ManifestSignature;
+use crate::manifest::store::EntityStore;
+use crate::manifest::tantivy_search::TantivySearcher;
 use crate::utils::{IN_USE_LOCK_FILENAME, unique_suffix};
 
 pub(super) const MANIFEST_SIGNATURE_FILENAME: &str = "manifest.signature.json";
 const MANIFEST_CURRENT_FILENAME: &str = "manifest.current.json";
+const BUILD_LOCK_FILENAME: &str = ".build.lock";
+
+pub(super) enum BuildLockAttempt {
+    Acquired(File),
+    Busy,
+}
+
+pub(super) struct StorageVersionSelection {
+    pub(super) signature: ManifestSignature,
+    pub(super) version_id: String,
+    pub(super) storage_dir: PathBuf,
+    pub(super) signature_path: PathBuf,
+    pub(super) build_lock: Option<File>,
+}
+
+struct PublishedStorageVersion {
+    version_id: String,
+    storage_dir: PathBuf,
+    signature_path: PathBuf,
+    signature: ManifestSignature,
+}
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 struct ManifestCurrent {
@@ -100,13 +126,7 @@ pub(super) fn current_time_ms() -> u128 {
 }
 
 pub(super) fn acquire_build_lock(storage_dir: &Path, wait_secs: u64) -> Result<File> {
-    let lock_path = storage_dir.join(".build.lock");
-    let file = fs::OpenOptions::new()
-        .create(true)
-        .read(true)
-        .write(true)
-        .truncate(false)
-        .open(&lock_path)?;
+    let file = open_build_lock(storage_dir)?;
     let start = Instant::now();
     let wait = Duration::from_secs(wait_secs);
     let mut warned = false;
@@ -130,6 +150,165 @@ pub(super) fn acquire_build_lock(storage_dir: &Path, wait_secs: u64) -> Result<F
             }
         }
     }
+}
+
+fn try_acquire_build_lock(storage_dir: &Path) -> Result<BuildLockAttempt> {
+    let file = open_build_lock(storage_dir)?;
+    match file.try_lock_exclusive() {
+        Ok(()) => Ok(BuildLockAttempt::Acquired(file)),
+        Err(err) if err.kind() == ErrorKind::WouldBlock => Ok(BuildLockAttempt::Busy),
+        Err(err) => Err(DbtNovaError::ServerError(format!(
+            "Storage lock failed: {err}"
+        ))),
+    }
+}
+
+fn open_build_lock(storage_dir: &Path) -> Result<File> {
+    let lock_path = storage_dir.join(BUILD_LOCK_FILENAME);
+    Ok(fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)?)
+}
+
+pub(super) fn select_storage_version_or_lock(
+    config: &DbtNovaConfig,
+    instance_root: &Path,
+    versions_root: &Path,
+    signature: ManifestSignature,
+    version_id: String,
+    storage_dir: PathBuf,
+    signature_path: PathBuf,
+) -> Result<StorageVersionSelection> {
+    let mut selection = StorageVersionSelection {
+        signature,
+        version_id,
+        storage_dir,
+        signature_path,
+        build_lock: None,
+    };
+
+    if storage_version_has_lockless_read_artifacts(
+        config,
+        instance_root,
+        versions_root,
+        &selection.signature,
+        &selection.storage_dir,
+        &selection.signature_path,
+    )? {
+        tracing::info!(
+            version_id = %selection.version_id,
+            "serving complete storage version without acquiring build lock"
+        );
+        return Ok(selection);
+    }
+
+    selection.build_lock = match try_acquire_build_lock(instance_root)? {
+        BuildLockAttempt::Acquired(lock) => Some(lock),
+        BuildLockAttempt::Busy => serve_current_or_wait_for_build_lock(
+            config,
+            instance_root,
+            versions_root,
+            &mut selection,
+        )?,
+    };
+    Ok(selection)
+}
+
+fn serve_current_or_wait_for_build_lock(
+    config: &DbtNovaConfig,
+    instance_root: &Path,
+    versions_root: &Path,
+    selection: &mut StorageVersionSelection,
+) -> Result<Option<File>> {
+    if let Some(published) =
+        load_complete_published_storage_version(config, instance_root, versions_root)?
+    {
+        tracing::info!(
+            requested_version_id = %selection.version_id,
+            served_version_id = %published.version_id,
+            "serving published storage version while another build holds the lock"
+        );
+        selection.signature = published.signature;
+        selection.version_id = published.version_id;
+        selection.storage_dir = published.storage_dir;
+        selection.signature_path = published.signature_path;
+        return Ok(None);
+    }
+    acquire_build_lock(instance_root, config.storage_build_lock_wait_secs).map(Some)
+}
+
+fn storage_version_has_lockless_read_artifacts(
+    config: &DbtNovaConfig,
+    instance_root: &Path,
+    versions_root: &Path,
+    signature: &ManifestSignature,
+    initial_storage_dir: &Path,
+    initial_signature_path: &Path,
+) -> Result<bool> {
+    if let Some(current) = read_current_version(instance_root)? {
+        let current_dir = versions_root.join(current);
+        let current_sig_path = current_dir.join(MANIFEST_SIGNATURE_FILENAME);
+        if storage_signature_matches(&current_sig_path, signature)?
+            && storage_dir_has_lockless_read_artifacts(config, &current_dir, signature)
+        {
+            return Ok(true);
+        }
+    }
+
+    Ok(
+        storage_signature_matches(initial_signature_path, signature)?
+            && storage_dir_has_lockless_read_artifacts(config, initial_storage_dir, signature),
+    )
+}
+
+fn load_complete_published_storage_version(
+    config: &DbtNovaConfig,
+    instance_root: &Path,
+    versions_root: &Path,
+) -> Result<Option<PublishedStorageVersion>> {
+    let Some(version_id) = read_current_version(instance_root)? else {
+        return Ok(None);
+    };
+    let storage_dir = versions_root.join(&version_id);
+    let signature_path = storage_dir.join(MANIFEST_SIGNATURE_FILENAME);
+    let Some(signature) = read_manifest_signature(&signature_path)? else {
+        return Ok(None);
+    };
+    if !storage_dir_has_lockless_read_artifacts(config, &storage_dir, &signature) {
+        return Ok(None);
+    }
+    Ok(Some(PublishedStorageVersion {
+        version_id,
+        storage_dir,
+        signature_path,
+        signature,
+    }))
+}
+
+fn storage_signature_matches(path: &Path, signature: &ManifestSignature) -> Result<bool> {
+    Ok(read_manifest_signature(path)?
+        .as_ref()
+        .is_some_and(|existing| manifest_signature_matches_for_reuse(existing, signature)))
+}
+
+fn storage_dir_has_lockless_read_artifacts(
+    config: &DbtNovaConfig,
+    storage_dir: &Path,
+    signature: &ManifestSignature,
+) -> bool {
+    if EntityStore::open(storage_dir).is_err() {
+        return false;
+    }
+    if !matches!(
+        TantivySearcher::open(storage_dir, &config.search),
+        Ok(Some(_))
+    ) {
+        return false;
+    }
+    rkyv_indexes::try_load_indexes(storage_dir, &signature.content_hash).is_some()
 }
 
 pub(super) fn acquire_in_use_locks(instance_root: &Path, storage_dir: &Path) -> Result<InUseLocks> {


### PR DESCRIPTION
## Summary
- Let loaders reuse a complete matching storage version without acquiring the writer build lock.
- When another process is building a newer version, serve the complete published `manifest.current.json` version instead of blocking readers.
- Keep pruning, artifact materialization, and `manifest.current.json` publishing on writer-owned paths; report the served manifest metadata and document the storage availability behavior.

## Root Cause
`prepare_storage` acquired the instance build lock before checking whether a complete reusable version was already available. That made concurrent readers wait behind index builds even though storage is already versioned and published via `manifest.current.json`.

## Validation
- `cargo test --locked --lib manifest_search_`
- `cargo fmt --check`
- `bash scripts/check_module_size.sh`
- `git diff --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`

Earlier on this PR before the final race guard, I also ran `cargo test --locked --all-features` and `uv run mkdocs build --strict`; the amended head is covered by the PR CI matrix.
