### PR TITLE
JOE-686 Add catalog-backed grain time diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed storage loading so readers reuse complete published versions without
   taking the build lock, and fall back to `manifest.current.json` while another
   process builds a newer version.
+- Added catalog-backed metadata diagnostics for `meta.nova.grain.time_field`
+  values that resolve to non-temporal warehouse column types, without warning
+  for manifest-only projects that lack catalog type evidence.
 - Tightened release and reusable-workflow supply-chain posture: releases are
   tag-triggered only, release asset verification now requires tag-scoped
   identities, ARM64 images are smoked and Trivy-gated before push, Trivy no

--- a/docs/features/metadata-scoring.md
+++ b/docs/features/metadata-scoring.md
@@ -90,6 +90,10 @@ declared columns absent from catalog remain visible in `catalog_drift` fields on
 Entity and column responses include `diagnostics` when Nova can explain partial
 or missing credit. Diagnostics are deterministic JSON rows with `code`,
 `category`, `field`, observed values, expected thresholds, and a short message.
+Catalog-backed grain diagnostics are evidence-gated: Nova only warns about
+`meta.nova.grain.time_field` type issues when the target column has
+`catalog_data_type` from dbt `catalog.json`. Manifest-only deployments do not
+receive type-based grain warnings.
 Common diagnostic codes:
 
 - `description_tier_progress`: shows observed character count, the 50-character
@@ -99,6 +103,10 @@ Common diagnostic codes:
 - `invalid_grain_shape`: identifies `meta.nova.grain`, `meta.nova.metric.grain`,
   or `meta.nova.metrics[].grain` values that are strings, empty objects, or
   otherwise not canonical grain objects
+- `grain_time_field_not_temporal`: warns when catalog evidence shows
+  `meta.nova.grain.time_field` points at a non-temporal column type, including
+  integer `year`, `month`, `week`, or `quarter` fields that should usually be
+  dimensions instead
 - `primary_key_integrity_missing_tests`: names the primary key column and the
   missing `unique` or `not_null` dbt manifest test evidence; Nova does not infer
   uniqueness from compiled SQL or warehouse introspection

--- a/src/tools/metadata_score/diagnostics.rs
+++ b/src/tools/metadata_score/diagnostics.rs
@@ -153,6 +153,7 @@ pub(crate) fn build_entity_score_diagnostics(
     );
 
     push_grain_shape_diagnostics(&mut diagnostics, nova);
+    push_catalog_grain_time_field_diagnostics(&mut diagnostics, nova, entity_json);
     push_primary_key_integrity_diagnostics(&mut diagnostics, search, unique_id, entity_json);
 
     JsonValue::Array(diagnostics)
@@ -381,6 +382,130 @@ fn json_type_label(value: &JsonValue) -> &'static str {
     }
 }
 
