### PR TITLE
JOE-663 Implement proxy-signed identity headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,8 +70,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed DuckDB `execute_sql`/`run_recipe` temporal result cells so DATE,
   TIMESTAMP, and TIME values serialize as ISO-style strings instead of raw
   epoch-day or tick integers.
-- Added a fail-closed hosted auth config skeleton for future proxy/JWT identity
-  work while keeping effective runtime behavior default-off.
+- Added default-off hosted identity config and implemented proxy-signed HMAC
+  header verification for streamable HTTP, while keeping JWT validation planned
+  and fail-closed.
 - Added design-only hosted identity and JWT threat-model docs, planned config
   contract docs, and guardrail tests for the default-off identity milestone.
 - Added machine-checked MCP tool stability metadata, profile membership docs,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,6 +1612,7 @@ dependencies = [
  "fs4",
  "google-cloud-storage",
  "hf-hub",
+ "hmac",
  "insta",
  "jsonschema",
  "jsonwebtoken",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 jsonwebtoken = "9"
 base64 = "0.22"
 sha2 = "0.10"
+hmac = "0.12"
 pem = "3.0"
 simple_asn1 = "0.6"
 zstd = "0.13"

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -49,16 +49,16 @@ see [Modes & Combinations](../getting-started/modes-and-combinations.md).
 - `DBT_NOVA_HTTP_SSE_RETRY_SECS` – SSE retry hint for streamable HTTP mode (`0` disables retry hints, default: `3`)
 - `DBT_NOVA_HTTP_MAX_BODY_BYTES` – global streamable HTTP request body cap (`0` disables the in-process cap, default: `16777216`)
 - `DBT_NOVA_METRICS_ENABLED` – expose the Prometheus-compatible `GET /metrics` endpoint in streamable HTTP mode (`true`|`false`, default: `true`)
-- `DBT_NOVA_AUTH_MODE` – default-off hosted identity parser mode (`off`, `proxy_signed_headers`, or `jwt`; default: `off`). Non-`off` modes fail validation until their verifiers are implemented.
+- `DBT_NOVA_AUTH_MODE` – default-off hosted identity mode (`off`, `proxy_signed_headers`, or `jwt`; default: `off`). `proxy_signed_headers` is enforced when configured; `jwt` remains planned and fails validation until its verifier is implemented.
 - `DBT_NOVA_AUTH_REQUIRED` – require hosted identity for non-`off` modes (`true`|`false`, default: `false`; non-`off` modes default to required when this is unset and fail closed if explicitly false)
-- `DBT_NOVA_IDENTITY_SUBJECT_CLAIM` – stable subject claim/field for future proxy/JWT identity (`sub` by default; required for non-`off` modes)
-- `DBT_NOVA_IDENTITY_EMAIL_CLAIM` – optional email claim/field for future proxy/JWT identity (`email` by default)
-- `DBT_NOVA_IDENTITY_NAME_CLAIM` – optional display-name claim/field for future proxy/JWT identity (`name` by default)
+- `DBT_NOVA_IDENTITY_SUBJECT_CLAIM` – stable subject claim/field for proxy/JWT identity (`sub` by default; required for non-`off` modes)
+- `DBT_NOVA_IDENTITY_EMAIL_CLAIM` – optional email claim/field for proxy/JWT identity (`email` by default)
+- `DBT_NOVA_IDENTITY_NAME_CLAIM` – optional display-name claim/field for proxy/JWT identity (`name` by default)
 - `DBT_NOVA_IDENTITY_GROUPS_CLAIM` – optional groups claim/field reserved for future policy hooks (`groups` by default; no implicit authorization)
-- `DBT_NOVA_PROXY_IDENTITY_HEADER` – planned proxy-signed identity envelope header (required for `proxy_signed_headers`; parsed but not enforced yet)
-- `DBT_NOVA_PROXY_SIGNATURE_HEADER` – planned proxy-signed identity signature header (required for `proxy_signed_headers`; parsed but not enforced yet)
-- `DBT_NOVA_PROXY_IDENTITY_SECRET_FILE` – planned local verification secret file for proxy-signed identity envelopes (required for `proxy_signed_headers`; redacted from config inspection; parsed but not enforced yet)
-- `DBT_NOVA_PROXY_IDENTITY_MAX_AGE_SECS` – planned proxy identity envelope freshness window (`300` by default; must be greater than `0`)
+- `DBT_NOVA_PROXY_IDENTITY_HEADER` – proxy-signed identity envelope header carrying base64url-no-pad JSON with `iat` and the configured subject field (required for `proxy_signed_headers`)
+- `DBT_NOVA_PROXY_SIGNATURE_HEADER` – proxy-signed identity signature header carrying `sha256=<base64url-no-pad HMAC-SHA256>` over the exact identity header value (required for `proxy_signed_headers`)
+- `DBT_NOVA_PROXY_IDENTITY_SECRET_FILE` – local HMAC verification secret file for proxy-signed identity envelopes (required for `proxy_signed_headers`; at least 32 bytes; redacted from config inspection)
+- `DBT_NOVA_PROXY_IDENTITY_MAX_AGE_SECS` – proxy identity envelope freshness window (`300` by default; must be greater than `0`)
 - `DBT_NOVA_JWT_ISSUER` – planned JWT issuer allowlist entry (required for `jwt`; parsed but not enforced yet)
 - `DBT_NOVA_JWT_AUDIENCE` – planned JWT audience allowlist entry (required for `jwt`; parsed but not enforced yet)
 - `DBT_NOVA_JWT_JWKS_URL` – planned HTTPS JWKS endpoint for JWT signature verification (required for `jwt`; sanitized in config inspection; parsed but not enforced yet)
@@ -187,7 +187,7 @@ Remote manifest notes:
 - Published container images set `DBT_NOVA_PRESET=hosted-discovery` by default
   so hosted image starts are discovery-only and non-admin unless an operator
   overrides the preset or clears/customizes the denylist.
-- Streamable HTTP mode has **no built-in authentication** by default. Keep it bound to loopback for local use, or set `DBT_NOVA_HTTP_EXPECT_AUTH_PROXY=true` only when an authenticating reverse proxy is enforcing access in front of dbt-nova. `DBT_NOVA_AUTH_MODE` currently provides a fail-closed parser skeleton only: non-`off` modes fail validation until proxy/JWT verifiers are implemented. For hosted/proxied deployments, set `DBT_NOVA_HTTP_ALLOWED_HOSTS` to the public/proxy hostnames clients send in `Host`. Published container images do not set these acknowledgements by default.
+- Streamable HTTP mode has **no built-in authentication** by default. Keep it bound to loopback for local use, or set `DBT_NOVA_HTTP_EXPECT_AUTH_PROXY=true` only when an authenticating reverse proxy is enforcing access in front of dbt-nova. `DBT_NOVA_AUTH_MODE=proxy_signed_headers` adds default-off HMAC verification for proxy-provided identity envelopes; JWT mode remains fail-closed until implemented. For hosted/proxied deployments, set `DBT_NOVA_HTTP_ALLOWED_HOSTS` to the public/proxy hostnames clients send in `Host`. Published container images do not set these acknowledgements by default.
 - Streamable HTTP mode applies a global request body cap before the mounted MCP transport reads request bodies. Keep `DBT_NOVA_HTTP_MAX_BODY_BYTES` bounded in hosted deployments unless an outer proxy enforces a stricter limit.
 - The MCP endpoint is mounted at `DBT_NOVA_HTTP_PATH`; plain operational
   endpoints are reserved at `/healthz`, `/readyz`, and `/metrics`.

--- a/docs/development/hosted-identity-contract.md
+++ b/docs/development/hosted-identity-contract.md
@@ -1,8 +1,9 @@
 # Hosted Identity Contract
 
-Status: planned contract for JOE-665 and fail-closed config skeleton for
-JOE-662. These settings are parsed by runtime configuration, but non-`off`
-modes are not enforced yet.
+Status: proxy-signed identity implemented for JOE-663; JWT remains a planned,
+fail-closed contract. Proxy settings are parsed and enforced by streamable HTTP
+mode when enabled. JWT settings are parsed for future compatibility but still
+fail validation until a verifier implementation lands.
 
 ## Product Boundary
 
@@ -14,23 +15,22 @@ Identity is not authorization. Tool exposure remains controlled by runtime
 presets, allowlists, denylists, and explicit safety gates. Entity-level and
 warehouse-level authorization stay outside Nova.
 
-## Planned Modes
+## Modes
 
 | Mode | Purpose | Default |
 |---|---|---|
 | `off` | Current behavior: rely on the authenticating proxy or platform layer | Yes |
 | `proxy_signed_headers` | Verify a small signed identity envelope produced by a trusted proxy | No |
-| `jwt` | Validate bearer JWTs at the Nova HTTP boundary | No |
+| `jwt` | Planned bearer JWT validation at the Nova HTTP boundary | No |
 
 Unknown modes fail validation. Non-off modes fail closed when required
-validation material is missing or invalid. Until proxy/JWT verifiers land,
-complete non-`off` configurations also fail validation instead of silently
-running unauthenticated.
+validation material is missing or invalid. `proxy_signed_headers` enforces
+request signatures and freshness when configured. `jwt` still fails validation
+instead of silently running unauthenticated.
 
 ## Planned Config Surface
 
-The names below are the design contract and current parser surface. They are
-parsed but not enforced for non-`off` modes yet.
+The names below are the current config contract.
 
 | Setting | Applies to | Contract |
 |---|---|---|
@@ -40,9 +40,9 @@ parsed but not enforced for non-`off` modes yet.
 | `DBT_NOVA_IDENTITY_EMAIL_CLAIM` | proxy/JWT | Optional email claim; sanitized and never used as an authz decision by default |
 | `DBT_NOVA_IDENTITY_NAME_CLAIM` | proxy/JWT | Optional display-name claim; sanitized |
 | `DBT_NOVA_IDENTITY_GROUPS_CLAIM` | proxy/JWT | Optional groups claim for future policy hooks; no implicit authorization |
-| `DBT_NOVA_PROXY_IDENTITY_HEADER` | proxy mode | Header carrying the identity envelope |
-| `DBT_NOVA_PROXY_SIGNATURE_HEADER` | proxy mode | Header carrying the signature |
-| `DBT_NOVA_PROXY_IDENTITY_SECRET_FILE` | proxy mode | Local file containing the verification secret |
+| `DBT_NOVA_PROXY_IDENTITY_HEADER` | proxy mode | Header carrying the base64url JSON identity envelope |
+| `DBT_NOVA_PROXY_SIGNATURE_HEADER` | proxy mode | Header carrying `sha256=<base64url-no-pad HMAC-SHA256>` |
+| `DBT_NOVA_PROXY_IDENTITY_SECRET_FILE` | proxy mode | Local file containing at least 32 bytes of HMAC verification secret |
 | `DBT_NOVA_PROXY_IDENTITY_MAX_AGE_SECS` | proxy mode | Timestamp freshness window |
 | `DBT_NOVA_JWT_ISSUER` | JWT mode | Required issuer allowlist entry |
 | `DBT_NOVA_JWT_AUDIENCE` | JWT mode | Required audience allowlist entry |
@@ -51,9 +51,31 @@ parsed but not enforced for non-`off` modes yet.
 | `DBT_NOVA_JWT_CLOCK_SKEW_SECS` | JWT mode | Small leeway for `exp` and `nbf` checks |
 
 Secrets and key material must not be logged or returned by `show_config`.
-Config validation should report presence and posture, not raw values.
-Non-`off` modes are parsed but not enforced and therefore fail closed until a
-verifier implementation lands.
+Config validation should report presence and posture, not raw values. JWT mode
+is parsed but not enforced and therefore fails closed until a verifier
+implementation lands.
+
+## Proxy Envelope
+
+For `proxy_signed_headers`, the proxy sets:
+
+- `DBT_NOVA_PROXY_IDENTITY_HEADER`: base64url-no-pad encoded JSON object.
+- `DBT_NOVA_PROXY_SIGNATURE_HEADER`: `sha256=` followed by the base64url-no-pad
+  HMAC-SHA256 signature over the exact identity header value.
+
+The envelope must be a JSON object with:
+
+- `iat`: Unix timestamp in seconds, used with
+  `DBT_NOVA_PROXY_IDENTITY_MAX_AGE_SECS`.
+- the configured `DBT_NOVA_IDENTITY_SUBJECT_CLAIM` field, default `sub`, as a
+  non-empty string.
+
+Optional email, name, and groups fields may be present for future request
+context, but Nova does not use them for authorization.
+
+The proxy must strip any inbound client-supplied identity/signature headers
+before setting its own trusted values. Stale, malformed, missing, oversized, or
+badly signed envelopes return `401 Unauthorized`.
 
 ## Runtime Behavior Contract
 
@@ -70,6 +92,7 @@ Mode `proxy_signed_headers`:
 - Accept identity only from configured headers.
 - Verify signature and timestamp before constructing request identity.
 - Reject malformed, unsigned, stale, or oversized envelopes.
+- Apply the requirement to all hosted HTTP routes, including probes and metrics.
 - Treat identity as request context only.
 
 Mode `jwt`:
@@ -82,10 +105,9 @@ Mode `jwt`:
 
 ## Observability Contract
 
-Identity-aware logs may include bounded `auth_mode`, request ID, and sanitized
-subject hash or subject string only after explicit review. Metrics must not add
-raw subject, email, group, token, query text, entity name, path, or credential
-labels by default.
+Proxy identity logs include bounded `auth_mode` and a SHA-256 subject hash after
+verification. Metrics must not add raw subject, email, group, token, query text,
+entity name, path, or credential labels by default.
 
 ## Tests Before Implementation
 

--- a/docs/development/hosted-identity-threat-model.md
+++ b/docs/development/hosted-identity-threat-model.md
@@ -100,7 +100,7 @@ platform layer and does not construct request identity.
 1. JOE-665: accept this threat model and default-off hosted identity design.
 2. JOE-662: add a fail-closed config skeleton without changing effective
    runtime behavior for mode `off`.
-3. JOE-663: implement proxy-signed identity headers if the design remains
-   valid.
+3. JOE-663: implement proxy-signed identity headers as the first enforced
+   default-off hosted identity mode.
 4. JOE-664: implement JWT validation only after the skeleton and proxy mode are
    reviewed.

--- a/docs/operations/hosted-deployment.md
+++ b/docs/operations/hosted-deployment.md
@@ -5,14 +5,16 @@ service on platforms like Cloud Run.
 
 ## Authentication Requirement
 
-Hosted `streamable_http` mode has no built-in authentication or authorization.
-If you expose it beyond loopback, you must place it behind an authenticating
-reverse proxy or platform auth layer first.
+Hosted `streamable_http` mode has no built-in authentication or authorization by
+default. If you expose it beyond loopback, you must place it behind an
+authenticating reverse proxy or platform auth layer first.
 
-Default-off hosted identity config is parsed as a fail-closed skeleton, but
-proxy-signed headers and JWT validation are not enforced yet. Non-`off`
-`DBT_NOVA_AUTH_MODE` values fail validation until their verifiers land, so the
-current runtime still relies on the proxy or platform layer for authentication.
+Default-off hosted identity config also supports
+`DBT_NOVA_AUTH_MODE=proxy_signed_headers`, where Nova verifies a small HMAC
+identity envelope produced by the trusted proxy. JWT validation remains planned
+and fail-closed until its verifier lands. Proxy identity is request attribution,
+not authorization; the proxy or platform layer remains responsible for
+authenticating users and stripping any client-supplied identity headers.
 See
 [Hosted Identity Threat Model](../development/hosted-identity-threat-model.md)
 and [Hosted Identity Contract](../development/hosted-identity-contract.md).
@@ -36,8 +38,9 @@ Recommended hosted posture:
   intentionally warming semantic caches.
 - Set `DBT_NOVA_HTTP_EXPECT_AUTH_PROXY=true` only when the reverse proxy or
   platform auth layer is actually enforcing authentication.
-- Keep `DBT_NOVA_AUTH_MODE=off` until a verifier implementation lands; non-`off`
-  modes currently fail validation rather than running without enforcement.
+- Leave `DBT_NOVA_AUTH_MODE=off` unless the proxy-signed header contract is
+  configured end to end. JWT mode currently fails validation rather than running
+  without enforcement.
 
 ## Local HTTP Profile
 
@@ -102,6 +105,49 @@ Why these defaults matter:
 - `DBT_NOVA_EMBEDDINGS_CACHE_DIR=/tmp/dbt-nova/models` keeps model cache resolution deterministic.
 - `DBT_NOVA_BOOTSTRAP_URI` should point at the stable bootstrap alias published by the reusable asset workflow.
 - First start should **not** use strict read-only mode. Nova may need to materialize prebuilt assets locally before it can serve traffic.
+
+## Proxy-Signed Identity Mode
+
+Use this mode when a trusted reverse proxy has already authenticated the caller
+and you want Nova to fail closed unless that proxy signs a bounded request
+identity envelope.
+
+Nova config:
+
+```bash
+export DBT_NOVA_AUTH_MODE=proxy_signed_headers
+export DBT_NOVA_AUTH_REQUIRED=true
+export DBT_NOVA_PROXY_IDENTITY_HEADER=X-Nova-Identity
+export DBT_NOVA_PROXY_SIGNATURE_HEADER=X-Nova-Signature
+export DBT_NOVA_PROXY_IDENTITY_SECRET_FILE=/run/secrets/nova_proxy_identity_hmac
+export DBT_NOVA_PROXY_IDENTITY_MAX_AGE_SECS=300
+```
+
+The secret file must contain at least 32 bytes of HMAC secret material. Nova
+reads it locally at startup, trims surrounding ASCII whitespace, and never logs
+or returns the secret through config inspection.
+
+The proxy must:
+
+- authenticate the caller before forwarding to Nova;
+- remove any inbound client-supplied `X-Nova-Identity` and `X-Nova-Signature`
+  headers;
+- set the identity header to base64url-no-pad JSON with `iat` and the configured
+  subject field, default `sub`;
+- set the signature header to `sha256=<base64url-no-pad HMAC-SHA256>`, signing
+  the exact identity header value;
+- keep `/healthz`, `/readyz`, `/metrics`, and the MCP path behind the same
+  signing behavior when proxy mode is enabled.
+
+Example identity JSON before base64url encoding:
+
+```json
+{"sub":"user-123","email":"user@example.com","iat":1784097600}
+```
+
+Nova rejects missing, malformed, oversized, stale, or badly signed envelopes
+with `401 Unauthorized`. Verified identity is recorded as a SHA-256 subject hash
+in logs only; metrics do not add identity labels.
 
 ## Request Correlation
 

--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -54,14 +54,15 @@ it is privacy-safe by label design, but still exposes readiness, tool names,
 call counts, error counts, and latency. Restrict scrapes with the same
 proxy/network ACL as MCP, or set `DBT_NOVA_METRICS_ENABLED=false`.
 
-Hosted identity config is a fail-closed skeleton, not current request
-authentication behavior. `DBT_NOVA_AUTH_MODE=off` is the only effective mode;
-non-`off` proxy/JWT modes fail validation until verifier implementations land.
+Hosted identity is default-off. `DBT_NOVA_AUTH_MODE=proxy_signed_headers`
+enables fail-closed HMAC verification for trusted proxy identity envelopes; JWT
+mode remains planned and fails validation until its verifier implementation
+lands.
 See [Hosted Identity Threat Model](../development/hosted-identity-threat-model.md)
 and [Hosted Identity Contract](../development/hosted-identity-contract.md) for
-the default-off, proxy-first boundaries. Until an implementation lands, treat the
-reverse proxy or platform auth layer as the authentication and authorization
-boundary.
+the default-off, proxy-first boundaries. Treat the reverse proxy or platform
+auth layer as the authentication and authorization boundary; Nova's verified
+proxy identity is attribution context only.
 
 Some tools read from the server filesystem. `validate_nova_meta` validates dbt
 YAML under the server working directory and rejects absolute or traversal paths

--- a/src/cli/config_cmd.rs
+++ b/src/cli/config_cmd.rs
@@ -5,7 +5,9 @@ use serde_json::Value as JsonValue;
 
 use crate::cli::args::{ConfigShowArgs, ConfigValidateArgs};
 use crate::cli::output::{CliEnvelope, error_envelope};
-use crate::config::{ArtifactFetchPolicy, DbtNovaConfig, RuntimePreset, ServerTransport};
+use crate::config::{
+    ArtifactFetchPolicy, DbtNovaConfig, HostedAuthMode, RuntimePreset, ServerTransport,
+};
 use crate::error::{DbtNovaError, Result};
 use crate::manifest::bootstrap::prepare_runtime_config;
 use crate::params::{ConfigShowParams, ConfigValidateParams};
@@ -390,11 +392,17 @@ fn build_validation_checklist(config: &DbtNovaConfig) -> ConfigValidationCheckli
 }
 
 fn build_hosted_auth_posture(config: &DbtNovaConfig) -> HostedAuthPosture {
+    let proxy_mode_enabled = config.hosted_auth.mode == HostedAuthMode::ProxySignedHeaders;
+    let effective_mode = if proxy_mode_enabled {
+        HostedAuthMode::ProxySignedHeaders.as_str()
+    } else {
+        HostedAuthMode::Off.as_str()
+    };
     HostedAuthPosture {
         mode: config.hosted_auth.mode.as_str().to_string(),
-        effective_mode: "off".to_string(),
+        effective_mode: effective_mode.to_string(),
         required: config.hosted_auth.required,
-        non_off_modes_implemented: false,
+        non_off_modes_implemented: proxy_mode_enabled,
         proxy_identity_header_configured: !config
             .hosted_auth
             .proxy_identity_header
@@ -744,6 +752,42 @@ mod tests {
         );
         assert!(
             response["data"]["checklist"]["storage"]["access"]["local_writes_allowed"].is_boolean()
+        );
+    }
+
+    #[test]
+    fn config_validate_reports_proxy_signed_headers_as_effective_auth_mode() {
+        let config = DbtNovaConfig {
+            hosted_auth: HostedAuthConfig {
+                mode: HostedAuthMode::ProxySignedHeaders,
+                required: true,
+                proxy_identity_header: "X-Nova-Identity".to_string(),
+                proxy_signature_header: "X-Nova-Signature".to_string(),
+                proxy_identity_secret_file: "/run/secrets/nova-proxy-key".to_string(),
+                ..HostedAuthConfig::default()
+            },
+            ..DbtNovaConfig::default()
+        };
+
+        let response =
+            build_config_validate_tool_response(&config, &ConfigValidateParams::default())
+                .expect("config validate response");
+
+        assert_eq!(
+            response["data"]["checklist"]["hosted_auth"]["mode"],
+            serde_json::json!("proxy_signed_headers")
+        );
+        assert_eq!(
+            response["data"]["checklist"]["hosted_auth"]["effective_mode"],
+            serde_json::json!("proxy_signed_headers")
+        );
+        assert_eq!(
+            response["data"]["checklist"]["hosted_auth"]["non_off_modes_implemented"],
+            serde_json::json!(true)
+        );
+        assert_eq!(
+            response["data"]["checklist"]["hosted_auth"]["proxy_secret_file_configured"],
+            serde_json::json!(true)
         );
     }
 

--- a/src/cli/server_cmd.rs
+++ b/src/cli/server_cmd.rs
@@ -27,6 +27,7 @@ use crate::manifest::bootstrap::prepare_runtime_config;
 use crate::manifest::search::ManifestSearchHandle;
 use crate::server::correlation::correlate_http_request;
 use crate::server::health::build_manifest_health_payload;
+use crate::server::identity::{ProxyIdentityVerifier, verify_proxy_identity_request};
 use crate::server::mcp::DbtNovaServer;
 use crate::utils::{ToolMetricsStore, sanitize_uri};
 
@@ -43,6 +44,7 @@ struct HttpServerSettings {
     max_body_bytes: usize,
     allowed_hosts: Vec<String>,
     metrics_enabled: bool,
+    proxy_identity_verifier: Option<Arc<ProxyIdentityVerifier>>,
 }
 
 #[derive(Clone)]
@@ -53,8 +55,8 @@ struct HostedProbeState {
 }
 
 impl HttpServerSettings {
-    fn from_config(config: &DbtNovaConfig) -> Self {
-        Self {
+    fn from_config(config: &DbtNovaConfig) -> Result<Self> {
+        Ok(Self {
             host: config.http_host.clone(),
             port: config.http_port,
             path: config.http_path.trim().to_string(),
@@ -64,7 +66,9 @@ impl HttpServerSettings {
             max_body_bytes: config.http_max_body_bytes,
             allowed_hosts: parse_http_allowed_hosts(&config.http_allowed_hosts),
             metrics_enabled: config.metrics_enabled,
-        }
+            proxy_identity_verifier: ProxyIdentityVerifier::from_config(&config.hosted_auth)?
+                .map(Arc::new),
+        })
     }
 }
 
@@ -172,7 +176,11 @@ async fn start_with_config_and_shutdown(
     }
 
     let transport = config.server_transport;
-    let http_settings = HttpServerSettings::from_config(&config);
+    let http_settings = if transport == ServerTransport::StreamableHttp {
+        Some(HttpServerSettings::from_config(&config)?)
+    } else {
+        None
+    };
     let exposed_tools = config.resolved_mcp_tool_names();
     let searcher = ManifestSearchHandle::spawn(config);
     let ready_handle = searcher.clone();
@@ -191,7 +199,13 @@ async fn start_with_config_and_shutdown(
     match transport {
         ServerTransport::Stdio => serve_stdio(server, shutdown).await,
         ServerTransport::StreamableHttp => {
-            serve_streamable_http(server, searcher, http_settings, shutdown).await
+            serve_streamable_http(
+                server,
+                searcher,
+                http_settings.expect("HTTP settings are initialized for streamable HTTP"),
+                shutdown,
+            )
+            .await
         }
     }
 }
@@ -282,6 +296,14 @@ async fn serve_streamable_http(
     };
     let app = if settings.max_body_bytes > 0 {
         app.layer(RequestBodyLimitLayer::new(settings.max_body_bytes))
+    } else {
+        app
+    };
+    let app = if let Some(verifier) = settings.proxy_identity_verifier {
+        app.layer(middleware::from_fn_with_state(
+            verifier,
+            verify_proxy_identity_request,
+        ))
     } else {
         app
     };
@@ -407,7 +429,7 @@ async fn wait_for_shutdown_signal() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use std::sync::{LazyLock, Mutex};
-    use std::time::Duration;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use reqwest::Client;
     use serde_json::{Value, json};
@@ -419,7 +441,10 @@ mod tests {
         HttpServerSettings, apply_start_args, build_start_config, start_with_config_and_shutdown,
     };
     use crate::cli::args::{ServerStartArgs, ServerTransportArg};
-    use crate::config::{DbtNovaConfig, RuntimePreset, SearchConfig, ServerTransport};
+    use crate::config::{
+        DbtNovaConfig, HostedAuthMode, RuntimePreset, SearchConfig, ServerTransport,
+    };
+    use crate::server::identity::{encode_proxy_identity_for_tests, sign_proxy_identity_for_tests};
     use crate::tests::common::fixture_manifest_path_string;
 
     static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
@@ -675,7 +700,7 @@ mod tests {
             ..Default::default()
         };
 
-        let settings = HttpServerSettings::from_config(&config);
+        let settings = HttpServerSettings::from_config(&config).expect("settings");
 
         assert_eq!(settings.max_body_bytes, 16 * 1024 * 1024);
         assert_eq!(
@@ -745,6 +770,35 @@ mod tests {
             }
             None => panic!("timed out waiting for {url} to return {expected_status}"),
         }
+    }
+
+    const TEST_PROXY_SECRET: &[u8] = b"0123456789abcdef0123456789abcdef";
+
+    fn enable_proxy_identity(config: &mut DbtNovaConfig, temp_dir: &TempDir) {
+        let secret_file = temp_dir.path().join("nova-proxy-identity-secret");
+        std::fs::write(&secret_file, TEST_PROXY_SECRET).expect("write proxy identity secret");
+        config.hosted_auth.mode = HostedAuthMode::ProxySignedHeaders;
+        config.hosted_auth.required = true;
+        config.hosted_auth.proxy_identity_header = "X-Nova-Identity".to_string();
+        config.hosted_auth.proxy_signature_header = "X-Nova-Signature".to_string();
+        config.hosted_auth.proxy_identity_secret_file = secret_file.display().to_string();
+        config.hosted_auth.proxy_identity_max_age_secs = 300;
+    }
+
+    fn unix_now_secs_for_test() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock after epoch")
+            .as_secs()
+    }
+
+    fn signed_proxy_identity_headers(subject: &str, iat: u64) -> (String, String) {
+        let identity = encode_proxy_identity_for_tests(&json!({
+            "sub": subject,
+            "iat": iat,
+        }));
+        let signature = sign_proxy_identity_for_tests(TEST_PROXY_SECRET, &identity);
+        (identity, signature)
     }
 
     #[tokio::test]
@@ -828,6 +882,150 @@ mod tests {
             "unexpected body: {body}"
         );
         assert!(body.contains(r#""id":1"#), "unexpected body: {body}");
+    }
+
+    #[tokio::test]
+    async fn http_transport_accepts_signed_proxy_identity_when_enabled() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let port = next_test_port().await;
+        let shutdown = CancellationToken::new();
+        let mut config = http_test_config(&temp_dir, fixture_manifest_path_string(), port);
+        enable_proxy_identity(&mut config, &temp_dir);
+        let (identity, signature) =
+            signed_proxy_identity_headers("user@example.com", unix_now_secs_for_test());
+
+        let server_task = tokio::spawn(start_with_config_and_shutdown(config, shutdown.clone()));
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        let client = Client::new();
+
+        let response = client
+            .get(format!("http://127.0.0.1:{port}/healthz"))
+            .header("X-Nova-Identity", identity)
+            .header("X-Nova-Signature", signature)
+            .send()
+            .await
+            .expect("liveness request should succeed");
+        let status = response.status();
+        let body = response.text().await.expect("liveness body");
+
+        shutdown.cancel();
+        let join_result = server_task.await.expect("server task");
+        assert!(
+            join_result.is_ok(),
+            "server should shut down cleanly: {join_result:?}"
+        );
+
+        assert_eq!(status, reqwest::StatusCode::OK, "{body}");
+        assert!(!body.contains("user@example.com"));
+    }
+
+    #[tokio::test]
+    async fn http_transport_rejects_missing_proxy_identity_when_enabled() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let port = next_test_port().await;
+        let shutdown = CancellationToken::new();
+        let mut config = http_test_config(&temp_dir, fixture_manifest_path_string(), port);
+        enable_proxy_identity(&mut config, &temp_dir);
+
+        let server_task = tokio::spawn(start_with_config_and_shutdown(config, shutdown.clone()));
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        let client = Client::new();
+
+        let response = client
+            .get(format!("http://127.0.0.1:{port}/healthz"))
+            .send()
+            .await
+            .expect("liveness request should succeed");
+        let status = response.status();
+        let body = response.text().await.expect("auth error body");
+
+        shutdown.cancel();
+        let join_result = server_task.await.expect("server task");
+        assert!(
+            join_result.is_ok(),
+            "server should shut down cleanly: {join_result:?}"
+        );
+
+        assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED);
+        assert!(body.contains("UNAUTHORIZED"));
+        assert!(!body.contains("secret"));
+    }
+
+    #[tokio::test]
+    async fn http_transport_rejects_invalid_proxy_identity_signature() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let port = next_test_port().await;
+        let shutdown = CancellationToken::new();
+        let mut config = http_test_config(&temp_dir, fixture_manifest_path_string(), port);
+        enable_proxy_identity(&mut config, &temp_dir);
+        let identity = encode_proxy_identity_for_tests(&json!({
+            "sub": "user@example.com",
+            "iat": unix_now_secs_for_test(),
+        }));
+        let signature =
+            sign_proxy_identity_for_tests(b"abcdef0123456789abcdef0123456789", &identity);
+
+        let server_task = tokio::spawn(start_with_config_and_shutdown(config, shutdown.clone()));
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        let client = Client::new();
+
+        let response = client
+            .get(format!("http://127.0.0.1:{port}/healthz"))
+            .header("X-Nova-Identity", identity)
+            .header("X-Nova-Signature", signature)
+            .send()
+            .await
+            .expect("liveness request should succeed");
+        let status = response.status();
+        let body = response.text().await.expect("auth error body");
+
+        shutdown.cancel();
+        let join_result = server_task.await.expect("server task");
+        assert!(
+            join_result.is_ok(),
+            "server should shut down cleanly: {join_result:?}"
+        );
+
+        assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED);
+        assert!(body.contains("hosted identity verification failed"));
+        assert!(!body.contains("user@example.com"));
+    }
+
+    #[tokio::test]
+    async fn http_transport_rejects_stale_proxy_identity() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let port = next_test_port().await;
+        let shutdown = CancellationToken::new();
+        let mut config = http_test_config(&temp_dir, fixture_manifest_path_string(), port);
+        enable_proxy_identity(&mut config, &temp_dir);
+        config.hosted_auth.proxy_identity_max_age_secs = 1;
+        let stale_iat = unix_now_secs_for_test().saturating_sub(10);
+        let (identity, signature) = signed_proxy_identity_headers("user@example.com", stale_iat);
+
+        let server_task = tokio::spawn(start_with_config_and_shutdown(config, shutdown.clone()));
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        let client = Client::new();
+
+        let response = client
+            .get(format!("http://127.0.0.1:{port}/healthz"))
+            .header("X-Nova-Identity", identity)
+            .header("X-Nova-Signature", signature)
+            .send()
+            .await
+            .expect("liveness request should succeed");
+        let status = response.status();
+        let body = response.text().await.expect("auth error body");
+
+        shutdown.cancel();
+        let join_result = server_task.await.expect("server task");
+        assert!(
+            join_result.is_ok(),
+            "server should shut down cleanly: {join_result:?}"
+        );
+
+        assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED);
+        assert!(body.contains("hosted identity verification failed"));
+        assert!(!body.contains("user@example.com"));
     }
 
     #[tokio::test]

