### PR TITLE
Clarify OSI boundary for semantic evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a provider-backed reviewer eval case and reviewer skill guidance for
   flagging raw fact joins when Nova evidence marks a cross-grain KPI as
   metadata-only or not directly SQL-queryable.
+- Clarified that external semantic interchange files count as Nova evidence
+  only after dbt normalizes them into manifest-backed metrics or semantic
+  models, avoiding a direct ingestion path.
 - Added machine-checked MCP tool stability metadata, profile membership docs,
   and safety-gate posture for the canonical 53-tool catalog while preserving
   v0.0.x versioning.

--- a/docs/features/nova-meta-metrics.md
+++ b/docs/features/nova-meta-metrics.md
@@ -107,8 +107,11 @@ For cross-grain KPIs, prefer one of these surfaces:
 - a dbt model at the intended analysis grain;
 - an existing `meta.nova` measure or metric on a queryable dbt artifact;
 - a dbt Semantic Layer / MetricFlow artifact;
-- an OSI semantic artifact when the artifact is scoped and deterministic;
 - a saved query or Nova recipe for report-shaped outputs.
+
+When dbt parses an external semantic interchange file into manifest `metrics`
+or `semantic_models`, Nova treats it through the existing manifest-backed
+Semantic Layer evidence. Nova does not ingest those external files directly.
 
 `composite_metrics` and `NovaMetric.derivation` graphs are not part of the
 current Nova schema. They should not be used as metadata-only substitutes for a

--- a/src/tools/modeling/agent_findings.rs
+++ b/src/tools/modeling/agent_findings.rs
@@ -610,7 +610,7 @@ pub(super) fn collect_single_metric_cross_grain_findings(
                 "direct_sql_queryable": execution.direct_sql_queryable(),
                 "queryable_via": execution.queryable_via()
             }),
-            recommendation: "Do not leave a ratio/cross-grain KPI as metadata-only. Expose a dbt model, MetricFlow metric, OSI-derived semantic artifact, recipe, or saved query.".to_string(),
+            recommendation: "Do not leave a ratio/cross-grain KPI as metadata-only. Expose a dbt model, manifest-backed Semantic Layer metric, recipe, or saved query.".to_string(),
             drill_down_hints: entity_drill_down_hints(unique_id),
         });
     }


### PR DESCRIPTION
## Summary

- Remove direct OSI semantic artifact wording from cross-grain KPI guidance.
- Clarify that external semantic interchange files only count as Nova evidence after dbt normalizes them into manifest-backed `metrics` or `semantic_models`.
- Update the ratio/cross-grain finding recommendation so it points agents toward manifest-backed Semantic Layer evidence, dbt models, recipes, or saved queries without implying direct OSI ingestion.

## Why

JOE-350 is a conservative boundary decision. Current dbt docs say OSI definitions are parsed into dbt artifacts, including `manifest.json`; Nova already consumes the manifest semantic sections and should stay a metadata bridge rather than grow a direct OSI ingestion path.

## Validation

- `cargo test --locked docs_and_skills_avoid_semantic_layer_product_drift`
- `cargo test --locked modeling`
- `uv run mkdocs build --strict`
- `cargo fmt --check && git diff --check`

Linear: JOE-350