+fn push_catalog_grain_time_field_diagnostics(
+    diagnostics: &mut Vec<JsonValue>,
+    nova: Option<&JsonValue>,
+    entity_json: &JsonValue,
+) {
+    let Some(grain) = nova
+        .and_then(|value| value.get("grain"))
+        .and_then(JsonValue::as_object)
+    else {
+        return;
+    };
+    let Some(time_field) = grain
+        .get("time_field")
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return;
+    };
+    let Some(column) = entity_column(entity_json, time_field) else {
+        return;
+    };
+    let Some(catalog_type) = column
+        .get("catalog_data_type")
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return;
+    };
+    if is_temporal_catalog_type(catalog_type) {
+        return;
+    }
+
+    diagnostics.push(json!({
+        "code": "grain_time_field_not_temporal",
+        "category": "semantic",
+        "severity": "warning",
+        "field": "meta.nova.grain.time_field",
+        "column": time_field,
+        "resolved_type": catalog_type,
+        "evidence_source": "dbt catalog column type",
+        "hint": grain_time_field_type_hint(time_field, catalog_type),
+        "message": format!("meta.nova.grain.time_field points at '{time_field}', but catalog type '{catalog_type}' is not temporal")
+    }));
+}
+
+fn entity_column<'a>(entity_json: &'a JsonValue, column_name: &str) -> Option<&'a JsonValue> {
+    let columns = entity_json.get("columns").and_then(JsonValue::as_object)?;
+    columns.get(column_name).or_else(|| {
+        columns
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case(column_name))
+            .map(|(_, column)| column)
+    })
+}
+
+fn is_temporal_catalog_type(catalog_type: &str) -> bool {
+    let normalized = catalog_type.to_ascii_lowercase();
+    ["date", "time", "timestamp", "datetime"]
+        .iter()
+        .any(|token| normalized.contains(token))
+}
+
+fn grain_time_field_type_hint(time_field: &str, catalog_type: &str) -> String {
+    if is_integer_catalog_type(catalog_type)
+        && let Some(bucket) = calendar_bucket_token(time_field)
+    {
+        return format!(
+            "integer {bucket} fields are dimensions, not time fields; point `meta.nova.grain.time_field` at a date/timestamp column such as `{bucket}_start` or `{bucket}_date`, and keep `{time_field}` in `grain.dimensions` if agents should group by it"
+        );
+    }
+    format!(
+        "point `meta.nova.grain.time_field` at a date/timestamp column, or move `{time_field}` to `grain.dimensions` if it is a categorical grain"
+    )
+}
+
+fn is_integer_catalog_type(catalog_type: &str) -> bool {
+    catalog_type
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .map(str::to_ascii_lowercase)
+        .any(|token| {
+            matches!(
+                token.as_str(),
+                "int"
+                    | "integer"
+                    | "bigint"
+                    | "smallint"
+                    | "tinyint"
+                    | "mediumint"
+                    | "uint"
+                    | "uinteger"
+                    | "ubigint"
+                    | "usmallint"
+                    | "utinyint"
+                    | "number"
+                    | "numeric"
+                    | "decimal"
+            ) || token.strip_prefix("int").is_some_and(|suffix| {
+                !suffix.is_empty() && suffix.chars().all(|ch| ch.is_ascii_digit())
+            }) || token.strip_prefix("uint").is_some_and(|suffix| {
+                !suffix.is_empty() && suffix.chars().all(|ch| ch.is_ascii_digit())
+            })
+        })
+}
+
+fn calendar_bucket_token(field: &str) -> Option<&'static str> {
+    for token in field
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .map(str::to_ascii_lowercase)
+    {
+        match token.as_str() {
+            "year" => return Some("year"),
+            "month" => return Some("month"),
+            "week" => return Some("week"),
+            "quarter" | "qtr" => return Some("quarter"),
+            _ => {}
+        }
+    }
+    None
+}
+
 fn push_primary_key_integrity_diagnostics(
     diagnostics: &mut Vec<JsonValue>,
     search: &ManifestSearch,
@@ -471,4 +596,47 @@ fn constraint_count(column: &JsonValue) -> usize {
                 })
                 .count()
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{calendar_bucket_token, grain_time_field_type_hint, is_integer_catalog_type};
+
+    #[test]
+    fn integer_catalog_type_detection_uses_sql_type_tokens() {
+        for catalog_type in [
+            "integer",
+            "BIGINT",
+            "int64",
+            "UINT32",
+            "NUMBER(38,0)",
+            "numeric(10,0)",
+            "decimal",
+        ] {
+            assert!(
+                is_integer_catalog_type(catalog_type),
+                "{catalog_type} should be integer-like"
+            );
+        }
+
+        for catalog_type in ["interval", "point", "varchar", "timestamp"] {
+            assert!(
+                !is_integer_catalog_type(catalog_type),
+                "{catalog_type} should not be integer-like"
+            );
+        }
+    }
+
+    #[test]
+    fn calendar_bucket_hint_only_uses_integer_like_types() {
+        assert_eq!(calendar_bucket_token("fiscal_month"), Some("month"));
+        assert!(
+            grain_time_field_type_hint("fiscal_month", "integer")
+                .contains("integer month fields are dimensions")
+        );
+        assert!(
+            !grain_time_field_type_hint("fiscal_month", "interval")
+                .contains("integer month fields are dimensions")
+        );
+    }
 }