--- a/src/config/core.rs
+++ b/src/config/core.rs
@@ -433,7 +433,7 @@ pub struct DbtNovaConfig {
     pub http_max_body_bytes: usize,
     /// Expose the Prometheus-compatible `/metrics` endpoint in hosted HTTP mode.
     pub metrics_enabled: bool,
-    /// Default-off hosted HTTP identity/authentication skeleton.
+    /// Default-off hosted HTTP identity/authentication config.
     pub hosted_auth: HostedAuthConfig,
     /// Per-tool rate limits (comma-separated, e.g. "`search=60,execute_sql=30,default=120`")
     pub tool_rate_limits: String,

--- a/src/config/core/tests.rs
+++ b/src/config/core/tests.rs
@@ -275,13 +275,23 @@ fn from_env_defaults_non_off_hosted_auth_to_required() {
 
     assert_eq!(config.hosted_auth.mode, HostedAuthMode::ProxySignedHeaders);
     assert!(config.hosted_auth.required);
+    config
+        .validate()
+        .expect("complete proxy-signed header mode should validate");
+}
+
+#[test]
+fn validate_rejects_incomplete_proxy_signed_header_mode() {
+    let config = with_env_vars(
+        &[("DBT_NOVA_AUTH_MODE", Some("proxy_signed_headers"))],
+        DbtNovaConfig::from_env,
+    );
+
     let error = config
         .validate()
-        .expect_err("parsed-but-unimplemented proxy mode should fail closed");
+        .expect_err("incomplete proxy mode should fail validation");
     assert!(
-        error
-            .to_string()
-            .contains("proxy_signed_headers is parsed but not implemented yet"),
+        error.to_string().contains("DBT_NOVA_PROXY_IDENTITY_HEADER"),
         "unexpected error: {error}"
     );
 }
@@ -727,6 +737,27 @@ fn validate_rejects_exposed_http_transport_without_auth_proxy_ack() {
     let error = config
         .validate()
         .expect_err("public HTTP bind without auth proxy acknowledgement should fail");
+    assert!(
+        error
+            .to_string()
+            .contains("DBT_NOVA_HTTP_EXPECT_AUTH_PROXY=true")
+    );
+}
+
+#[test]
+fn validate_rejects_exposed_proxy_identity_mode_without_auth_proxy_ack() {
+    let mut config = base_config();
+    config.server_transport = ServerTransport::StreamableHttp;
+    config.http_host = "0.0.0.0".to_string();
+    config.hosted_auth.mode = HostedAuthMode::ProxySignedHeaders;
+    config.hosted_auth.required = true;
+    config.hosted_auth.proxy_identity_header = "X-Nova-Identity".to_string();
+    config.hosted_auth.proxy_signature_header = "X-Nova-Signature".to_string();
+    config.hosted_auth.proxy_identity_secret_file = "/run/secrets/nova-proxy-key".to_string();
+
+    let error = config
+        .validate()
+        .expect_err("proxy identity mode still needs auth proxy acknowledgement");
     assert!(
         error
             .to_string()

--- a/src/config/hosted_auth.rs
+++ b/src/config/hosted_auth.rs
@@ -2,14 +2,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{DbtNovaError, Result};
 
-/// Planned hosted authentication modes for streamable HTTP deployments.
+/// Hosted authentication modes for streamable HTTP deployments.
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum HostedAuthMode {
     /// Current behavior: rely on the external proxy/platform boundary.
     #[default]
     Off,
-    /// Planned signed identity envelope from a trusted reverse proxy.
+    /// Signed identity envelope from a trusted reverse proxy.
     ProxySignedHeaders,
     /// Planned bearer JWT validation at the Nova HTTP boundary.
     Jwt,
@@ -38,15 +38,15 @@ impl HostedAuthMode {
     }
 }
 
-/// Default-off skeleton for future hosted HTTP identity validation.
+/// Default-off hosted HTTP identity validation config.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct HostedAuthConfig {
-    /// Hosted auth mode. Non-off modes are parsed but not enforced yet.
+    /// Hosted auth mode. Proxy mode is implemented; JWT remains planned.
     pub mode: HostedAuthMode,
     /// Whether authentication must be present for hosted requests.
     pub required: bool,
-    /// Claim/field used as stable request subject in future modes.
+    /// Claim/field used as stable request subject.
     pub identity_subject_claim: String,
     /// Optional email claim/field.
     pub identity_email_claim: String,
@@ -54,9 +54,9 @@ pub struct HostedAuthConfig {
     pub identity_name_claim: String,
     /// Optional groups claim/field reserved for future policy hooks.
     pub identity_groups_claim: String,
-    /// Proxy-mode identity envelope header.
+    /// Proxy-mode base64url JSON identity envelope header.
     pub proxy_identity_header: String,
-    /// Proxy-mode signature header.
+    /// Proxy-mode HMAC-SHA256 signature header.
     pub proxy_signature_header: String,
     /// Proxy-mode local secret file used for envelope verification.
     pub proxy_identity_secret_file: String,
@@ -97,7 +97,7 @@ impl Default for HostedAuthConfig {
 }
 
 impl HostedAuthConfig {
-    /// Validate the skeleton without enabling authentication behavior.
+    /// Validate hosted auth configuration.
     ///
     /// # Errors
     /// Returns an error for unknown/incomplete/misleading auth configuration.
@@ -106,7 +106,7 @@ impl HostedAuthConfig {
             HostedAuthMode::Off => {
                 if self.required {
                     return Err(DbtNovaError::InvalidParams(
-                        "DBT_NOVA_AUTH_REQUIRED=true requires DBT_NOVA_AUTH_MODE=proxy_signed_headers or jwt, but non-off hosted auth modes are not implemented yet"
+                        "DBT_NOVA_AUTH_REQUIRED=true requires DBT_NOVA_AUTH_MODE=proxy_signed_headers or jwt"
                             .to_string(),
                     ));
                 }
@@ -114,7 +114,7 @@ impl HostedAuthConfig {
             }
             HostedAuthMode::ProxySignedHeaders => {
                 self.validate_proxy_signed_headers()?;
-                Err(non_off_auth_mode_unimplemented_error(self.mode))
+                Ok(())
             }
             HostedAuthMode::Jwt => {
                 self.validate_jwt()?;
@@ -184,7 +184,7 @@ impl HostedAuthConfig {
 
 fn non_off_auth_mode_unimplemented_error(mode: HostedAuthMode) -> DbtNovaError {
     DbtNovaError::InvalidParams(format!(
-        "DBT_NOVA_AUTH_MODE={} is parsed but not implemented yet; keep DBT_NOVA_AUTH_MODE=off until hosted identity verification lands",
+        "DBT_NOVA_AUTH_MODE={} is parsed but not implemented yet; use DBT_NOVA_AUTH_MODE=proxy_signed_headers or off until its verifier lands",
         mode.as_str()
     ))
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,7 +4,7 @@
 //! - `core`: Core settings (manifest, storage, logging)
 //! - `search`: Search configuration and persona weights
 //! - `column_lineage`: Column lineage tracing settings
-//! - `hosted_auth`: Default-off hosted HTTP authentication config skeleton
+//! - `hosted_auth`: Default-off hosted HTTP authentication config
 //! - `metadata_score`: Metadata scoring configuration
 //! - `warehouse`: Warehouse connection settings
 

--- a/src/server/identity.rs
+++ b/src/server/identity.rs
@@ -1,0 +1,451 @@
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use axum::{
+    extract::{Request, State},
+    http::{HeaderMap, HeaderName, StatusCode, header},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use base64::Engine as _;
+use hmac::{Hmac, Mac};
+use serde_json::Value as JsonValue;
+use sha2::{Digest, Sha256};
+use tracing::warn;
+
+use crate::config::{HostedAuthConfig, HostedAuthMode};
+use crate::error::{DbtNovaError, Result};
+
+const SIGNATURE_PREFIX: &str = "sha256=";
+const MAX_IDENTITY_HEADER_BYTES: usize = 8 * 1024;
+const MAX_SIGNATURE_HEADER_BYTES: usize = 256;
+const MAX_SECRET_FILE_BYTES: usize = 64 * 1024;
+const MIN_SECRET_BYTES: usize = 32;
+const FUTURE_IAT_SKEW_SECS: u64 = 60;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Sanitized request identity verified from trusted proxy headers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RequestIdentity {
+    pub mode: HostedAuthMode,
+    pub subject_hash: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ProxyIdentityVerifier {
+    identity_header: HeaderName,
+    signature_header: HeaderName,
+    subject_claim: String,
+    max_age: Duration,
+    secret: Arc<Vec<u8>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VerificationError {
+    MissingIdentity,
+    MissingSignature,
+    MalformedIdentity,
+    InvalidSignature,
+    StaleIdentity,
+}
+
+impl ProxyIdentityVerifier {
+    /// Build a proxy identity verifier from validated hosted auth config.
+    ///
+    /// # Errors
+    /// Returns an error when header names are invalid or the secret file cannot
+    /// be loaded safely.
+    pub(crate) fn from_config(config: &HostedAuthConfig) -> Result<Option<Self>> {
+        if config.mode != HostedAuthMode::ProxySignedHeaders {
+            return Ok(None);
+        }
+        let identity_header = parse_header_name(
+            "DBT_NOVA_PROXY_IDENTITY_HEADER",
+            &config.proxy_identity_header,
+        )?;
+        let signature_header = parse_header_name(
+            "DBT_NOVA_PROXY_SIGNATURE_HEADER",
+            &config.proxy_signature_header,
+        )?;
+        if identity_header == signature_header {
+            return Err(DbtNovaError::InvalidParams(
+                "DBT_NOVA_PROXY_IDENTITY_HEADER and DBT_NOVA_PROXY_SIGNATURE_HEADER must be different"
+                    .to_string(),
+            ));
+        }
+        let secret = read_proxy_identity_secret(&config.proxy_identity_secret_file)?;
+        Ok(Some(Self {
+            identity_header,
+            signature_header,
+            subject_claim: config.identity_subject_claim.trim().to_string(),
+            max_age: Duration::from_secs(config.proxy_identity_max_age_secs),
+            secret: Arc::new(secret),
+        }))
+    }
+
+    fn verify_headers(
+        &self,
+        headers: &HeaderMap,
+    ) -> std::result::Result<RequestIdentity, VerificationError> {
+        self.verify_headers_at(headers, unix_now_secs())
+    }
+
+    fn verify_headers_at(
+        &self,
+        headers: &HeaderMap,
+        now_secs: u64,
+    ) -> std::result::Result<RequestIdentity, VerificationError> {
+        let identity = header_value(headers, &self.identity_header, MAX_IDENTITY_HEADER_BYTES)
+            .ok_or(VerificationError::MissingIdentity)?;
+        let signature = header_value(headers, &self.signature_header, MAX_SIGNATURE_HEADER_BYTES)
+            .ok_or(VerificationError::MissingSignature)?;
+        self.verify_header_values_at(identity, signature, now_secs)
+    }
+
+    fn verify_header_values_at(
+        &self,
+        identity_header_value: &str,
+        signature_header_value: &str,
+        now_secs: u64,
+    ) -> std::result::Result<RequestIdentity, VerificationError> {
+        verify_signature(
+            identity_header_value.as_bytes(),
+            signature_header_value,
+            &self.secret,
+        )?;
+        let envelope = decode_identity_envelope(identity_header_value)?;
+        let iat = envelope_iat(&envelope)?;
+        if iat > now_secs.saturating_add(FUTURE_IAT_SKEW_SECS) {
+            return Err(VerificationError::StaleIdentity);
+        }
+        if now_secs.saturating_sub(iat) > self.max_age.as_secs() {
+            return Err(VerificationError::StaleIdentity);
+        }
+        let subject = envelope
+            .get(&self.subject_claim)
+            .and_then(JsonValue::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or(VerificationError::MalformedIdentity)?;
+        Ok(RequestIdentity {
+            mode: HostedAuthMode::ProxySignedHeaders,
+            subject_hash: sha256_hex(subject.as_bytes()),
+        })
+    }
+}
+
+pub(crate) async fn verify_proxy_identity_request(
+    State(verifier): State<Arc<ProxyIdentityVerifier>>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    match verifier.verify_headers(request.headers()) {
+        Ok(identity) => {
+            tracing::info!(
+                auth_mode = identity.mode.as_str(),
+                subject_hash = %identity.subject_hash,
+                "hosted proxy identity verified"
+            );
+            request.extensions_mut().insert(identity);
+            next.run(request).await
+        }
+        Err(error) => {
+            warn!(
+                auth_mode = HostedAuthMode::ProxySignedHeaders.as_str(),
+                reason = error.reason(),
+                "hosted proxy identity verification failed"
+            );
+            unauthorized_identity_response()
+        }
+    }
+}
+
+impl VerificationError {
+    const fn reason(self) -> &'static str {
+        match self {
+            Self::MissingIdentity => "missing_identity_header",
+            Self::MissingSignature => "missing_signature_header",
+            Self::MalformedIdentity => "malformed_identity_envelope",
+            Self::InvalidSignature => "invalid_signature",
+            Self::StaleIdentity => "stale_identity_envelope",
+        }
+    }
+}
+
+fn unauthorized_identity_response() -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        [(header::CONTENT_TYPE, "application/json")],
+        serde_json::json!({
+            "success": false,
+            "error": "hosted identity verification failed",
+            "error_code": "UNAUTHORIZED"
+        })
+        .to_string(),
+    )
+        .into_response()
+}
+
+fn parse_header_name(name: &str, value: &str) -> Result<HeaderName> {
+    HeaderName::from_bytes(value.trim().as_bytes()).map_err(|_| {
+        DbtNovaError::InvalidParams(format!(
+            "{name} must be a valid HTTP header name for proxy identity mode"
+        ))
+    })
+}
+
+fn read_proxy_identity_secret(path: &str) -> Result<Vec<u8>> {
+    let path = path.trim();
+    let metadata = std::fs::metadata(path).map_err(|error| {
+        DbtNovaError::InvalidParams(format!(
+            "DBT_NOVA_PROXY_IDENTITY_SECRET_FILE could not be read: {error}"
+        ))
+    })?;
+    if !metadata.is_file() {
+        return Err(DbtNovaError::InvalidParams(
+            "DBT_NOVA_PROXY_IDENTITY_SECRET_FILE must point to a regular file".to_string(),
+        ));
+    }
+    if metadata.len() > MAX_SECRET_FILE_BYTES as u64 {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "DBT_NOVA_PROXY_IDENTITY_SECRET_FILE must be at most {MAX_SECRET_FILE_BYTES} bytes"
+        )));
+    }
+    let mut secret = std::fs::read(path).map_err(|error| {
+        DbtNovaError::InvalidParams(format!(
+            "DBT_NOVA_PROXY_IDENTITY_SECRET_FILE could not be read: {error}"
+        ))
+    })?;
+    trim_ascii_whitespace(&mut secret);
+    if secret.len() < MIN_SECRET_BYTES {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "DBT_NOVA_PROXY_IDENTITY_SECRET_FILE must contain at least {MIN_SECRET_BYTES} bytes of secret material"
+        )));
+    }
+    Ok(secret)
+}
+
+fn header_value<'a>(
+    headers: &'a HeaderMap,
+    name: &HeaderName,
+    max_bytes: usize,
+) -> Option<&'a str> {
+    let value = headers.get(name)?.to_str().ok()?;
+    if value.trim().is_empty() || value.len() > max_bytes {
+        return None;
+    }
+    Some(value)
+}
+
+fn decode_identity_envelope(value: &str) -> std::result::Result<JsonValue, VerificationError> {
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(value)
+        .map_err(|_| VerificationError::MalformedIdentity)?;
+    if decoded.len() > MAX_IDENTITY_HEADER_BYTES {
+        return Err(VerificationError::MalformedIdentity);
+    }
+    let envelope: JsonValue =
+        serde_json::from_slice(&decoded).map_err(|_| VerificationError::MalformedIdentity)?;
+    if !envelope.is_object() {
+        return Err(VerificationError::MalformedIdentity);
+    }
+    Ok(envelope)
+}
+
+fn envelope_iat(envelope: &JsonValue) -> std::result::Result<u64, VerificationError> {
+    match envelope.get("iat") {
+        Some(JsonValue::Number(number)) => {
+            number.as_u64().ok_or(VerificationError::MalformedIdentity)
+        }
+        Some(JsonValue::String(value)) => value
+            .parse::<u64>()
+            .map_err(|_| VerificationError::MalformedIdentity),
+        _ => Err(VerificationError::MalformedIdentity),
+    }
+}
+
+fn verify_signature(
+    identity_header_value: &[u8],
+    signature_header_value: &str,
+    secret: &[u8],
+) -> std::result::Result<(), VerificationError> {
+    let signature = signature_header_value
+        .strip_prefix(SIGNATURE_PREFIX)
+        .ok_or(VerificationError::InvalidSignature)?;
+    let signature = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(signature)
+        .map_err(|_| VerificationError::InvalidSignature)?;
+    let mut mac =
+        HmacSha256::new_from_slice(secret).map_err(|_| VerificationError::InvalidSignature)?;
+    mac.update(identity_header_value);
+    mac.verify_slice(&signature)
+        .map_err(|_| VerificationError::InvalidSignature)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+fn trim_ascii_whitespace(bytes: &mut Vec<u8>) {
+    while bytes.last().is_some_and(u8::is_ascii_whitespace) {
+        bytes.pop();
+    }
+    let first_non_ws = bytes
+        .iter()
+        .position(|byte| !byte.is_ascii_whitespace())
+        .unwrap_or(bytes.len());
+    if first_non_ws > 0 {
+        bytes.drain(..first_non_ws);
+    }
+}
+
+fn unix_now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_secs())
+}
+
+#[cfg(test)]
+pub(crate) fn encode_proxy_identity_for_tests(value: &JsonValue) -> String {
+    let bytes = serde_json::to_vec(value).expect("test identity JSON");
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+#[cfg(test)]
+pub(crate) fn sign_proxy_identity_for_tests(secret: &[u8], identity_header_value: &str) -> String {
+    let mut mac = HmacSha256::new_from_slice(secret).expect("HMAC accepts test keys");
+    mac.update(identity_header_value.as_bytes());
+    let signature = mac.finalize().into_bytes();
+    format!(
+        "{SIGNATURE_PREFIX}{}",
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(signature)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::HeaderMap;
+    use serde_json::json;
+
+    use super::{
+        HostedAuthMode, ProxyIdentityVerifier, VerificationError, encode_proxy_identity_for_tests,
+        sign_proxy_identity_for_tests,
+    };
+
+    const SECRET: &[u8] = b"0123456789abcdef0123456789abcdef";
+
+    fn verifier(max_age_secs: u64) -> ProxyIdentityVerifier {
+        ProxyIdentityVerifier {
+            identity_header: "x-nova-identity".parse().unwrap(),
+            signature_header: "x-nova-signature".parse().unwrap(),
+            subject_claim: "sub".to_string(),
+            max_age: std::time::Duration::from_secs(max_age_secs),
+            secret: std::sync::Arc::new(SECRET.to_vec()),
+        }
+    }
+
+    fn signed_headers(identity: &str, signature: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-nova-identity", identity.parse().unwrap());
+        headers.insert("x-nova-signature", signature.parse().unwrap());
+        headers
+    }
+
+    #[test]
+    fn proxy_identity_accepts_valid_hmac_envelope() {
+        let identity = encode_proxy_identity_for_tests(&json!({
+            "sub": "user@example.com",
+            "iat": 100,
+        }));
+        let signature = sign_proxy_identity_for_tests(SECRET, &identity);
+
+        let verified = verifier(300)
+            .verify_header_values_at(&identity, &signature, 120)
+            .expect("identity should verify");
+
+        assert_eq!(verified.mode, HostedAuthMode::ProxySignedHeaders);
+        assert_eq!(verified.subject_hash.len(), 64);
+        assert_ne!(verified.subject_hash, "user@example.com");
+    }
+
+    #[test]
+    fn proxy_identity_rejects_invalid_signature() {
+        let identity = encode_proxy_identity_for_tests(&json!({
+            "sub": "user@example.com",
+            "iat": 100,
+        }));
+        let signature =
+            sign_proxy_identity_for_tests(b"abcdef0123456789abcdef0123456789", &identity);
+
+        let error = verifier(300)
+            .verify_header_values_at(&identity, &signature, 120)
+            .expect_err("wrong secret should fail");
+
+        assert_eq!(error, VerificationError::InvalidSignature);
+    }
+
+    #[test]
+    fn proxy_identity_rejects_tampered_header_whitespace() {
+        let identity = encode_proxy_identity_for_tests(&json!({
+            "sub": "user@example.com",
+            "iat": 100,
+        }));
+        let signature = sign_proxy_identity_for_tests(SECRET, &identity);
+        let tampered_identity = format!(" {identity}");
+
+        let error = verifier(300)
+            .verify_header_values_at(&tampered_identity, &signature, 120)
+            .expect_err("signature should cover exact header value");
+
+        assert_eq!(error, VerificationError::InvalidSignature);
+    }
+
+    #[test]
+    fn proxy_identity_rejects_stale_envelope() {
+        let identity = encode_proxy_identity_for_tests(&json!({
+            "sub": "user@example.com",
+            "iat": 100,
+        }));
+        let signature = sign_proxy_identity_for_tests(SECRET, &identity);
+
+        let error = verifier(30)
+            .verify_header_values_at(&identity, &signature, 200)
+            .expect_err("stale identity should fail");
+
+        assert_eq!(error, VerificationError::StaleIdentity);
+    }
+
+    #[test]
+    fn proxy_identity_rejects_missing_subject() {
+        let identity = encode_proxy_identity_for_tests(&json!({
+            "iat": 100,
+        }));
+        let signature = sign_proxy_identity_for_tests(SECRET, &identity);
+
+        let error = verifier(300)
+            .verify_header_values_at(&identity, &signature, 120)
+            .expect_err("subject is required");
+
+        assert_eq!(error, VerificationError::MalformedIdentity);
+    }
+
+    #[test]
+    fn proxy_identity_rejects_oversized_header_as_missing() {
+        let identity = "a".repeat(super::MAX_IDENTITY_HEADER_BYTES + 1);
+        let signature = sign_proxy_identity_for_tests(SECRET, &identity);
+        let headers = signed_headers(&identity, &signature);
+
+        let error = verifier(300)
+            .verify_headers_at(&headers, 120)
+            .expect_err("oversized identity header should fail");
+
+        assert_eq!(error, VerificationError::MissingIdentity);
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,5 +1,6 @@
 pub mod correlation;
 pub mod health;
+pub(crate) mod identity;
 pub mod mcp;
 
 pub use mcp::DbtNovaServer;

--- a/tests/hosted_identity_docs.rs
+++ b/tests/hosted_identity_docs.rs
@@ -33,17 +33,21 @@ fn hosted_identity_docs_lock_default_off_guardrails() {
 }
 
 #[test]
-fn hosted_identity_contract_is_documented_as_fail_closed_config_skeleton() {
+fn hosted_identity_contract_documents_proxy_mode_and_jwt_fail_closed() {
     let contract = read_doc("docs/development/hosted-identity-contract.md");
     let config_reference = read_doc("docs/configuration/reference.md");
+    let hosted_deployment = read_doc("docs/operations/hosted-deployment.md");
 
     assert!(contract.contains("DBT_NOVA_AUTH_MODE"));
     assert!(contract.contains("proxy_signed_headers"));
     assert!(contract.contains("jwt"));
-    assert!(contract.contains("parsed but not enforced"));
+    assert!(contract.contains("Proxy Envelope"));
+    assert!(contract.contains("HMAC-SHA256"));
     assert!(config_reference.contains("DBT_NOVA_AUTH_MODE"));
+    assert!(config_reference.contains("proxy_signed_headers` is enforced"));
+    assert!(hosted_deployment.contains("Proxy-Signed Identity Mode"));
     assert!(
-        config_reference.contains("fail validation until their verifiers are implemented"),
-        "runtime config reference must describe hosted auth as fail-closed skeleton"
+        config_reference.contains("`jwt` remains planned and fails validation"),
+        "runtime config reference must describe JWT as fail-closed"
     );
 }


### PR DESCRIPTION
## Summary
- implements `DBT_NOVA_AUTH_MODE=proxy_signed_headers` for streamable HTTP using a trusted-proxy base64url JSON identity envelope plus `sha256=` HMAC-SHA256 signature
- applies fail-closed identity verification to hosted HTTP routes when proxy mode is enabled, with sanitized request identity context and no raw subject logging
- updates config posture, docs, changelog, and guardrail tests while keeping JWT mode planned and fail-closed

## Validation
- `cargo fmt --check`
- `git diff --check`
- `uv run mkdocs build --strict`
- Earlier in this branch: targeted proxy/config/docs tests passed before the final dependency/wiring polish (`cargo test --locked server::identity --lib`, selected HTTP proxy identity tests, selected config validation tests, `cargo test --locked --test hosted_identity_docs`, `bash scripts/check_config_reference.sh`, `bash scripts/check_module_size.sh`).
- Attempted a fresh default-feature cargo test/config-reference compile after the HMAC dependency change, but the local machine was saturated by another Rust build and the command was interrupted without diagnostics; GitHub CI is the authoritative full check.

Linear: JOE-663
