### PR TITLE
Validate hosted JWT identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,10 +71,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   TIMESTAMP, and TIME values serialize as ISO-style strings instead of raw
   epoch-day or tick integers.
 - Added default-off hosted identity config and implemented proxy-signed HMAC
-  header verification for streamable HTTP, while keeping JWT validation planned
-  and fail-closed.
-- Added design-only hosted identity and JWT threat-model docs, planned config
-  contract docs, and guardrail tests for the default-off identity milestone.
+  header verification plus bearer JWT/JWKS validation for streamable HTTP.
+- Added hosted identity threat-model docs, config contract docs, and guardrail
+  tests for the default-off identity milestone.
 - Added machine-checked MCP tool stability metadata, profile membership docs,
   and safety-gate posture for the canonical 53-tool catalog while preserving
   v0.0.x versioning.

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -49,7 +49,7 @@ see [Modes & Combinations](../getting-started/modes-and-combinations.md).
 - `DBT_NOVA_HTTP_SSE_RETRY_SECS` – SSE retry hint for streamable HTTP mode (`0` disables retry hints, default: `3`)
 - `DBT_NOVA_HTTP_MAX_BODY_BYTES` – global streamable HTTP request body cap (`0` disables the in-process cap, default: `16777216`)
 - `DBT_NOVA_METRICS_ENABLED` – expose the Prometheus-compatible `GET /metrics` endpoint in streamable HTTP mode (`true`|`false`, default: `true`)
-- `DBT_NOVA_AUTH_MODE` – default-off hosted identity mode (`off`, `proxy_signed_headers`, or `jwt`; default: `off`). `proxy_signed_headers` is enforced when configured; `jwt` remains planned and fails validation until its verifier is implemented.
+- `DBT_NOVA_AUTH_MODE` – default-off hosted identity mode (`off`, `proxy_signed_headers`, or `jwt`; default: `off`). `proxy_signed_headers` and `jwt` are enforced when configured.
 - `DBT_NOVA_AUTH_REQUIRED` – require hosted identity for non-`off` modes (`true`|`false`, default: `false`; non-`off` modes default to required when this is unset and fail closed if explicitly false)
 - `DBT_NOVA_IDENTITY_SUBJECT_CLAIM` – stable subject claim/field for proxy/JWT identity (`sub` by default; required for non-`off` modes)
 - `DBT_NOVA_IDENTITY_EMAIL_CLAIM` – optional email claim/field for proxy/JWT identity (`email` by default)
@@ -59,11 +59,11 @@ see [Modes & Combinations](../getting-started/modes-and-combinations.md).
 - `DBT_NOVA_PROXY_SIGNATURE_HEADER` – proxy-signed identity signature header carrying `sha256=<base64url-no-pad HMAC-SHA256>` over the exact identity header value (required for `proxy_signed_headers`)
 - `DBT_NOVA_PROXY_IDENTITY_SECRET_FILE` – local HMAC verification secret file for proxy-signed identity envelopes (required for `proxy_signed_headers`; at least 32 bytes; redacted from config inspection)
 - `DBT_NOVA_PROXY_IDENTITY_MAX_AGE_SECS` – proxy identity envelope freshness window (`300` by default; must be greater than `0`)
-- `DBT_NOVA_JWT_ISSUER` – planned JWT issuer allowlist entry (required for `jwt`; parsed but not enforced yet)
-- `DBT_NOVA_JWT_AUDIENCE` – planned JWT audience allowlist entry (required for `jwt`; parsed but not enforced yet)
-- `DBT_NOVA_JWT_JWKS_URL` – planned HTTPS JWKS endpoint for JWT signature verification (required for `jwt`; sanitized in config inspection; parsed but not enforced yet)
-- `DBT_NOVA_JWT_ALGORITHMS` – comma-separated planned JWT algorithm allowlist (required for `jwt`; `none` is rejected; parsed but not enforced yet)
-- `DBT_NOVA_JWT_CLOCK_SKEW_SECS` – planned JWT clock skew leeway for `exp` and `nbf` checks (`60` by default)
+- `DBT_NOVA_JWT_ISSUER` – JWT issuer allowlist entry (required for `jwt`)
+- `DBT_NOVA_JWT_AUDIENCE` – JWT audience allowlist entry (required for `jwt`)
+- `DBT_NOVA_JWT_JWKS_URL` – HTTPS JWKS endpoint for JWT signature verification (required for `jwt`; sanitized in config inspection)
+- `DBT_NOVA_JWT_ALGORITHMS` – comma-separated JWT algorithm allowlist (required for `jwt`; `none` and HS* algorithms are rejected; asymmetric/EdDSA algorithms only)
+- `DBT_NOVA_JWT_CLOCK_SKEW_SECS` – JWT clock skew leeway for `exp` and `nbf` checks (`60` by default)
 - `DBT_NOVA_STRICT_SCHEMA` – fail build if schema files are missing or invalid (`true`|`false`, default: `false`; forced `true` in CI)
 - `DBT_NOVA_S3_MODE` – S3 fetch mode (`https` or `sdk`, default: `https`)
 - `DBT_NOVA_GCS_MODE` – GCS fetch mode (`https` or `sdk`, default: `https`)
@@ -187,7 +187,7 @@ Remote manifest notes:
 - Published container images set `DBT_NOVA_PRESET=hosted-discovery` by default
   so hosted image starts are discovery-only and non-admin unless an operator
   overrides the preset or clears/customizes the denylist.
-- Streamable HTTP mode has **no built-in authentication** by default. Keep it bound to loopback for local use, or set `DBT_NOVA_HTTP_EXPECT_AUTH_PROXY=true` only when an authenticating reverse proxy is enforcing access in front of dbt-nova. `DBT_NOVA_AUTH_MODE=proxy_signed_headers` adds default-off HMAC verification for proxy-provided identity envelopes; JWT mode remains fail-closed until implemented. For hosted/proxied deployments, set `DBT_NOVA_HTTP_ALLOWED_HOSTS` to the public/proxy hostnames clients send in `Host`. Published container images do not set these acknowledgements by default.
+- Streamable HTTP mode has **no built-in authentication** by default. Keep it bound to loopback for local use, or set `DBT_NOVA_HTTP_EXPECT_AUTH_PROXY=true` only when an authenticating reverse proxy is enforcing access in front of dbt-nova. `DBT_NOVA_AUTH_MODE=proxy_signed_headers` adds default-off HMAC verification for proxy-provided identity envelopes. `DBT_NOVA_AUTH_MODE=jwt` adds default-off bearer JWT verification using the configured HTTPS JWKS, issuer, audience, and asymmetric algorithm allowlist. For hosted/proxied deployments, set `DBT_NOVA_HTTP_ALLOWED_HOSTS` to the public/proxy hostnames clients send in `Host`. Published container images do not set these acknowledgements by default.
 - Streamable HTTP mode applies a global request body cap before the mounted MCP transport reads request bodies. Keep `DBT_NOVA_HTTP_MAX_BODY_BYTES` bounded in hosted deployments unless an outer proxy enforces a stricter limit.
 - The MCP endpoint is mounted at `DBT_NOVA_HTTP_PATH`; plain operational
   endpoints are reserved at `/healthz`, `/readyz`, and `/metrics`.

--- a/docs/development/adrs.md
+++ b/docs/development/adrs.md
@@ -75,11 +75,11 @@ authentication layer for `streamable_http`. The default remains `off`, and
 existing stdio, local CLI, and loopback development workflows must not require
 identity.
 
-The preferred sequence is design, fail-closed config skeleton,
-proxy-signed identity headers, then JWT validation only if the narrower proxy
-mode does not cover common hosted deployments. Any JWT support must validate
-issuer, audience, expiry, not-before, signature, and algorithm allowlists, and
-must treat claims as sanitized request identity only.
+Supported identity modes remain intentionally narrow: proxy-signed identity
+headers and bearer JWT validation. JWT support validates issuer, audience,
+expiry, not-before, signature, key ID, and algorithm allowlists through an
+operator-configured JWKS URL, and treats claims as sanitized request identity
+only.
 
 Identity must not become tenant routing, per-entity authorization, warehouse
 credential brokering, semantic-layer authorization, or a multi-manifest control

--- a/docs/development/hosted-identity-contract.md
+++ b/docs/development/hosted-identity-contract.md
@@ -1,15 +1,18 @@
 # Hosted Identity Contract
 
