### PR TITLE
Add Snowflake workload identity federation auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardened Databricks and BigQuery SQL execution so local poll timeouts attempt
   provider-side cancellation, and Databricks now enforces local row/byte caps
   while merging inline and fetched result chunks.
+- Added Snowflake SQL API workload identity federation auth as a pass-through
+  bearer-token mode (`DBT_NOVA_SNOWFLAKE_AUTH=wif`) for caller-supplied
+  AWS/Azure/GCP/OIDC workload identity tokens.
 - Enforced `manifest_max_bytes` for local manifest paths and auto-discovered
   sibling `catalog.json` files before parsing.
 - Fixed storage loading so readers reuse complete published versions without

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -1284,7 +1284,7 @@ Notes:
   strings while `column_types` retains the provider type names.
 - Object-level preflight checks (`preflight_catalog`, `preflight_schema`, `preflight_relation`) require a non-empty probe result across providers; missing/inaccessible targets return `ok=false`.
 - BigQuery credentials can come from OAuth token env vars, `GOOGLE_APPLICATION_CREDENTIALS`, or gcloud ADC (same auth family used by GCS SDK mode).
-- Snowflake credentials can use key-pair JWT, a supplied OAuth bearer token, a Snowflake programmatic access token, or local interactive external browser SSO (`DBT_NOVA_SNOWFLAKE_AUTH=externalbrowser`). Snowflake SQL API workload identity federation is not implemented yet.
+- Snowflake credentials can use key-pair JWT, a supplied OAuth bearer token, a Snowflake programmatic access token, pass-through SQL API workload identity federation (`DBT_NOVA_SNOWFLAKE_AUTH=wif`), or local interactive external browser SSO (`DBT_NOVA_SNOWFLAKE_AUTH=externalbrowser`). Nova does not mint or refresh workload identity tokens; provide `DBT_NOVA_SNOWFLAKE_WIF_TOKEN` or `DBT_NOVA_SNOWFLAKE_WIF_TOKEN_PATH`.
 
 ```json
 {"name":"execute_sql","arguments":{"statement":"select * from orders where order_date > :date","parameters":{"date":"2024-01-01"},"row_limit":100}}

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -99,13 +99,16 @@ see [Modes & Combinations](../getting-started/modes-and-combinations.md).
 - `DBT_NOVA_SNOWFLAKE_DATABASE` – optional default Snowflake database
 - `DBT_NOVA_SNOWFLAKE_SCHEMA` – optional default Snowflake schema
 - `DBT_NOVA_SNOWFLAKE_ROLE` – optional default Snowflake role
-- `DBT_NOVA_SNOWFLAKE_AUTH` – Snowflake auth mode (`keypair`, `oauth`, `pat`, or `externalbrowser`; default: inferred from provided token variables, otherwise `keypair`)
+- `DBT_NOVA_SNOWFLAKE_AUTH` – Snowflake auth mode (`keypair`, `oauth`, `pat`, `wif`, or `externalbrowser`; default: inferred from provided token variables, otherwise `keypair`)
 - `DBT_NOVA_SNOWFLAKE_USER` – Snowflake user for key-pair or external browser auth
 - `DBT_NOVA_SNOWFLAKE_JWT_ACCOUNT` – account identifier override for key-pair JWT claims; required when key-pair auth uses `DBT_NOVA_SNOWFLAKE_ACCOUNT_URL` without `DBT_NOVA_SNOWFLAKE_ACCOUNT`. JWT account identifiers are uppercased, periods are replaced with hyphens, legacy locator-style region suffixes are excluded, and fully qualified organization/account names are preserved.
 - `DBT_NOVA_SNOWFLAKE_PRIVATE_KEY_PATH` – path to an unencrypted RSA private key PEM for key-pair auth
 - `DBT_NOVA_SNOWFLAKE_PRIVATE_KEY_PEM` – inline unencrypted RSA private key PEM for key-pair auth (`\n` escapes are accepted)
 - `DBT_NOVA_SNOWFLAKE_OAUTH_TOKEN` – OAuth bearer token for `DBT_NOVA_SNOWFLAKE_AUTH=oauth`
 - `DBT_NOVA_SNOWFLAKE_PAT` – programmatic access token for `DBT_NOVA_SNOWFLAKE_AUTH=pat`
+- `DBT_NOVA_SNOWFLAKE_WIF_PROVIDER` – workload identity federation provider for `DBT_NOVA_SNOWFLAKE_AUTH=wif` (`AWS`, `AZURE`, `GCP`, or `OIDC`)
+- `DBT_NOVA_SNOWFLAKE_WIF_TOKEN` – inline workload identity token for `DBT_NOVA_SNOWFLAKE_AUTH=wif`; set either this or `DBT_NOVA_SNOWFLAKE_WIF_TOKEN_PATH`
+- `DBT_NOVA_SNOWFLAKE_WIF_TOKEN_PATH` – path to a workload identity token file for `DBT_NOVA_SNOWFLAKE_AUTH=wif`; Nova rereads this file for each Snowflake authorization so projected tokens can rotate
 - `DBT_NOVA_SNOWFLAKE_EXTERNAL_BROWSER_TIMEOUT_S` – local browser SSO timeout for `DBT_NOVA_SNOWFLAKE_AUTH=externalbrowser` (default: `120`)
 - `DBT_NOVA_SNOWFLAKE_EXTERNAL_BROWSER_OPEN` – open the system browser automatically for external browser auth (`true`|`false`, default: `true`; when false, Nova prints the SSO URL for manual opening)
 - `DBT_NOVA_SNOWFLAKE_EXTERNAL_BROWSER_CALLBACK_PORT` – optional fixed loopback callback port for external browser auth (default: bind an ephemeral `127.0.0.1` port)
@@ -591,6 +594,7 @@ Supported providers:
   - Key-pair JWT auth: `DBT_NOVA_SNOWFLAKE_USER` plus `DBT_NOVA_SNOWFLAKE_PRIVATE_KEY_PATH` or `DBT_NOVA_SNOWFLAKE_PRIVATE_KEY_PEM`. This is the default when no token env vars are present. If only `DBT_NOVA_SNOWFLAKE_ACCOUNT_URL` is set, also set `DBT_NOVA_SNOWFLAKE_JWT_ACCOUNT`. Legacy locator-style region suffixes are excluded from JWT claims while organization/account identifiers are preserved.
   - OAuth token auth: `DBT_NOVA_SNOWFLAKE_AUTH=oauth` plus `DBT_NOVA_SNOWFLAKE_OAUTH_TOKEN`. Nova uses the supplied bearer token and does not mint or refresh OAuth tokens.
   - Programmatic access token auth: `DBT_NOVA_SNOWFLAKE_AUTH=pat` plus `DBT_NOVA_SNOWFLAKE_PAT`. PAT is inferred when `DBT_NOVA_SNOWFLAKE_AUTH` is omitted and `DBT_NOVA_SNOWFLAKE_PAT` is set.
+  - Workload identity federation auth: `DBT_NOVA_SNOWFLAKE_AUTH=wif`, `DBT_NOVA_SNOWFLAKE_WIF_PROVIDER` (`AWS`, `AZURE`, `GCP`, or `OIDC`), and exactly one of `DBT_NOVA_SNOWFLAKE_WIF_TOKEN` or `DBT_NOVA_SNOWFLAKE_WIF_TOKEN_PATH`. Nova passes the supplied token through to the Snowflake SQL API and does not mint cloud or IdP tokens.
   - External browser SSO auth: `DBT_NOVA_SNOWFLAKE_AUTH=externalbrowser` plus `DBT_NOVA_SNOWFLAKE_USER`; requires `DBT_NOVA_SNOWFLAKE_ACCOUNT` because browser SSO login needs the account name. This is local interactive auth only.
 - `duckdb`: requires `DBT_NOVA_DUCKDB_PATH` and executes queries against that file in read-only mode. Ad-hoc DuckDB file-scan functions in `execute_sql` text are rejected. Connection-level external access for trusted file-backed database objects is disabled by default; enabling it requires `DBT_NOVA_DUCKDB_ALLOW_EXTERNAL_ACCESS=true` and `DBT_NOVA_DUCKDB_FILE_SEARCH_PATH`, which is applied as both the DuckDB `file_search_path` and an `allowed_directories` bound before configuration is locked.
 
@@ -611,8 +615,10 @@ Snowflake notes:
   cancel endpoint before returning a timeout error.
 - Key-pair auth supports unencrypted RSA PEM keys. Encrypted private keys are not
   supported yet; use OAuth or PAT auth if a passphrase-protected key is required.
-- Snowflake SQL API workload identity federation is not implemented yet. Use
-  key-pair JWT, OAuth, or PAT auth for hosted automation.
+- Snowflake SQL API workload identity federation is supported as a pass-through
+  bearer-token mode. Nova does not mint or refresh AWS, Azure, GCP, Kubernetes,
+  or OIDC tokens; provide a token directly or through
+  `DBT_NOVA_SNOWFLAKE_WIF_TOKEN_PATH`.
 - External browser auth is a local interactive mode. It binds a loopback callback
   listener, opens the system browser to Snowflake SSO, keeps the returned session
   token only in process memory, rejects CI or non-loopback streamable HTTP

--- a/docs/getting-started/mcp-clients.md
+++ b/docs/getting-started/mcp-clients.md
@@ -276,6 +276,7 @@ Required:
 | `keypair` | CI, services, and long-running MCP servers | `DBT_NOVA_SNOWFLAKE_USER` plus `DBT_NOVA_SNOWFLAKE_PRIVATE_KEY_PATH` or `DBT_NOVA_SNOWFLAKE_PRIVATE_KEY_PEM` | Default when no token env vars are present. Keys must be unencrypted RSA PEM today. |
 | `oauth` | Existing Snowflake OAuth or External OAuth token flows | `DBT_NOVA_SNOWFLAKE_AUTH=oauth` plus `DBT_NOVA_SNOWFLAKE_OAUTH_TOKEN` | Nova uses a supplied bearer token; it does not mint or refresh OAuth tokens. |
 | `pat` | Simple service or personal token setup | `DBT_NOVA_SNOWFLAKE_AUTH=pat` plus `DBT_NOVA_SNOWFLAKE_PAT` | Nova sends the token as a Snowflake endpoint token. Keep it in a secret manager and rotate it. |
+| `wif` | Hosted workloads that already receive a Snowflake-trusted workload identity token | `DBT_NOVA_SNOWFLAKE_AUTH=wif`, `DBT_NOVA_SNOWFLAKE_WIF_PROVIDER`, and exactly one of `DBT_NOVA_SNOWFLAKE_WIF_TOKEN` or `DBT_NOVA_SNOWFLAKE_WIF_TOKEN_PATH` | Provider must be `AWS`, `AZURE`, `GCP`, or `OIDC`. Nova passes the supplied token through to Snowflake SQL API and does not mint cloud or IdP tokens. |
 | `externalbrowser` | Local desktop SSO and Okta/SAML testing | `DBT_NOVA_SNOWFLAKE_AUTH=externalbrowser`, `DBT_NOVA_SNOWFLAKE_USER`, and `DBT_NOVA_SNOWFLAKE_ACCOUNT` | Local interactive only. Not allowed in CI or non-loopback hosted HTTP mode. |
 
 Optional:
@@ -283,6 +284,9 @@ Optional:
 - `DBT_NOVA_SNOWFLAKE_SCHEMA`
 - `DBT_NOVA_SNOWFLAKE_ROLE`
 - `DBT_NOVA_SNOWFLAKE_JWT_ACCOUNT` (JWT account identifier override; required for key-pair auth when using `DBT_NOVA_SNOWFLAKE_ACCOUNT_URL` without `DBT_NOVA_SNOWFLAKE_ACCOUNT`)
+- `DBT_NOVA_SNOWFLAKE_WIF_PROVIDER` (`AWS`|`AZURE`|`GCP`|`OIDC`, required for `wif`)
+- `DBT_NOVA_SNOWFLAKE_WIF_TOKEN` (inline workload identity token for `wif`; set either this or `DBT_NOVA_SNOWFLAKE_WIF_TOKEN_PATH`)
+- `DBT_NOVA_SNOWFLAKE_WIF_TOKEN_PATH` (workload identity token file for `wif`; reread for each Snowflake authorization)
 - `DBT_NOVA_SNOWFLAKE_TIMEOUT_MS` (default: `30000`)
 - `DBT_NOVA_SNOWFLAKE_STATEMENT_TIMEOUT_S` (default: `60`; `0` requests Snowflake SQL API's maximum timeout window)
 - `DBT_NOVA_SNOWFLAKE_POLL_INTERVAL_MS` (default: `1000`)
@@ -307,17 +311,21 @@ Snowflake behavior notes:
 - `DBT_NOVA_SNOWFLAKE_ACCOUNT_URL` must be an account root URL such as `https://<host>`, not an `/api` endpoint.
 - If `DBT_NOVA_SNOWFLAKE_AUTH` is omitted, Nova infers `pat` when
   `DBT_NOVA_SNOWFLAKE_PAT` is set, infers `oauth` when