--- a/tests/metricflow_catalog.rs
+++ b/tests/metricflow_catalog.rs
@@ -658,6 +658,126 @@ async fn catalog_json_enriches_columns_and_surfaces_drift() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn catalog_backed_non_temporal_grain_time_field_emits_diagnostic() {
+    let manifest = r#"{
+      "metadata": {"dbt_version": "1.10.0"},
+      "nodes": {
+        "model.pkg.monthly_orders": {
+          "name": "monthly_orders",
+          "resource_type": "model",
+          "package_name": "pkg",
+          "columns": {
+            "month": {"name": "month", "data_type": "integer"},
+            "month_start": {"name": "month_start", "data_type": "date"},
+            "country": {"name": "country", "data_type": "text"}
+          },
+          "depends_on": {"nodes": [], "macros": []},
+          "meta": {
+            "nova": {
+              "grain": {
+                "time_field": "month",
+                "dimensions": ["country"]
+              }
+            }
+          }
+        }
+      },
+      "sources": {},
+      "macros": {},
+      "docs": {},
+      "groups": {},
+      "exposures": {},
+      "metrics": {},
+      "saved_queries": {},
+      "semantic_models": {},
+      "unit_tests": {}
+    }"#;
+    let catalog = serde_json::json!({
+        "nodes": {
+            "model.pkg.monthly_orders": {
+                "columns": {
+                    "month": {"type": "integer", "comment": "Calendar month number"},
+                    "month_start": {"type": "date", "comment": "Month start date"},
+                    "country": {"type": "varchar", "comment": "Country code"}
+                }
+            }
+        }
+    });
+    let temp = tempfile::tempdir().expect("tempdir");
+    let manifest_path = temp.path().join("nova_manifest.json");
+    let catalog_path = temp.path().join("catalog.json");
+    fs::write(&manifest_path, manifest).expect("write manifest");
+    fs::write(
+        &catalog_path,
+        serde_json::to_vec(&catalog).expect("serialize catalog"),
+    )
+    .expect("write catalog");
+    let (searcher, _guard) = load_searcher(&manifest_path, Some(&catalog_path));
+
+    let score = json(
+        searcher
+            .get_metadata_score(&GetMetadataScoreParams {
+                id_or_name: Some("model.pkg.monthly_orders".to_string()),
+                resource_type: Some("model".to_string()),
+                scope: Some("entity".to_string()),
+                include_breakdown: true,
+                include_recommendations: false,
+                ..GetMetadataScoreParams::default()
+            })
+            .await,
+    );
+    let diagnostics = score["data"]["diagnostics"]
+        .as_array()
+        .expect("diagnostics");
+    let diagnostic = diagnostics
+        .iter()
+        .find(|item| item["code"] == "grain_time_field_not_temporal")
+        .unwrap_or_else(|| panic!("missing grain time-field diagnostic: {score:#?}"));
+
+    assert_eq!(
+        diagnostic["field"].as_str(),
+        Some("meta.nova.grain.time_field")
+    );
+    assert_eq!(diagnostic["column"].as_str(), Some("month"));
+    assert_eq!(diagnostic["resolved_type"].as_str(), Some("integer"));
+    assert_eq!(
+        diagnostic["evidence_source"].as_str(),
+        Some("dbt catalog column type")
+    );
+    assert!(
+        diagnostic["hint"]
+            .as_str()
+            .is_some_and(|hint| hint.contains("integer month fields are dimensions")),
+        "{diagnostic:#?}"
+    );
+
+    let manifest_only_temp = tempfile::tempdir().expect("manifest-only tempdir");
+    let manifest_only_path = manifest_only_temp.path().join("nova_manifest.json");
+    fs::write(&manifest_only_path, manifest).expect("write manifest-only manifest");
+    let (manifest_only_searcher, _guard) = load_searcher(&manifest_only_path, None);
+    let manifest_only_score = json(
+        manifest_only_searcher
+            .get_metadata_score(&GetMetadataScoreParams {
+                id_or_name: Some("model.pkg.monthly_orders".to_string()),
+                resource_type: Some("model".to_string()),
+                scope: Some("entity".to_string()),
+                include_breakdown: true,
+                include_recommendations: false,
+                ..GetMetadataScoreParams::default()
+            })
+            .await,
+    );
+    assert!(
+        manifest_only_score["data"]["diagnostics"]
+            .as_array()
+            .is_some_and(|items| items
+                .iter()
+                .all(|item| item["code"] != "grain_time_field_not_temporal")),
+        "manifest-only load must not emit catalog-backed diagnostic: {manifest_only_score:#?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn agent_modelling_findings_use_catalog_and_semantic_artifact_evidence() {
     let manifest = r#"{
       "metadata": {"dbt_version": "1.10.0"},


### PR DESCRIPTION
## Summary

- Add an evidence-gated metadata diagnostic for `meta.nova.grain.time_field` when dbt `catalog.json` proves the referenced column has a non-temporal warehouse type.
- Include the resolved catalog type, evidence source, and a targeted hint for integer calendar bucket fields like `year`, `month`, `week`, and `quarter`.
- Document that manifest-only deployments stay quiet when catalog type evidence is unavailable.

## Validation

- `cargo test --locked tools::metadata_score::diagnostics::tests`
- `cargo test --locked --test metricflow_catalog catalog_backed_non_temporal_grain_time_field_emits_diagnostic`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `uv run mkdocs build --strict`
- `bash scripts/check_module_size.sh`

Full local all-features tests passed before the final helper hardening amend; the final SHA is covered by the focused diagnostics/catalog tests plus remote CI.