-Status: proxy-signed identity implemented for JOE-663; JWT remains a planned,
-fail-closed contract. Proxy settings are parsed and enforced by streamable HTTP
-mode when enabled. JWT settings are parsed for future compatibility but still
-fail validation until a verifier implementation lands.
+Status: proxy-signed identity implemented for JOE-663 and JWT validation
+implemented for JOE-664. Both modes are default-off, fail closed when enabled,
+and apply only to hosted `streamable_http` requests.
 
 ## Product Boundary
 
 Hosted identity is an optional `streamable_http` extension for request
 attribution and inbound authentication checks. It does not change Nova's core
 role as a one-manifest metadata bridge for agents.
+
+The deployment posture stays proxy-first: Nova should sit behind an
+authenticating proxy or platform boundary even when a default-off hosted
+identity mode is enabled.
 
 Identity is not authorization. Tool exposure remains controlled by runtime
 presets, allowlists, denylists, and explicit safety gates. Entity-level and
@@ -21,14 +24,14 @@ warehouse-level authorization stay outside Nova.
 |---|---|---|
 | `off` | Current behavior: rely on the authenticating proxy or platform layer | Yes |
 | `proxy_signed_headers` | Verify a small signed identity envelope produced by a trusted proxy | No |
-| `jwt` | Planned bearer JWT validation at the Nova HTTP boundary | No |
+| `jwt` | Bearer JWT validation at the Nova HTTP boundary | No |
 
 Unknown modes fail validation. Non-off modes fail closed when required
 validation material is missing or invalid. `proxy_signed_headers` enforces
-request signatures and freshness when configured. `jwt` still fails validation
-instead of silently running unauthenticated.
+request signatures and freshness when configured. `jwt` enforces bearer token
+issuer, audience, time, signature, key ID, and algorithm checks when configured.
 
-## Planned Config Surface
+## Config Surface
 
 The names below are the current config contract.
 
@@ -47,13 +50,11 @@ The names below are the current config contract.
 | `DBT_NOVA_JWT_ISSUER` | JWT mode | Required issuer allowlist entry |
 | `DBT_NOVA_JWT_AUDIENCE` | JWT mode | Required audience allowlist entry |
 | `DBT_NOVA_JWT_JWKS_URL` | JWT mode | HTTPS JWKS endpoint for signature verification |
-| `DBT_NOVA_JWT_ALGORITHMS` | JWT mode | Explicit algorithm allowlist; `none` is never accepted |
+| `DBT_NOVA_JWT_ALGORITHMS` | JWT mode | Explicit asymmetric algorithm allowlist; `none` and HS* algorithms are never accepted |
 | `DBT_NOVA_JWT_CLOCK_SKEW_SECS` | JWT mode | Small leeway for `exp` and `nbf` checks |
 
 Secrets and key material must not be logged or returned by `show_config`.
-Config validation should report presence and posture, not raw values. JWT mode
-is parsed but not enforced and therefore fails closed until a verifier
-implementation lands.
+Config validation should report presence and posture, not raw values.
 
 ## Proxy Envelope
 
@@ -76,6 +77,29 @@ context, but Nova does not use them for authorization.
 The proxy must strip any inbound client-supplied identity/signature headers
 before setting its own trusted values. Stale, malformed, missing, oversized, or
 badly signed envelopes return `401 Unauthorized`.
+
+## JWT Mode
+
+For `jwt`, callers send:
+
+- `Authorization: Bearer <token>`.
+
+Nova fetches the configured HTTPS JWKS at startup and caches it in process. On an
+unknown `kid` or signature failure, Nova refreshes JWKS once and retries so
+normal key rotation can succeed. If JWKS cannot be fetched at startup or during
+refresh, JWT mode fails closed.
+
+JWT requirements:
+
+- token header `kid` must be present and match a JWKS key;
+- `alg` must be in `DBT_NOVA_JWT_ALGORITHMS`;
+- only asymmetric/EdDSA algorithms are accepted (`RS*`, `PS*`, `ES*`, `EdDSA`);
+- `iss`, `aud`, `exp`, and `nbf` are required and validated;
+- the configured `DBT_NOVA_IDENTITY_SUBJECT_CLAIM`, default `sub`, must be a
+  non-empty string.
+
+Nova ignores token-provided `jku`, embedded `jwk`, and x509 URL/header hints. It
+uses only the operator-configured JWKS URL.
 
 ## Runtime Behavior Contract
 
@@ -100,24 +124,27 @@ Mode `jwt`:
 - Require `Authorization: Bearer <token>`.
 - Validate issuer, audience, expiry, not-before, signature, and accepted
   algorithm.
-- Reject unsigned tokens and unsupported algorithms.
+- Reject unsigned tokens, HS* algorithms, missing/unknown `kid`, and unsupported
+  algorithms.
+- Apply the requirement to all hosted HTTP routes, including probes and metrics.
 - Treat claims as sanitized request context only.
 
 ## Observability Contract
 
-Proxy identity logs include bounded `auth_mode` and a SHA-256 subject hash after
+Hosted identity logs include bounded `auth_mode` and a SHA-256 subject hash after
 verification. Metrics must not add raw subject, email, group, token, query text,
 entity name, path, or credential labels by default.
 
-## Tests Before Implementation
+## Verification Coverage
 
-The implementation PRs should add failing-closed tests before enabling behavior:
+Implementation PRs should keep failing-closed tests around:
 
 - Unknown mode fails validation.
 - Non-off mode without required config fails validation.
 - Stdio and CLI behavior are unchanged when mode is `off`.
 - Proxy mode rejects missing/invalid/stale signatures.
 - JWT mode rejects missing bearer token, bad issuer, bad audience, expired
-  token, not-yet-valid token, invalid signature, and unsupported algorithms.
+  token, not-yet-valid token, invalid signature, unknown `kid`, JWKS outage,
+  and unsupported algorithms.
 - Sanitized identity never leaks secrets through config, metrics, or error
   payloads.

--- a/docs/development/hosted-identity-threat-model.md
+++ b/docs/development/hosted-identity-threat-model.md
@@ -1,16 +1,17 @@
 # Hosted Identity Threat Model
 
-Status: design contract for JOE-665. This page does not describe shipped
-runtime authentication behavior.
+Status: threat model for shipped proxy-signed identity and JWT hosted identity
+modes. Future identity work must keep these boundaries intact.
 
 ## Current State
 
-`streamable_http` has no built-in authentication. Non-loopback hosted
+`streamable_http` has no built-in authentication by default. Non-loopback hosted
 deployments must sit behind an authenticating reverse proxy or platform auth
 layer and set `DBT_NOVA_HTTP_EXPECT_AUTH_PROXY=true` only when that layer is
-actually enforcing access.
+actually enforcing access. Operators may additionally enable default-off
+`proxy_signed_headers` or `jwt` verification for hosted HTTP requests.
 
-The identity extension track is default-off and proxy-first. It is scoped to
+The identity extension track is default-off and hosted-only. It is scoped to
 request attribution and optional inbound authentication checks for hosted HTTP.
 It must not change stdio, CLI, loopback development, or the one-manifest
 metadata-bridge model.
@@ -66,7 +67,7 @@ Identity work must not add:
 
 ## Request Identity
 
-If implemented, request identity is limited to sanitized attribution context:
+Request identity is limited to sanitized attribution context:
 
 - Stable subject.
 - Optional display name.
@@ -95,12 +96,10 @@ Nova must reject startup or requests when:
 Mode `off` preserves current behavior: Nova relies on the external proxy or
 platform layer and does not construct request identity.
 
-## Sequencing
+## Shipped Sequence
 
 1. JOE-665: accept this threat model and default-off hosted identity design.
-2. JOE-662: add a fail-closed config skeleton without changing effective
-   runtime behavior for mode `off`.
-3. JOE-663: implement proxy-signed identity headers as the first enforced
-   default-off hosted identity mode.
-4. JOE-664: implement JWT validation only after the skeleton and proxy mode are
-   reviewed.
+2. JOE-662: add fail-closed config parsing without changing effective runtime
+   behavior for mode `off`.
+3. JOE-663: implement proxy-signed identity headers.
+4. JOE-664: implement JWT/JWKS validation.

--- a/docs/operations/hosted-deployment.md
+++ b/docs/operations/hosted-deployment.md
@@ -11,10 +11,11 @@ authenticating reverse proxy or platform auth layer first.
 
 Default-off hosted identity config also supports
 `DBT_NOVA_AUTH_MODE=proxy_signed_headers`, where Nova verifies a small HMAC