-  `DBT_NOVA_SNOWFLAKE_OAUTH_TOKEN` is set, and otherwise uses key-pair JWT auth.
+  `DBT_NOVA_SNOWFLAKE_OAUTH_TOKEN` is set, infers `wif` when
+  `DBT_NOVA_SNOWFLAKE_WIF_TOKEN` or `DBT_NOVA_SNOWFLAKE_WIF_TOKEN_PATH` is set,
+  and otherwise uses key-pair JWT auth.
 - Key-pair JWT claims normalize account identifiers for Snowflake: account/user values are uppercased, periods are replaced with hyphens, legacy locator-style account region suffixes are excluded, and fully qualified organization/account names are preserved.
 - For key-pair auth with a private-link or custom account URL, set both `DBT_NOVA_SNOWFLAKE_ACCOUNT_URL` and `DBT_NOVA_SNOWFLAKE_JWT_ACCOUNT`.
 - Key-pair auth supports unencrypted RSA PEM keys; encrypted private keys are not supported yet.
-- Snowflake SQL API workload identity federation is not implemented yet. Use
-  key-pair JWT, OAuth, or PAT auth for hosted automation.
+- Workload identity federation is a pass-through Snowflake SQL API bearer-token
+  mode. Nova does not call AWS, Azure, GCP, Kubernetes, or OIDC endpoints to mint
+  tokens. Prefer `DBT_NOVA_SNOWFLAKE_WIF_TOKEN_PATH` for projected tokens that
+  rotate while Nova is running.
 - External browser auth is for local interactive use. Nova binds a `127.0.0.1`
   callback listener, opens the system browser for Snowflake SSO, keeps the
   returned Snowflake session token only in memory, and supports Okta SAML