-identity envelope produced by the trusted proxy. JWT validation remains planned
-and fail-closed until its verifier lands. Proxy identity is request attribution,
-not authorization; the proxy or platform layer remains responsible for
-authenticating users and stripping any client-supplied identity headers.
+identity envelope produced by the trusted proxy, and `DBT_NOVA_AUTH_MODE=jwt`,
+where Nova verifies inbound bearer JWTs against an operator-configured HTTPS
+JWKS. Hosted identity is request attribution and inbound access checking, not
+authorization; the proxy or platform layer remains responsible for coarse access
+control and network exposure.
 See
 [Hosted Identity Threat Model](../development/hosted-identity-threat-model.md)
 and [Hosted Identity Contract](../development/hosted-identity-contract.md).
@@ -38,9 +39,8 @@ Recommended hosted posture:
   intentionally warming semantic caches.
 - Set `DBT_NOVA_HTTP_EXPECT_AUTH_PROXY=true` only when the reverse proxy or
   platform auth layer is actually enforcing authentication.
-- Leave `DBT_NOVA_AUTH_MODE=off` unless the proxy-signed header contract is
-  configured end to end. JWT mode currently fails validation rather than running
-  without enforcement.
+- Leave `DBT_NOVA_AUTH_MODE=off` unless the proxy-signed header or JWT contract
+  is configured end to end.
 
 ## Local HTTP Profile
 
@@ -148,6 +148,36 @@ Example identity JSON before base64url encoding:
 Nova rejects missing, malformed, oversized, stale, or badly signed envelopes
 with `401 Unauthorized`. Verified identity is recorded as a SHA-256 subject hash
 in logs only; metrics do not add identity labels.
+
+## JWT Identity Mode
+
+Use this mode when the caller presents a bearer token issued by a known issuer
+and Nova should verify it directly at the hosted HTTP boundary.
+
+Nova config:
+
+```bash
+export DBT_NOVA_AUTH_MODE=jwt
+export DBT_NOVA_AUTH_REQUIRED=true
+export DBT_NOVA_JWT_ISSUER=https://issuer.example
+export DBT_NOVA_JWT_AUDIENCE=dbt-nova
+export DBT_NOVA_JWT_JWKS_URL=https://issuer.example/.well-known/jwks.json
+export DBT_NOVA_JWT_ALGORITHMS=RS256
+export DBT_NOVA_JWT_CLOCK_SKEW_SECS=60
+```
+
+JWT mode requires `Authorization: Bearer <token>` on every hosted HTTP route,
+including `/healthz`, `/readyz`, `/metrics`, and the MCP path. Tokens must
+include `kid`, `iss`, `aud`, `exp`, `nbf`, and the configured subject claim
+(`sub` by default). Nova accepts only asymmetric/EdDSA algorithms in the
+explicit allowlist (`RS*`, `PS*`, `ES*`, `EdDSA`); `none` and HS* algorithms are
+rejected.
+
+Nova fetches JWKS at startup and caches it in process. On unknown `kid` or
+signature failure, Nova refreshes JWKS once and retries to support key rotation.
+If JWKS is unavailable at startup or refresh, JWT mode fails closed. Verified
+identity is recorded as a SHA-256 subject hash in logs only; metrics do not add
+identity labels.
 
 ## Request Correlation
 

--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -55,14 +55,15 @@ call counts, error counts, and latency. Restrict scrapes with the same
 proxy/network ACL as MCP, or set `DBT_NOVA_METRICS_ENABLED=false`.
 
 Hosted identity is default-off. `DBT_NOVA_AUTH_MODE=proxy_signed_headers`
-enables fail-closed HMAC verification for trusted proxy identity envelopes; JWT
-mode remains planned and fails validation until its verifier implementation
-lands.
+enables fail-closed HMAC verification for trusted proxy identity envelopes.
+`DBT_NOVA_AUTH_MODE=jwt` enables fail-closed bearer JWT verification using an
+operator-configured HTTPS JWKS, issuer, audience, and asymmetric algorithm
+allowlist.
 See [Hosted Identity Threat Model](../development/hosted-identity-threat-model.md)
 and [Hosted Identity Contract](../development/hosted-identity-contract.md) for
-the default-off, proxy-first boundaries. Treat the reverse proxy or platform
-auth layer as the authentication and authorization boundary; Nova's verified
-proxy identity is attribution context only.
+the default-off hosted identity boundaries. Treat the reverse proxy or platform
+auth layer as the authorization and coarse access boundary; Nova's verified
+hosted identity is attribution context only.
 
 Some tools read from the server filesystem. `validate_nova_meta` validates dbt
 YAML under the server working directory and rejects absolute or traversal paths

--- a/src/cli/config_cmd.rs
+++ b/src/cli/config_cmd.rs
@@ -392,9 +392,12 @@ fn build_validation_checklist(config: &DbtNovaConfig) -> ConfigValidationCheckli
 }
 
 fn build_hosted_auth_posture(config: &DbtNovaConfig) -> HostedAuthPosture {
-    let proxy_mode_enabled = config.hosted_auth.mode == HostedAuthMode::ProxySignedHeaders;
-    let effective_mode = if proxy_mode_enabled {
-        HostedAuthMode::ProxySignedHeaders.as_str()
+    let non_off_mode_implemented = matches!(
+        config.hosted_auth.mode,
+        HostedAuthMode::ProxySignedHeaders | HostedAuthMode::Jwt
+    );
+    let effective_mode = if non_off_mode_implemented {
+        config.hosted_auth.mode.as_str()
     } else {
         HostedAuthMode::Off.as_str()
     };
@@ -402,7 +405,7 @@ fn build_hosted_auth_posture(config: &DbtNovaConfig) -> HostedAuthPosture {
         mode: config.hosted_auth.mode.as_str().to_string(),
         effective_mode: effective_mode.to_string(),
         required: config.hosted_auth.required,
-        non_off_modes_implemented: proxy_mode_enabled,
+        non_off_modes_implemented: non_off_mode_implemented,
         proxy_identity_header_configured: !config
             .hosted_auth
             .proxy_identity_header
@@ -787,6 +790,43 @@ mod tests {
         );
         assert_eq!(
             response["data"]["checklist"]["hosted_auth"]["proxy_secret_file_configured"],
+            serde_json::json!(true)
+        );
+    }
+
+    #[test]
+    fn config_validate_reports_jwt_as_effective_auth_mode() {
+        let config = DbtNovaConfig {
+            hosted_auth: HostedAuthConfig {
+                mode: HostedAuthMode::Jwt,
+                required: true,
+                jwt_issuer: "https://issuer.example".to_string(),
+                jwt_audience: "dbt-nova".to_string(),
+                jwt_jwks_url: "https://issuer.example/.well-known/jwks.json".to_string(),
+                jwt_algorithms: vec!["EdDSA".to_string()],
+                ..HostedAuthConfig::default()
+            },
+            ..DbtNovaConfig::default()
+        };
+
+        let response =
+            build_config_validate_tool_response(&config, &ConfigValidateParams::default())
+                .expect("config validate response");
+
+        assert_eq!(
+            response["data"]["checklist"]["hosted_auth"]["mode"],
+            serde_json::json!("jwt")
+        );
+        assert_eq!(
+            response["data"]["checklist"]["hosted_auth"]["effective_mode"],
+            serde_json::json!("jwt")
+        );
+        assert_eq!(
+            response["data"]["checklist"]["hosted_auth"]["non_off_modes_implemented"],
+            serde_json::json!(true)
+        );
+        assert_eq!(
+            response["data"]["checklist"]["hosted_auth"]["jwt_jwks_url_configured"],
             serde_json::json!(true)
         );
     }

--- a/src/cli/server_cmd.rs
+++ b/src/cli/server_cmd.rs
@@ -21,13 +21,13 @@ use tower_http::limit::RequestBodyLimitLayer;
 use tracing::{error, info, warn};
 
 use crate::cli::args::{ServerStartArgs, ServerTransportArg};
-use crate::config::{DbtNovaConfig, ServerTransport};
+use crate::config::{DbtNovaConfig, HostedAuthMode, ServerTransport};
 use crate::error::{DbtNovaError, Result};
 use crate::manifest::bootstrap::prepare_runtime_config;
 use crate::manifest::search::ManifestSearchHandle;
 use crate::server::correlation::correlate_http_request;
 use crate::server::health::build_manifest_health_payload;
-use crate::server::identity::{ProxyIdentityVerifier, verify_proxy_identity_request};
+use crate::server::identity::{HostedIdentityVerifier, verify_hosted_identity_request};
 use crate::server::mcp::DbtNovaServer;
 use crate::utils::{ToolMetricsStore, sanitize_uri};
 
@@ -44,7 +44,7 @@ struct HttpServerSettings {
     max_body_bytes: usize,
     allowed_hosts: Vec<String>,
     metrics_enabled: bool,
-    proxy_identity_verifier: Option<Arc<ProxyIdentityVerifier>>,
+    hosted_identity_verifier: Option<Arc<HostedIdentityVerifier>>,
 }
 
 #[derive(Clone)]
@@ -66,7 +66,7 @@ impl HttpServerSettings {
             max_body_bytes: config.http_max_body_bytes,
             allowed_hosts: parse_http_allowed_hosts(&config.http_allowed_hosts),
             metrics_enabled: config.metrics_enabled,
-            proxy_identity_verifier: ProxyIdentityVerifier::from_config(&config.hosted_auth)?
+            hosted_identity_verifier: HostedIdentityVerifier::from_config(&config.hosted_auth)?
                 .map(Arc::new),
         })
     }
@@ -211,6 +211,16 @@ async fn start_with_config_and_shutdown(
 }
 
 fn log_streamable_http_auth_posture(config: &DbtNovaConfig) {
+    if config.hosted_auth.mode != HostedAuthMode::Off {
+        info!(
+            http_host = %config.http_host,
+            http_port = config.http_port,
+            http_path = %config.http_path,
+            auth_mode = config.hosted_auth.mode.as_str(),
+            "streamable HTTP hosted identity verification enabled; keep authorization and proxy/network access controls outside Nova"
+        );
+        return;
+    }
     if config.http_transport_binds_non_loopback() {
         warn!(
             http_host = %config.http_host,
@@ -299,10 +309,10 @@ async fn serve_streamable_http(
     } else {
         app
     };
-    let app = if let Some(verifier) = settings.proxy_identity_verifier {
+    let app = if let Some(verifier) = settings.hosted_identity_verifier {
         app.layer(middleware::from_fn_with_state(
             verifier,
-            verify_proxy_identity_request,
+            verify_hosted_identity_request,
         ))
     } else {
         app

--- a/src/config/core/tests.rs
+++ b/src/config/core/tests.rs
@@ -92,7 +92,7 @@ fn server_transport_parse_is_case_insensitive() {
 }
 
 #[test]
-fn hosted_auth_mode_parse_accepts_planned_modes() {
+fn hosted_auth_mode_parse_accepts_supported_modes() {
     assert_eq!(HostedAuthMode::parse("off"), Some(HostedAuthMode::Off));
     assert_eq!(
         HostedAuthMode::parse("proxy_signed_headers"),
@@ -313,7 +313,7 @@ fn validate_rejects_incomplete_jwt_hosted_auth_skeleton() {
 }
 
 #[test]
-fn validate_rejects_complete_jwt_until_verifier_lands() {
+fn validate_accepts_complete_jwt_hosted_auth() {
     let config = with_env_vars(
         &[
             ("DBT_NOVA_AUTH_MODE", Some("jwt")),
@@ -334,13 +334,57 @@ fn validate_rejects_complete_jwt_until_verifier_lands() {
         config.hosted_auth.jwt_algorithms,
         vec!["RS256".to_string(), "ES256".to_string()]
     );
+    config
+        .validate()
+        .expect("complete jwt mode should validate");
+}
+
+#[test]
+fn validate_rejects_hmac_jwt_algorithm() {
+    let config = with_env_vars(
+        &[
+            ("DBT_NOVA_AUTH_MODE", Some("jwt")),
+            ("DBT_NOVA_JWT_ISSUER", Some("https://issuer.example")),
+            ("DBT_NOVA_JWT_AUDIENCE", Some("dbt-nova")),
+            (
+                "DBT_NOVA_JWT_JWKS_URL",
+                Some("https://issuer.example/.well-known/jwks.json"),
+            ),
+            ("DBT_NOVA_JWT_ALGORITHMS", Some("HS256")),
+        ],
+        DbtNovaConfig::from_env,
+    );
+
     let error = config
         .validate()
-        .expect_err("complete jwt skeleton should still fail closed until implemented");
+        .expect_err("HMAC JWT algorithms should fail validation");
     assert!(
-        error
-            .to_string()
-            .contains("jwt is parsed but not implemented yet"),
+        error.to_string().contains("HS256"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn validate_rejects_unknown_jwt_algorithm() {
+    let config = with_env_vars(
+        &[
+            ("DBT_NOVA_AUTH_MODE", Some("jwt")),
+            ("DBT_NOVA_JWT_ISSUER", Some("https://issuer.example")),
+            ("DBT_NOVA_JWT_AUDIENCE", Some("dbt-nova")),
+            (
+                "DBT_NOVA_JWT_JWKS_URL",
+                Some("https://issuer.example/.well-known/jwks.json"),
+            ),
+            ("DBT_NOVA_JWT_ALGORITHMS", Some("none")),
+        ],
+        DbtNovaConfig::from_env,
+    );
+
+    let error = config
+        .validate()
+        .expect_err("unsupported JWT algorithms should fail validation");
+    assert!(
+        error.to_string().contains("unsupported algorithm"),
         "unexpected error: {error}"
     );
 }

--- a/src/config/hosted_auth.rs
+++ b/src/config/hosted_auth.rs
@@ -1,3 +1,6 @@
+use std::str::FromStr;
+
+use jsonwebtoken::Algorithm;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{DbtNovaError, Result};
@@ -11,7 +14,7 @@ pub enum HostedAuthMode {
     Off,
     /// Signed identity envelope from a trusted reverse proxy.
     ProxySignedHeaders,
-    /// Planned bearer JWT validation at the Nova HTTP boundary.
+    /// Bearer JWT validation at the Nova HTTP boundary.
     Jwt,
 }
 
@@ -42,7 +45,7 @@ impl HostedAuthMode {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct HostedAuthConfig {
-    /// Hosted auth mode. Proxy mode is implemented; JWT remains planned.
+    /// Hosted auth mode. Proxy and JWT modes are implemented.
     pub mode: HostedAuthMode,
     /// Whether authentication must be present for hosted requests.
     pub required: bool,
@@ -118,7 +121,7 @@ impl HostedAuthConfig {
             }
             HostedAuthMode::Jwt => {
                 self.validate_jwt()?;
-                Err(non_off_auth_mode_unimplemented_error(self.mode))
+                Ok(())
             }
         }
     }
@@ -151,21 +154,7 @@ impl HostedAuthConfig {
         require_non_empty("DBT_NOVA_JWT_AUDIENCE", &self.jwt_audience)?;
         require_non_empty("DBT_NOVA_JWT_JWKS_URL", &self.jwt_jwks_url)?;
         require_https_url("DBT_NOVA_JWT_JWKS_URL", &self.jwt_jwks_url)?;
-        if self.jwt_algorithms.is_empty() {
-            return Err(DbtNovaError::InvalidParams(
-                "DBT_NOVA_JWT_ALGORITHMS must include at least one accepted algorithm for JWT mode"
-                    .to_string(),
-            ));
-        }
-        if self
-            .jwt_algorithms
-            .iter()
-            .any(|algorithm| algorithm.trim().eq_ignore_ascii_case("none"))
-        {
-            return Err(DbtNovaError::InvalidParams(
-                "DBT_NOVA_JWT_ALGORITHMS must not include `none`".to_string(),
-            ));
-        }
+        parse_jwt_algorithms(&self.jwt_algorithms)?;
         Ok(())
     }
 
@@ -182,13 +171,6 @@ impl HostedAuthConfig {
     }
 }
 
-fn non_off_auth_mode_unimplemented_error(mode: HostedAuthMode) -> DbtNovaError {
-    DbtNovaError::InvalidParams(format!(
-        "DBT_NOVA_AUTH_MODE={} is parsed but not implemented yet; use DBT_NOVA_AUTH_MODE=proxy_signed_headers or off until its verifier lands",
-        mode.as_str()
-    ))
-}
-
 fn require_non_empty(name: &str, value: &str) -> Result<()> {
     if value.trim().is_empty() {
         return Err(DbtNovaError::InvalidParams(format!(
@@ -196,6 +178,44 @@ fn require_non_empty(name: &str, value: &str) -> Result<()> {
         )));
     }
     Ok(())
+}
+
+pub(crate) fn parse_jwt_algorithms(values: &[String]) -> Result<Vec<Algorithm>> {
+    let mut algorithms = Vec::with_capacity(values.len());
+    for value in values {
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        let algorithm = Algorithm::from_str(value).map_err(|_| {
+            DbtNovaError::InvalidParams(format!(
+                "DBT_NOVA_JWT_ALGORITHMS contains unsupported algorithm `{value}`"
+            ))
+        })?;
+        if is_hmac_algorithm(algorithm) {
+            return Err(DbtNovaError::InvalidParams(
+                "DBT_NOVA_JWT_ALGORITHMS must use asymmetric algorithms; HS256, HS384, and HS512 are not accepted for hosted JWT mode"
+                    .to_string(),
+            ));
+        }
+        if !algorithms.contains(&algorithm) {
+            algorithms.push(algorithm);
+        }
+    }
+    if algorithms.is_empty() {
+        return Err(DbtNovaError::InvalidParams(
+            "DBT_NOVA_JWT_ALGORITHMS must include at least one accepted algorithm for JWT mode"
+                .to_string(),
+        ));
+    }
+    Ok(algorithms)
+}
+
+const fn is_hmac_algorithm(algorithm: Algorithm) -> bool {
+    matches!(
+        algorithm,
+        Algorithm::HS256 | Algorithm::HS384 | Algorithm::HS512
+    )
 }
 
 fn require_https_url(name: &str, value: &str) -> Result<()> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -23,6 +23,7 @@ pub use core::{
     ArtifactFetchPolicy, DbtNovaConfig, GovernanceGateConfig, ResultProfile, RuntimePreset,
     ServerTransport,
 };
+pub(crate) use hosted_auth::parse_jwt_algorithms;
 pub use hosted_auth::{HostedAuthConfig, HostedAuthMode};
 pub use metadata_score::{
     MetadataCategoryWeights, MetadataScoreConfig, MetadataScoreWeightProfiles,

--- a/src/server/identity.rs
+++ b/src/server/identity.rs
@@ -1,4 +1,5 @@
-use std::sync::Arc;
+use std::str::FromStr;
+use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use axum::{
@@ -9,11 +10,16 @@ use axum::{
 };
 use base64::Engine as _;
 use hmac::{Hmac, Mac};
+use jsonwebtoken::{
+    Algorithm, DecodingKey, Validation, decode, decode_header,
+    errors::ErrorKind as JwtErrorKind,
+    jwk::{AlgorithmParameters, Jwk, JwkSet, KeyOperations, PublicKeyUse},
+};
 use serde_json::Value as JsonValue;
 use sha2::{Digest, Sha256};
 use tracing::warn;
 
-use crate::config::{HostedAuthConfig, HostedAuthMode};
+use crate::config::{HostedAuthConfig, HostedAuthMode, parse_jwt_algorithms};
 use crate::error::{DbtNovaError, Result};
 
 const SIGNATURE_PREFIX: &str = "sha256=";
@@ -22,6 +28,9 @@ const MAX_SIGNATURE_HEADER_BYTES: usize = 256;
 const MAX_SECRET_FILE_BYTES: usize = 64 * 1024;
 const MIN_SECRET_BYTES: usize = 32;
 const FUTURE_IAT_SKEW_SECS: u64 = 60;
+const MAX_AUTHORIZATION_HEADER_BYTES: usize = 16 * 1024;
+const MAX_JWKS_RESPONSE_BYTES: usize = 256 * 1024;
+const JWKS_FETCH_TIMEOUT_SECS: u64 = 10;
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -30,6 +39,12 @@ type HmacSha256 = Hmac<Sha256>;
 pub(crate) struct RequestIdentity {
     pub mode: HostedAuthMode,
     pub subject_hash: String,
+}
+
+#[derive(Debug)]
+pub(crate) enum HostedIdentityVerifier {
+    Proxy(ProxyIdentityVerifier),
+    Jwt(Box<JwtIdentityVerifier>),
 }
 
 #[derive(Debug, Clone)]
@@ -41,13 +56,76 @@ pub(crate) struct ProxyIdentityVerifier {
     secret: Arc<Vec<u8>>,
 }
 
+#[derive(Debug)]
+pub(crate) struct JwtIdentityVerifier {
+    subject_claim: String,
+    jwks_url: String,
+    algorithms: Vec<Algorithm>,
+    validation: Validation,
+    jwks: RwLock<JwkSet>,
+    client: reqwest::Client,
+}
+
+#[derive(Debug)]
+struct JwtIdentityVerifierParts {
+    issuer: String,
+    audience: String,
+    subject_claim: String,
+    jwks_url: String,
+    algorithms: Vec<Algorithm>,
+    clock_skew_secs: u64,
+    jwks: JwkSet,
+    client: reqwest::Client,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum VerificationError {
     MissingIdentity,
     MissingSignature,
+    MissingAuthorization,
+    MalformedAuthorization,
     MalformedIdentity,
+    MissingKeyId,
+    UnknownKeyId,
+    UnsupportedAlgorithm,
     InvalidSignature,
     StaleIdentity,
+    InvalidToken,
+    JwksUnavailable,
+}
+
+impl HostedIdentityVerifier {
+    /// Build the active hosted identity verifier for the configured mode.
+    ///
+    /// # Errors
+    /// Returns an error when verifier config or key material cannot be loaded.
+    pub(crate) fn from_config(config: &HostedAuthConfig) -> Result<Option<Self>> {
+        match config.mode {
+            HostedAuthMode::Off => Ok(None),
+            HostedAuthMode::ProxySignedHeaders => {
+                ProxyIdentityVerifier::from_config(config).map(|verifier| verifier.map(Self::Proxy))
+            }
+            HostedAuthMode::Jwt => JwtIdentityVerifier::from_config(config)
+                .map(|verifier| verifier.map(|verifier| Self::Jwt(Box::new(verifier)))),
+        }
+    }
+
+    const fn mode(&self) -> HostedAuthMode {
+        match self {
+            Self::Proxy(_) => HostedAuthMode::ProxySignedHeaders,
+            Self::Jwt(_) => HostedAuthMode::Jwt,
+        }
+    }
+
+    async fn verify_headers(
+        &self,
+        headers: &HeaderMap,
+    ) -> std::result::Result<RequestIdentity, VerificationError> {
+        match self {
+            Self::Proxy(verifier) => verifier.verify_headers(headers),
+            Self::Jwt(verifier) => verifier.verify_headers(headers).await,
+        }
+    }
 }
 
 impl ProxyIdentityVerifier {
@@ -135,26 +213,155 @@ impl ProxyIdentityVerifier {
     }
 }
 
-pub(crate) async fn verify_proxy_identity_request(
-    State(verifier): State<Arc<ProxyIdentityVerifier>>,
+impl JwtIdentityVerifier {
+    /// Build a JWT verifier from validated hosted auth config.
+    ///
+    /// # Errors
+    /// Returns an error when JWT algorithms are unsupported or JWKS cannot be loaded.
+    pub(crate) fn from_config(config: &HostedAuthConfig) -> Result<Option<Self>> {
+        if config.mode != HostedAuthMode::Jwt {
+            return Ok(None);
+        }
+        let algorithms = parse_jwt_algorithms(&config.jwt_algorithms)?;
+        let startup_client = build_blocking_jwks_client()?;
+        let jwks_url = config.jwt_jwks_url.trim().to_string();
+        let jwks = fetch_jwks_blocking(&startup_client, &jwks_url)?;
+        validate_jwks_has_asymmetric_key(&jwks)?;
+        let client = build_jwks_client()?;
+        Ok(Some(Self::from_parts(JwtIdentityVerifierParts {
+            issuer: config.jwt_issuer.trim().to_string(),
+            audience: config.jwt_audience.trim().to_string(),
+            subject_claim: config.identity_subject_claim.trim().to_string(),
+            jwks_url,
+            algorithms,
+            clock_skew_secs: config.jwt_clock_skew_secs,
+            jwks,
+            client,
+        })))
+    }
+
+    fn from_parts(parts: JwtIdentityVerifierParts) -> Self {
+        let JwtIdentityVerifierParts {
+            issuer,
+            audience,
+            subject_claim,
+            jwks_url,
+            algorithms,
+            clock_skew_secs,
+            jwks,
+            client,
+        } = parts;
+        let mut validation = Validation::new(algorithms[0]);
+        validation.algorithms.clone_from(&algorithms);
+        validation.leeway = clock_skew_secs;
+        validation.validate_exp = true;
+        validation.validate_nbf = true;
+        validation.set_audience(&[audience.as_str()]);
+        validation.set_issuer(&[issuer.as_str()]);
+        validation.set_required_spec_claims(&["exp", "nbf", "aud", "iss"]);
+        Self {
+            subject_claim,
+            jwks_url,
+            algorithms,
+            validation,
+            jwks: RwLock::new(jwks),
+            client,
+        }
+    }
+
+    async fn verify_headers(
+        &self,
+        headers: &HeaderMap,
+    ) -> std::result::Result<RequestIdentity, VerificationError> {
+        let token = bearer_token(headers)?;
+        match self.verify_token_with_cache(token) {
+            Ok(identity) => Ok(identity),
+            Err(VerificationError::UnknownKeyId | VerificationError::InvalidSignature) => {
+                self.refresh_jwks().await?;
+                self.verify_token_with_cache(token)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    fn verify_token_with_cache(
+        &self,
+        token: &str,
+    ) -> std::result::Result<RequestIdentity, VerificationError> {
+        let header = decode_header(token).map_err(|_| VerificationError::MalformedAuthorization)?;
+        if !self.algorithms.contains(&header.alg) {
+            return Err(VerificationError::UnsupportedAlgorithm);
+        }
+        let kid = header
+            .kid
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or(VerificationError::MissingKeyId)?;
+        let jwk = self.cached_jwk(kid)?;
+        validate_jwk_for_header(&jwk, header.alg)?;
+        let decoding_key =
+            DecodingKey::from_jwk(&jwk).map_err(|_| VerificationError::InvalidToken)?;
+        let token_data = decode::<JsonValue>(token, &decoding_key, &self.validation)
+            .map_err(|error| jwt_error_to_verification_error(&error))?;
+        let subject = token_data
+            .claims
+            .get(&self.subject_claim)
+            .and_then(JsonValue::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or(VerificationError::MalformedIdentity)?;
+        Ok(RequestIdentity {
+            mode: HostedAuthMode::Jwt,
+            subject_hash: sha256_hex(subject.as_bytes()),
+        })
+    }
+
+    fn cached_jwk(&self, kid: &str) -> std::result::Result<Jwk, VerificationError> {
+        let jwks = self
+            .jwks
+            .read()
+            .map_err(|_| VerificationError::JwksUnavailable)?;
+        jwks.find(kid)
+            .cloned()
+            .ok_or(VerificationError::UnknownKeyId)
+    }
+
+    async fn refresh_jwks(&self) -> std::result::Result<(), VerificationError> {
+        let refreshed = fetch_jwks(&self.client, &self.jwks_url)
+            .await
+            .map_err(|_| VerificationError::JwksUnavailable)?;
+        validate_jwks_has_asymmetric_key(&refreshed)
+            .map_err(|_| VerificationError::JwksUnavailable)?;
+        let mut jwks = self
+            .jwks
+            .write()
+            .map_err(|_| VerificationError::JwksUnavailable)?;
+        *jwks = refreshed;
+        Ok(())
+    }
+}
+
+pub(crate) async fn verify_hosted_identity_request(
+    State(verifier): State<Arc<HostedIdentityVerifier>>,
     mut request: Request,
     next: Next,
 ) -> Response {
-    match verifier.verify_headers(request.headers()) {
+    match verifier.verify_headers(request.headers()).await {
         Ok(identity) => {
             tracing::info!(
                 auth_mode = identity.mode.as_str(),
                 subject_hash = %identity.subject_hash,
-                "hosted proxy identity verified"
+                "hosted identity verified"
             );
             request.extensions_mut().insert(identity);
             next.run(request).await
         }
         Err(error) => {
             warn!(
-                auth_mode = HostedAuthMode::ProxySignedHeaders.as_str(),
+                auth_mode = verifier.mode().as_str(),
                 reason = error.reason(),
-                "hosted proxy identity verification failed"
+                "hosted identity verification failed"
             );
             unauthorized_identity_response()
         }
@@ -166,9 +373,16 @@ impl VerificationError {
         match self {
             Self::MissingIdentity => "missing_identity_header",
             Self::MissingSignature => "missing_signature_header",
+            Self::MissingAuthorization => "missing_authorization_header",
+            Self::MalformedAuthorization => "malformed_authorization_header",
             Self::MalformedIdentity => "malformed_identity_envelope",
+            Self::MissingKeyId => "missing_jwt_kid",
+            Self::UnknownKeyId => "unknown_jwt_kid",
+            Self::UnsupportedAlgorithm => "unsupported_jwt_algorithm",
             Self::InvalidSignature => "invalid_signature",
-            Self::StaleIdentity => "stale_identity_envelope",
+            Self::StaleIdentity => "stale_identity",
+            Self::InvalidToken => "invalid_jwt",
+            Self::JwksUnavailable => "jwks_unavailable",
         }
     }
 }
@@ -283,6 +497,181 @@ fn verify_signature(
         .map_err(|_| VerificationError::InvalidSignature)
 }
 
+fn bearer_token(headers: &HeaderMap) -> std::result::Result<&str, VerificationError> {
+    let value = header_value(
+        headers,
+        &header::AUTHORIZATION,
+        MAX_AUTHORIZATION_HEADER_BYTES,
+    )
+    .ok_or(VerificationError::MissingAuthorization)?;
+    let (scheme, token) = value
+        .split_once(' ')
+        .ok_or(VerificationError::MalformedAuthorization)?;
+    if !scheme.eq_ignore_ascii_case("Bearer") {
+        return Err(VerificationError::MalformedAuthorization);
+    }
+    let token = token.trim();
+    if token.is_empty() || token.contains(char::is_whitespace) {
+        return Err(VerificationError::MalformedAuthorization);
+    }
+    Ok(token)
+}
+
+fn build_jwks_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(JWKS_FETCH_TIMEOUT_SECS))
+        .build()
+        .map_err(|error| {
+            DbtNovaError::InvalidParams(format!(
+                "DBT_NOVA_JWT_JWKS_URL client could not be created: {error}"
+            ))
+        })
+}
+
+fn build_blocking_jwks_client() -> Result<reqwest::blocking::Client> {
+    reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(JWKS_FETCH_TIMEOUT_SECS))
+        .build()
+        .map_err(|error| {
+            DbtNovaError::InvalidParams(format!(
+                "DBT_NOVA_JWT_JWKS_URL client could not be created: {error}"
+            ))
+        })
+}
+
+fn fetch_jwks_blocking(client: &reqwest::blocking::Client, url: &str) -> Result<JwkSet> {
+    let response = client
+        .get(url.trim())
+        .header(header::ACCEPT.as_str(), "application/json")
+        .send()
+        .and_then(reqwest::blocking::Response::error_for_status)
+        .map_err(|error| {
+            DbtNovaError::InvalidParams(format!(
+                "DBT_NOVA_JWT_JWKS_URL could not be fetched: {error}"
+            ))
+        })?;
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_JWKS_RESPONSE_BYTES as u64)
+    {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "DBT_NOVA_JWT_JWKS_URL response must be at most {MAX_JWKS_RESPONSE_BYTES} bytes"
+        )));
+    }
+    let bytes = response.bytes().map_err(|error| {
+        DbtNovaError::InvalidParams(format!(
+            "DBT_NOVA_JWT_JWKS_URL response could not be read: {error}"
+        ))
+    })?;
+    if bytes.len() > MAX_JWKS_RESPONSE_BYTES {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "DBT_NOVA_JWT_JWKS_URL response must be at most {MAX_JWKS_RESPONSE_BYTES} bytes"
+        )));
+    }
+    serde_json::from_slice::<JwkSet>(&bytes).map_err(|error| {
+        DbtNovaError::InvalidParams(format!(
+            "DBT_NOVA_JWT_JWKS_URL response was not a valid JWKS: {error}"
+        ))
+    })
+}
+
+async fn fetch_jwks(client: &reqwest::Client, url: &str) -> Result<JwkSet> {
+    let response = client
+        .get(url.trim())
+        .header(header::ACCEPT.as_str(), "application/json")
+        .send()
+        .await
+        .and_then(reqwest::Response::error_for_status)
+        .map_err(|error| {
+            DbtNovaError::InvalidParams(format!(
+                "DBT_NOVA_JWT_JWKS_URL could not be fetched: {error}"
+            ))
+        })?;
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_JWKS_RESPONSE_BYTES as u64)
+    {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "DBT_NOVA_JWT_JWKS_URL response must be at most {MAX_JWKS_RESPONSE_BYTES} bytes"
+        )));
+    }
+    let bytes = response.bytes().await.map_err(|error| {
+        DbtNovaError::InvalidParams(format!(
+            "DBT_NOVA_JWT_JWKS_URL response could not be read: {error}"
+        ))
+    })?;
+    if bytes.len() > MAX_JWKS_RESPONSE_BYTES {
+        return Err(DbtNovaError::InvalidParams(format!(
+            "DBT_NOVA_JWT_JWKS_URL response must be at most {MAX_JWKS_RESPONSE_BYTES} bytes"
+        )));
+    }
+    serde_json::from_slice::<JwkSet>(&bytes).map_err(|error| {
+        DbtNovaError::InvalidParams(format!(
+            "DBT_NOVA_JWT_JWKS_URL response was not a valid JWKS: {error}"
+        ))
+    })
+}
+
+fn validate_jwks_has_asymmetric_key(jwks: &JwkSet) -> Result<()> {
+    if jwks.keys.iter().any(is_asymmetric_jwk) {
+        return Ok(());
+    }
+    Err(DbtNovaError::InvalidParams(
+        "DBT_NOVA_JWT_JWKS_URL must contain at least one asymmetric signature key".to_string(),
+    ))
+}
+
+fn is_asymmetric_jwk(jwk: &Jwk) -> bool {
+    matches!(
+        jwk.algorithm,
+        AlgorithmParameters::RSA(_)
+            | AlgorithmParameters::EllipticCurve(_)
+            | AlgorithmParameters::OctetKeyPair(_)
+    )
+}
+
+fn validate_jwk_for_header(
+    jwk: &Jwk,
+    header_alg: Algorithm,
+) -> std::result::Result<(), VerificationError> {
+    if !is_asymmetric_jwk(jwk) {
+        return Err(VerificationError::UnsupportedAlgorithm);
+    }
+    if let Some(use_) = &jwk.common.public_key_use
+        && use_ != &PublicKeyUse::Signature
+    {
+        return Err(VerificationError::InvalidToken);
+    }
+    if let Some(key_ops) = &jwk.common.key_operations
+        && !key_ops
+            .iter()
+            .any(|operation| operation == &KeyOperations::Verify)
+    {
+        return Err(VerificationError::InvalidToken);
+    }
+    if let Some(key_algorithm) = jwk.common.key_algorithm {
+        let key_algorithm = Algorithm::from_str(&key_algorithm.to_string())
+            .map_err(|_| VerificationError::UnsupportedAlgorithm)?;
+        if key_algorithm != header_alg {
+            return Err(VerificationError::UnsupportedAlgorithm);
+        }
+    }
+    Ok(())
+}
+
+fn jwt_error_to_verification_error(error: &jsonwebtoken::errors::Error) -> VerificationError {
+    match error.kind() {
+        JwtErrorKind::ExpiredSignature | JwtErrorKind::ImmatureSignature => {
+            VerificationError::StaleIdentity
+        }
+        JwtErrorKind::InvalidSignature => VerificationError::InvalidSignature,
+        JwtErrorKind::InvalidAlgorithm | JwtErrorKind::MissingAlgorithm => {
+            VerificationError::UnsupportedAlgorithm
+        }
+        _ => VerificationError::InvalidToken,
+    }
+}
+
 fn sha256_hex(bytes: &[u8]) -> String {
     let digest = Sha256::digest(bytes);
     let mut out = String::with_capacity(digest.len() * 2);
@@ -332,10 +721,15 @@ pub(crate) fn sign_proxy_identity_for_tests(secret: &[u8], identity_header_value
 #[cfg(test)]
 mod tests {
     use axum::http::HeaderMap;
+    use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
     use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::{
-        HostedAuthMode, ProxyIdentityVerifier, VerificationError, encode_proxy_identity_for_tests,
+        HostedAuthMode, JwtIdentityVerifier, JwtIdentityVerifierParts, ProxyIdentityVerifier,
+        VerificationError, build_blocking_jwks_client, build_jwks_client,
+        encode_proxy_identity_for_tests, fetch_jwks_blocking, parse_jwt_algorithms,
         sign_proxy_identity_for_tests,
     };
 
@@ -355,6 +749,83 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("x-nova-identity", identity.parse().unwrap());
         headers.insert("x-nova-signature", signature.parse().unwrap());
+        headers
+    }
+
+    const PRIVATE_ED25519_KEY_PEM: &str = "\
+-----BEGIN PRIVATE KEY-----\n\
+MC4CAQAwBQYDK2VwBCIEIGrD/e7uKYqSY4twDEsRfMMuLSrODf14dpTiTK6K1YI0\n\
+-----END PRIVATE KEY-----\n";
+
+    const OTHER_PRIVATE_ED25519_KEY_PEM: &str = "\
+-----BEGIN PRIVATE KEY-----\n\
+MC4CAQAwBQYDK2VwBCIEIEKk6M0gfjMZ4Fd3gv9+78epAFf/OIMWfcospPeL6oyH\n\
+-----END PRIVATE KEY-----\n";
+
+    fn jwt_jwks(kid: &str) -> jsonwebtoken::jwk::JwkSet {
+        serde_json::from_value(json!({
+            "keys": [{
+                "kty": "OKP",
+                "use": "sig",
+                "crv": "Ed25519",
+                "x": "2-Jj2UvNCvQiUPNYRgSi0cJSPiJI6Rs6D0UTeEpQVj8",
+                "kid": kid,
+                "alg": "EdDSA"
+            }]
+        }))
+        .expect("test JWKS")
+    }
+
+    fn jwt_verifier(jwks: jsonwebtoken::jwk::JwkSet) -> JwtIdentityVerifier {
+        JwtIdentityVerifier::from_parts(JwtIdentityVerifierParts {
+            issuer: "https://issuer.example".to_string(),
+            audience: "dbt-nova".to_string(),
+            subject_claim: "sub".to_string(),
+            jwks_url: "https://issuer.example/.well-known/jwks.json".to_string(),
+            algorithms: vec![Algorithm::EdDSA],
+            clock_skew_secs: 0,
+            jwks,
+            client: build_jwks_client().expect("JWKS client"),
+        })
+    }
+
+    fn jwt_claims(
+        sub: &str,
+        issuer: &str,
+        audience: &str,
+        nbf: u64,
+        exp: u64,
+    ) -> serde_json::Value {
+        json!({
+            "sub": sub,
+            "iss": issuer,
+            "aud": audience,
+            "nbf": nbf,
+            "exp": exp,
+        })
+    }
+
+    fn signed_jwt(kid: &str, claims: &serde_json::Value) -> String {
+        signed_jwt_with_key(kid, claims, PRIVATE_ED25519_KEY_PEM)
+    }
+
+    fn signed_jwt_with_key(kid: &str, claims: &serde_json::Value, private_key_pem: &str) -> String {
+        let mut header = Header::new(Algorithm::EdDSA);
+        header.kid = Some(kid.to_string());
+        encode(
+            &header,
+            claims,
+            &EncodingKey::from_ed_pem(private_key_pem.as_bytes()).expect("test Ed25519 key"),
+        )
+        .expect("test JWT")
+    }
+
+    fn authorization_headers(token: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            format!("Bearer {token}").parse().unwrap(),
+        );
         headers
     }
 
@@ -447,5 +918,205 @@ mod tests {
             .expect_err("oversized identity header should fail");
 
         assert_eq!(error, VerificationError::MissingIdentity);
+    }
+
+    #[tokio::test]
+    async fn jwt_identity_rejects_missing_bearer_token() {
+        let verifier = jwt_verifier(jwt_jwks("ed01"));
+        let error = verifier
+            .verify_headers(&HeaderMap::new())
+            .await
+            .expect_err("JWT mode requires bearer authorization");
+
+        assert_eq!(error, VerificationError::MissingAuthorization);
+    }
+
+    #[test]
+    fn jwt_identity_accepts_valid_eddsa_jwks_token() {
+        let verifier = jwt_verifier(jwt_jwks("ed01"));
+        let claims = jwt_claims(
+            "user@example.com",
+            "https://issuer.example",
+            "dbt-nova",
+            super::unix_now_secs().saturating_sub(10),
+            super::unix_now_secs() + 3600,
+        );
+        let token = signed_jwt("ed01", &claims);
+
+        let identity = verifier
+            .verify_token_with_cache(&token)
+            .expect("JWT should verify");
+
+        assert_eq!(identity.mode, HostedAuthMode::Jwt);
+        assert_eq!(identity.subject_hash.len(), 64);
+        assert_ne!(identity.subject_hash, "user@example.com");
+    }
+
+    #[test]
+    fn jwt_identity_rejects_wrong_audience() {
+        let verifier = jwt_verifier(jwt_jwks("ed01"));
+        let claims = jwt_claims(
+            "user@example.com",
+            "https://issuer.example",
+            "other-service",
+            super::unix_now_secs().saturating_sub(10),
+            super::unix_now_secs() + 3600,
+        );
+        let token = signed_jwt("ed01", &claims);
+
+        let error = verifier
+            .verify_token_with_cache(&token)
+            .expect_err("wrong audience should fail");
+
+        assert_eq!(error, VerificationError::InvalidToken);
+    }
+
+    #[test]
+    fn jwt_identity_rejects_wrong_issuer() {
+        let verifier = jwt_verifier(jwt_jwks("ed01"));
+        let claims = jwt_claims(
+            "user@example.com",
+            "https://issuer.invalid",
+            "dbt-nova",
+            super::unix_now_secs().saturating_sub(10),
+            super::unix_now_secs() + 3600,
+        );
+        let token = signed_jwt("ed01", &claims);
+
+        let error = verifier
+            .verify_token_with_cache(&token)
+            .expect_err("wrong issuer should fail");
+
+        assert_eq!(error, VerificationError::InvalidToken);
+    }
+
+    #[test]
+    fn jwt_identity_rejects_expired_token() {
+        let verifier = jwt_verifier(jwt_jwks("ed01"));
+        let claims = jwt_claims(
+            "user@example.com",
+            "https://issuer.example",
+            "dbt-nova",
+            super::unix_now_secs().saturating_sub(120),
+            super::unix_now_secs().saturating_sub(60),
+        );
+        let token = signed_jwt("ed01", &claims);
+
+        let error = verifier
+            .verify_token_with_cache(&token)
+            .expect_err("expired token should fail");
+
+        assert_eq!(error, VerificationError::StaleIdentity);
+    }
+
+    #[test]
+    fn jwt_identity_rejects_not_yet_valid_token() {
+        let verifier = jwt_verifier(jwt_jwks("ed01"));
+        let claims = jwt_claims(
+            "user@example.com",
+            "https://issuer.example",
+            "dbt-nova",
+            super::unix_now_secs() + 60,
+            super::unix_now_secs() + 3600,
+        );
+        let token = signed_jwt("ed01", &claims);
+
+        let error = verifier
+            .verify_token_with_cache(&token)
+            .expect_err("future nbf token should fail");
+
+        assert_eq!(error, VerificationError::StaleIdentity);
+    }
+
+    #[test]
+    fn jwt_identity_rejects_unknown_kid() {
+        let verifier = jwt_verifier(jwt_jwks("other"));
+        let claims = jwt_claims(
+            "user@example.com",
+            "https://issuer.example",
+            "dbt-nova",
+            super::unix_now_secs().saturating_sub(10),
+            super::unix_now_secs() + 3600,
+        );
+        let token = signed_jwt("ed01", &claims);
+
+        let error = verifier
+            .verify_token_with_cache(&token)
+            .expect_err("unknown kid should fail");
+
+        assert_eq!(error, VerificationError::UnknownKeyId);
+    }
+
+    #[test]
+    fn jwt_identity_rejects_bad_signature() {
+        let verifier = jwt_verifier(jwt_jwks("ed01"));
+        let claims = jwt_claims(
+            "user@example.com",
+            "https://issuer.example",
+            "dbt-nova",
+            super::unix_now_secs().saturating_sub(10),
+            super::unix_now_secs() + 3600,
+        );
+        let token = signed_jwt_with_key("ed01", &claims, OTHER_PRIVATE_ED25519_KEY_PEM);
+
+        let error = verifier
+            .verify_token_with_cache(&token)
+            .expect_err("bad signature should fail");
+
+        assert_eq!(error, VerificationError::InvalidSignature);
+    }
+
+    #[test]
+    fn jwt_identity_rejects_hmac_algorithm_config() {
+        let error = parse_jwt_algorithms(&["HS256".to_string()])
+            .expect_err("HMAC JWT algorithms should be rejected");
+
+        assert!(error.to_string().contains("HS256"));
+    }
+
+    #[test]
+    fn jwt_identity_reports_jwks_fetch_outage() {
+        let client = build_blocking_jwks_client().expect("JWKS client");
+        let error = fetch_jwks_blocking(&client, "http://127.0.0.1:9/jwks")
+            .expect_err("outage should fail");
+
+        assert!(error.to_string().contains("DBT_NOVA_JWT_JWKS_URL"));
+    }
+
+    #[tokio::test]
+    async fn jwt_identity_refreshes_jwks_on_unknown_kid() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/jwks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(jwt_jwks("ed01")))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let verifier = JwtIdentityVerifier::from_parts(JwtIdentityVerifierParts {
+            issuer: "https://issuer.example".to_string(),
+            audience: "dbt-nova".to_string(),
+            subject_claim: "sub".to_string(),
+            jwks_url: format!("{}/jwks", server.uri()),
+            algorithms: vec![Algorithm::EdDSA],
+            clock_skew_secs: 0,
+            jwks: jwt_jwks("old"),
+            client: build_jwks_client().expect("JWKS client"),
+        });
+        let claims = jwt_claims(
+            "user@example.com",
+            "https://issuer.example",
+            "dbt-nova",
+            super::unix_now_secs().saturating_sub(10),
+            super::unix_now_secs() + 3600,
+        );
+        let token = signed_jwt("ed01", &claims);
+        let headers = authorization_headers(&token);
+
+        let identity = verifier
+            .verify_headers(&headers)
+            .await
+            .expect("refresh should load matching key");
+
+        assert_eq!(identity.mode, HostedAuthMode::Jwt);
     }
 }

--- a/tests/hosted_identity_docs.rs
+++ b/tests/hosted_identity_docs.rs
@@ -33,7 +33,7 @@ fn hosted_identity_docs_lock_default_off_guardrails() {
 }
 
 #[test]
-fn hosted_identity_contract_documents_proxy_mode_and_jwt_fail_closed() {
+fn hosted_identity_contract_documents_proxy_and_jwt_modes() {
     let contract = read_doc("docs/development/hosted-identity-contract.md");
     let config_reference = read_doc("docs/configuration/reference.md");
     let hosted_deployment = read_doc("docs/operations/hosted-deployment.md");
@@ -44,10 +44,9 @@ fn hosted_identity_contract_documents_proxy_mode_and_jwt_fail_closed() {
     assert!(contract.contains("Proxy Envelope"));
     assert!(contract.contains("HMAC-SHA256"));
     assert!(config_reference.contains("DBT_NOVA_AUTH_MODE"));
-    assert!(config_reference.contains("proxy_signed_headers` is enforced"));
+    assert!(config_reference.contains("proxy_signed_headers` and `jwt` are enforced"));
     assert!(hosted_deployment.contains("Proxy-Signed Identity Mode"));
-    assert!(
-        config_reference.contains("`jwt` remains planned and fails validation"),
-        "runtime config reference must describe JWT as fail-closed"
-    );
+    assert!(hosted_deployment.contains("JWT Identity Mode"));
+    assert!(contract.contains("HS* algorithms are never accepted"));
+    assert!(config_reference.contains("asymmetric/EdDSA algorithms only"));
 }


### PR DESCRIPTION
## Summary
- implement default-off `DBT_NOVA_AUTH_MODE=jwt` for hosted streamable HTTP using issuer/audience/time/signature/key-id validation against operator-configured HTTPS JWKS
- keep Nova proxy-first and attribution-only: no tenant routing, semantic-layer auth, warehouse brokering, or raw identity/token logging
- refresh JWKS once on unknown `kid` or signature failure, reject HS*/`none`, require bearer tokens, and document the shipped contract

## Validation
- `cargo fmt --check && git diff --check`
- `cargo test --locked --no-default-features jwt --lib`
- `cargo test --locked --test hosted_identity_docs`
- `bash scripts/check_config_reference.sh`
- `uv run mkdocs build --strict`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`

Linear: JOE-664