-  callbacks that omit `proofKey`. Use key-pair JWT, OAuth, or PAT auth for CI
-  and hosted/non-loopback streamable HTTP deployments.
+  callbacks that omit `proofKey`. Use key-pair JWT, OAuth, PAT, or WIF auth for
+  CI and hosted/non-loopback streamable HTTP deployments.
 
 ### Snowflake PAT Example (Codex CLI)
 
@@ -377,6 +385,27 @@ DBT_NOVA_SNOWFLAKE_SCHEMA = "REPORTING"
 DBT_NOVA_SNOWFLAKE_ROLE = "REPORTER"
 DBT_NOVA_SNOWFLAKE_AUTH = "oauth"
 DBT_NOVA_SNOWFLAKE_OAUTH_TOKEN = "<access-token>"
+DBT_NOVA_EMBEDDINGS_CACHE_DIR = "/Users/<you>/.dbt-nova/.fastembed_cache"
+```
+
+Workload identity federation token-file example:
+
+```toml
+[mcp_servers.dbt-nova]
+command = "/path/to/dbt-nova"
+startup_timeout_sec = 60
+
+[mcp_servers.dbt-nova.env]
+DBT_MANIFEST_PATH = "/path/to/manifest.json"
+DBT_NOVA_SQL_PROVIDER = "snowflake"
+DBT_NOVA_SNOWFLAKE_ACCOUNT = "myorg-myaccount"
+DBT_NOVA_SNOWFLAKE_WAREHOUSE = "ANALYST_WH"
+DBT_NOVA_SNOWFLAKE_DATABASE = "ANALYTICS"
+DBT_NOVA_SNOWFLAKE_SCHEMA = "REPORTING"
+DBT_NOVA_SNOWFLAKE_ROLE = "REPORTER"
+DBT_NOVA_SNOWFLAKE_AUTH = "wif"
+DBT_NOVA_SNOWFLAKE_WIF_PROVIDER = "OIDC"
+DBT_NOVA_SNOWFLAKE_WIF_TOKEN_PATH = "/var/run/secrets/tokens/snowflake"
 DBT_NOVA_EMBEDDINGS_CACHE_DIR = "/Users/<you>/.dbt-nova/.fastembed_cache"
 ```
 

--- a/docs/operations/limitations.md
+++ b/docs/operations/limitations.md
@@ -21,8 +21,8 @@ This page documents practical limits and edge cases to consider in production.
 - Parameterized queries are supported, but only for providers that implement them.
 - Snowflake provider uses the Snowflake SQL API. Multi-statement execution is not
   supported, key-pair auth currently requires an unencrypted RSA PEM key,
-  workload identity federation is not implemented yet, and external browser SSO
-  is local interactive only.
+  workload identity federation requires a caller-supplied Snowflake-trusted
+  token, and external browser SSO is local interactive only.
 - DuckDB provider is read-only and requires `DBT_NOVA_DUCKDB_PATH`; DuckDB `parameter_types` hints are not supported. Ad-hoc file-scan functions in `execute_sql` text are rejected. Connection-level external access for trusted file-backed database objects is disabled by default and requires `DBT_NOVA_DUCKDB_ALLOW_EXTERNAL_ACCESS=true` plus `DBT_NOVA_DUCKDB_FILE_SEARCH_PATH`.
 - DuckDB uses a bounded per-process connection pool keyed by `(duckdb_path,file_search_path,external_access)`; tune with `DBT_NOVA_DUCKDB_POOL_MAX_SIZE` if needed.
 - Object-level preflight checks (`preflight_catalog`, `preflight_schema`, `preflight_relation`) require non-empty probe results across providers.

--- a/src/warehouse/snowflake.rs
+++ b/src/warehouse/snowflake.rs
@@ -57,7 +57,7 @@ const SESSION_EXPIRY_SAFETY_WINDOW_SECONDS: u64 = 60;
 const MAX_BROWSER_CALLBACK_REQUEST_BYTES: usize = 1024 * 1024;
 const STATEMENT_STILL_EXECUTING_CODE: &str = "333333";
 const STATEMENT_ASYNC_EXECUTION_CODE: &str = "333334";
-const SUPPORTED_SNOWFLAKE_AUTH_MODES: &str = "keypair, oauth, pat, or externalbrowser";
+const SUPPORTED_SNOWFLAKE_AUTH_MODES: &str = "keypair, oauth, pat, wif, or externalbrowser";
 const EXTERNAL_BROWSER_AUTHENTICATOR: &str = "EXTERNALBROWSER";
 
 type ExternalBrowserSessionCache = Arc<TokioMutex<Option<SnowflakeSession>>>;
@@ -90,6 +90,10 @@ enum SnowflakeAuthConfig {
     ProgrammaticAccessToken {
         token: String,
     },
+    WorkloadIdentityFederation {
+        provider: String,
+        token_source: SnowflakeWifTokenSource,
+    },
     ExternalBrowser {
         user: String,
         account_identifier: String,
@@ -98,6 +102,32 @@ enum SnowflakeAuthConfig {
         callback_port: Option<u16>,
         session_cache: Arc<TokioMutex<Option<SnowflakeSession>>>,
     },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum SnowflakeWifTokenSource {
+    Inline(String),
+    FilePath(String),
+}
+
+impl SnowflakeWifTokenSource {
+    fn token(&self) -> Result<String> {
+        let token = match self {
+            Self::Inline(token) => token.clone(),
+            Self::FilePath(path) => std::fs::read_to_string(path).map_err(|err| {
+                DbtNovaError::InvalidParams(format!(
+                    "Failed to read DBT_NOVA_SNOWFLAKE_WIF_TOKEN_PATH '{path}': {err}"
+                ))
+            })?,
+        };
+        let token = token.trim();
+        if token.is_empty() {
+            return Err(DbtNovaError::InvalidParams(
+                "Snowflake workload identity token must not be empty".to_string(),
+            ));
+        }
+        Ok(token.to_string())
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -545,6 +575,13 @@ impl SnowflakeSqlClient {
                     token_type: "PROGRAMMATIC_ACCESS_TOKEN",
                 })
             }
+            SnowflakeAuthConfig::WorkloadIdentityFederation {
+                provider,
+                token_source,
+            } => Ok(SnowflakeAuthorization::Bearer {
+                token: format!("WIF.{}.{}", provider, token_source.token()?),
+                token_type: "WORKLOAD_IDENTITY_FEDERATION",
+            }),
             SnowflakeAuthConfig::KeyPair {
                 user,
                 account_identifier,

--- a/src/warehouse/snowflake/auth.rs
+++ b/src/warehouse/snowflake/auth.rs
@@ -600,6 +600,10 @@ pub(super) fn resolve_auth_from_env(
                 Some("pat".to_string())
             } else if read_optional_env("DBT_NOVA_SNOWFLAKE_OAUTH_TOKEN").is_some() {
                 Some("oauth".to_string())
+            } else if read_optional_env("DBT_NOVA_SNOWFLAKE_WIF_TOKEN").is_some()
+                || read_optional_env("DBT_NOVA_SNOWFLAKE_WIF_TOKEN_PATH").is_some()
+            {
+                Some("wif".to_string())
             } else {
                 Some("keypair".to_string())
             }
@@ -627,6 +631,14 @@ pub(super) fn resolve_auth_from_mode(
                 "DBT_NOVA_SNOWFLAKE_PAT is required for Snowflake PAT auth",
             )?,
         }),
+        "wif" | "workload_identity" | "workload_identity_federation" => {
+            let provider = read_optional_env("DBT_NOVA_SNOWFLAKE_WIF_PROVIDER");
+            build_workload_identity_auth_config(
+                provider.as_deref(),
+                read_optional_env("DBT_NOVA_SNOWFLAKE_WIF_TOKEN"),
+                read_optional_env("DBT_NOVA_SNOWFLAKE_WIF_TOKEN_PATH"),
+            )
+        }
         "externalbrowser" | "external_browser" | "browser" => {
             ensure_external_browser_allowed_from_env(streamable_http_env_binds_non_loopback())?;
             let timeout = Duration::from_secs(
@@ -675,6 +687,53 @@ pub(super) fn resolve_auth_from_mode(
         other => Err(DbtNovaError::InvalidParams(format!(
             "Unsupported DBT_NOVA_SNOWFLAKE_AUTH '{other}' (expected {SUPPORTED_SNOWFLAKE_AUTH_MODES})"
         ))),
+    }
+}
+
+pub(super) fn build_workload_identity_auth_config(
+    provider: Option<&str>,
+    token: Option<String>,
+    token_path: Option<String>,
+) -> Result<SnowflakeAuthConfig> {
+    Ok(SnowflakeAuthConfig::WorkloadIdentityFederation {
+        provider: normalize_workload_identity_provider(provider)?,
+        token_source: resolve_workload_identity_token_source(token, token_path)?,
+    })
+}
+
+pub(super) fn normalize_workload_identity_provider(provider: Option<&str>) -> Result<String> {
+    let provider = provider
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            DbtNovaError::InvalidParams(
+                "DBT_NOVA_SNOWFLAKE_WIF_PROVIDER is required for Snowflake workload identity federation auth".to_string(),
+            )
+        })?
+        .to_ascii_uppercase();
+    if matches!(provider.as_str(), "AWS" | "AZURE" | "GCP" | "OIDC") {
+        Ok(provider)
+    } else {
+        Err(DbtNovaError::InvalidParams(format!(
+            "Unsupported DBT_NOVA_SNOWFLAKE_WIF_PROVIDER '{provider}' (expected AWS, AZURE, GCP, or OIDC)"
+        )))
+    }
+}
+
+pub(super) fn resolve_workload_identity_token_source(
+    token: Option<String>,
+    token_path: Option<String>,
+) -> Result<SnowflakeWifTokenSource> {
+    match (token, token_path) {
+        (Some(token), None) => Ok(SnowflakeWifTokenSource::Inline(token)),
+        (None, Some(path)) => Ok(SnowflakeWifTokenSource::FilePath(path)),
+        (Some(_), Some(_)) => Err(DbtNovaError::InvalidParams(
+            "Set only one of DBT_NOVA_SNOWFLAKE_WIF_TOKEN or DBT_NOVA_SNOWFLAKE_WIF_TOKEN_PATH"
+                .to_string(),
+        )),
+        (None, None) => Err(DbtNovaError::InvalidParams(
+            "DBT_NOVA_SNOWFLAKE_WIF_TOKEN or DBT_NOVA_SNOWFLAKE_WIF_TOKEN_PATH is required for Snowflake workload identity federation auth".to_string(),
+        )),
     }
 }
 
@@ -779,12 +838,12 @@ pub(super) fn ensure_external_browser_allowed(
 ) -> Result<()> {
     if running_in_ci {
         return Err(DbtNovaError::InvalidParams(
-            "Snowflake externalbrowser auth is interactive and cannot run in CI; use keypair, oauth, or pat auth".to_string(),
+            "Snowflake externalbrowser auth is interactive and cannot run in CI; use keypair, oauth, pat, or wif auth".to_string(),
         ));
     }
     if non_loopback_http_bind {
         return Err(DbtNovaError::InvalidParams(
-            "Snowflake externalbrowser auth is local-only and cannot be used with non-loopback streamable HTTP binds; use keypair, oauth, or pat auth for hosted deployments".to_string(),
+            "Snowflake externalbrowser auth is local-only and cannot be used with non-loopback streamable HTTP binds; use keypair, oauth, pat, or wif auth for hosted deployments".to_string(),
         ));
     }
     Ok(())

--- a/src/warehouse/snowflake/tests.rs
+++ b/src/warehouse/snowflake/tests.rs
@@ -1,21 +1,22 @@
 use super::auth::{
     BrowserCallback, BrowserCallbackPreflight, BrowserCallbackRequest,
     ExternalBrowserAuthenticatorRequest, ExternalBrowserAuthenticatorRequestData,
-    ExternalBrowserLoginRequest, ExternalBrowserLoginRequestData,
-    build_external_browser_auth_config, decode_external_browser_authenticator_response,
-    decode_external_browser_login_response, external_browser_session_cache, generate_keypair_jwt,
-    normalize_account_url, normalize_jwt_identifier, parse_browser_callback_request,
-    public_key_fingerprint, read_browser_callback_request,
+    ExternalBrowserLoginRequest, ExternalBrowserLoginRequestData, SnowflakeAuthorization,
+    build_external_browser_auth_config, build_workload_identity_auth_config,
+    decode_external_browser_authenticator_response, decode_external_browser_login_response,
+    external_browser_session_cache, generate_keypair_jwt, normalize_account_url,
+    normalize_jwt_identifier, normalize_workload_identity_provider, parse_browser_callback_request,
+    public_key_fingerprint, read_browser_callback_request, resolve_workload_identity_token_source,
     validate_external_browser_runtime_for_auth_with_ci,
 };
 use super::{
     DEFAULT_EXTERNAL_BROWSER_TIMEOUT_SECONDS, MAX_BROWSER_CALLBACK_REQUEST_BYTES, Result,
     ResultColumn, SnowflakeAuthConfig, SnowflakeExecuteOptions, SnowflakeQueryResult,
-    SnowflakeQueryStats, SnowflakeSqlClient, SnowflakeSqlConfig, build_bindings,
-    catalog_preflight_statement, decode_statement_status_response, normalize_preflight_relation,
-    parse_cell_value, preflight_show_result_has_exact_name, relation_preflight_statement,
-    resolve_schema_preflight_target, rewrite_named_parameters, schema_preflight_statement,
-    send_json, session_parameters, snowflake_err, summarize_error_body,
+    SnowflakeQueryStats, SnowflakeSqlClient, SnowflakeSqlConfig, SnowflakeWifTokenSource,
+    build_bindings, catalog_preflight_statement, decode_statement_status_response,
+    normalize_preflight_relation, parse_cell_value, preflight_show_result_has_exact_name,
+    relation_preflight_statement, resolve_schema_preflight_target, rewrite_named_parameters,
+    schema_preflight_statement, send_json, session_parameters, snowflake_err, summarize_error_body,
 };
 use crate::config::{DbtNovaConfig, ServerTransport};
 use flate2::{Compression, write::GzEncoder};
@@ -179,6 +180,99 @@ fn external_browser_auth_env_resolves_aliases_and_options() {
     assert_eq!(timeout, Duration::from_secs(45));
     assert!(!open_browser);
     assert_eq!(callback_port, Some(4567));
+}
+
+#[test]
+fn workload_identity_auth_config_validates_provider_and_token_source() {
+    let auth =
+        build_workload_identity_auth_config(Some("aws"), Some("inline-token".to_string()), None)
+            .expect("wif auth config");
+    let SnowflakeAuthConfig::WorkloadIdentityFederation {
+        provider,
+        token_source,
+    } = auth
+    else {
+        panic!("expected workload identity auth");
+    };
+    assert_eq!(provider, "AWS");
+    assert_eq!(
+        token_source,
+        SnowflakeWifTokenSource::Inline("inline-token".to_string())
+    );
+
+    assert_eq!(
+        normalize_workload_identity_provider(Some("azure")).expect("provider"),
+        "AZURE"
+    );
+    assert_eq!(
+        normalize_workload_identity_provider(Some("OIDC")).expect("provider"),
+        "OIDC"
+    );
+
+    let invalid_provider =
+        normalize_workload_identity_provider(Some("snowflake")).expect_err("invalid provider");
+    assert!(
+        invalid_provider
+            .to_string()
+            .contains("DBT_NOVA_SNOWFLAKE_WIF_PROVIDER")
+    );
+
+    let missing_source =
+        resolve_workload_identity_token_source(None, None).expect_err("missing source");
+    assert!(
+        missing_source
+            .to_string()
+            .contains("DBT_NOVA_SNOWFLAKE_WIF_TOKEN")
+    );
+
+    let ambiguous_source = resolve_workload_identity_token_source(
+        Some("inline-token".to_string()),
+        Some("/secure/token".to_string()),
+    )
+    .expect_err("ambiguous source");
+    assert!(ambiguous_source.to_string().contains("Set only one"));
+}
+
+#[tokio::test]
+async fn workload_identity_authorization_uses_sql_api_contract_and_rereads_token_file() {
+    let token_file = tempfile::NamedTempFile::new().expect("token file");
+    std::fs::write(token_file.path(), "token-v1\n").expect("write first token");
+    let client = SnowflakeSqlClient::new(SnowflakeSqlConfig {
+        base_url: "https://org-account.snowflakecomputing.com".to_string(),
+        warehouse: "COMPUTE_WH".to_string(),
+        database: None,
+        schema: None,
+        role: None,
+        timeout: Duration::from_secs(5),
+        default_statement_timeout_s: 60,
+        poll_interval: Duration::from_millis(1),
+        max_poll: Duration::from_secs(1),
+        max_chunks: 1,
+        auth: SnowflakeAuthConfig::WorkloadIdentityFederation {
+            provider: "AWS".to_string(),
+            token_source: SnowflakeWifTokenSource::FilePath(
+                token_file.path().to_string_lossy().into_owned(),
+            ),
+        },
+    })
+    .expect("client");
+
+    let SnowflakeAuthorization::Bearer { token, token_type } =
+        client.authorization().await.expect("first authorization")
+    else {
+        panic!("expected bearer auth");
+    };
+    assert_eq!(token, "WIF.AWS.token-v1");
+    assert_eq!(token_type, "WORKLOAD_IDENTITY_FEDERATION");
+
+    std::fs::write(token_file.path(), "token-v2\n").expect("write rotated token");
+    let SnowflakeAuthorization::Bearer { token, token_type } =
+        client.authorization().await.expect("second authorization")
+    else {
+        panic!("expected bearer auth");
+    };
+    assert_eq!(token, "WIF.AWS.token-v2");
+    assert_eq!(token_type, "WORKLOAD_IDENTITY_FEDERATION");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add `DBT_NOVA_SNOWFLAKE_AUTH=wif` for Snowflake SQL API workload identity federation.
- Accept `DBT_NOVA_SNOWFLAKE_WIF_PROVIDER` (`AWS`, `AZURE`, `GCP`, `OIDC`) plus exactly one token source: `DBT_NOVA_SNOWFLAKE_WIF_TOKEN` or `DBT_NOVA_SNOWFLAKE_WIF_TOKEN_PATH`.
- Reread token files on each authorization so projected/rotating workload tokens can be used without Nova minting or refreshing cloud identities.
- Refresh Snowflake auth docs and limitations to describe WIF as pass-through auth, not a platform identity broker.

## Basis
- Snowflake SQL API docs specify `Authorization: Bearer WIF.{provider}.{token}` and `X-Snowflake-Authorization-Token-Type: WORKLOAD_IDENTITY_FEDERATION` for WIF.
- Snowflake WIF docs frame the feature as service-to-service auth where workloads obtain attestations from AWS/Azure/GCP/OIDC providers; Nova keeps that boundary and only forwards the caller-supplied token.

## Validation
- `cargo test --locked snowflake::tests::workload_identity --all-features`
- `cargo test --locked snowflake --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- `bash scripts/check_config_reference.sh`
- `uv run mkdocs build --strict`