### PR TITLE
Document OpenTelemetry metrics decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Snowflake SQL API workload identity federation auth as a pass-through
   bearer-token mode (`DBT_NOVA_SNOWFLAKE_AUTH=wif`) for caller-supplied
   AWS/Azure/GCP/OIDC workload identity tokens.
+- Documented the OpenTelemetry exporter decision: Nova keeps Prometheus as the
+  single metrics source for now and recommends collector scraping instead of
+  adding a native OTLP exporter.
 - Enforced `manifest_max_bytes` for local manifest paths and auto-discovered
   sibling `catalog.json` files before parsing.
 - Fixed storage loading so readers reuse complete published versions without

--- a/docs/api/metrics-reference.md
+++ b/docs/api/metrics-reference.md
@@ -94,6 +94,61 @@ nova_manifest_ready_for_traffic == 0
 `/metrics` is an operator endpoint. In hosted deployments, restrict it with the
 same proxy or network ACL as MCP, or set `DBT_NOVA_METRICS_ENABLED=false`.
 
+## OpenTelemetry Decision
+
+Nova does not ship a native OTLP/OpenTelemetry exporter yet. The current
+production recommendation is to keep Nova's telemetry source simple and let an
+existing Prometheus or OpenTelemetry Collector deployment scrape `GET /metrics`.
+This preserves one recorder, one metric vocabulary, and the same privacy and
+cardinality rules across health JSON, Prometheus, and collector pipelines.
+
+Use native Prometheus scraping when your deployment already has Prometheus or
+Prometheus-compatible managed monitoring. Use an OpenTelemetry Collector when
+your organization standardizes on OTLP export, needs collector processors, or
+wants to fan Nova metrics out to multiple observability backends.
+
+Example collector scrape:
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: dbt-nova
+          metrics_path: /metrics
+          static_configs:
+            - targets: ["dbt-nova.example.internal:8080"]
+
+processors:
+  batch:
+
+exporters:
+  otlp:
+    endpoint: otel-collector.example.internal:4317
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [batch]
+      exporters: [otlp]
+```
+
+Do not add query text, entity names, manifest paths, user IDs, warehouse
+credentials, or other high-cardinality/sensitive values as collector labels or
+resource attributes. Nova's exported metric labels remain limited to `tool` and
+`result`; any collector-side enrichment should keep that boundary.
+
+A native OTLP exporter would only be worth adding if scraping `/metrics` is
+insufficient for a proven deployment shape. If that happens, it should be
+default-off, metrics-only first, reuse `ToolMetricsStore`, and emit the same
+metric names and low-cardinality attributes instead of adding a second recorder.
+
+References:
+- [OpenTelemetry Prometheus/OpenMetrics compatibility](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/)
+- [OpenTelemetry Collector Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/README.md)
+- [Prometheus OTLP guide](https://prometheus.io/docs/guides/opentelemetry/)
+
 ## Search Concurrency
 
 `health` also reports search saturation under `search_concurrency`:

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -197,7 +197,9 @@ Remote manifest notes:
   `DBT_NOVA_METRICS_ENABLED=false` makes `/metrics` return `404` while keeping
   that path out of the MCP fallback. Protect `/metrics` with the same
   proxy/network ACL as MCP because it exposes tool names, call counts, latency,
-  and readiness posture.
+  and readiness posture. Nova does not expose a native OpenTelemetry exporter;
+  use a Prometheus scrape or an OpenTelemetry Collector Prometheus receiver for
+  OTLP pipelines.
 - Hosted HTTP requests propagate a safe `X-Request-ID` response header. Nova
   accepts proxy-provided `X-Request-ID` or `X-Correlation-ID` values when they
   are short printable identifiers, otherwise it generates a UUID. Request logs


### PR DESCRIPTION
## Summary
- Record the JOE-667 decision: do not add a native OTLP/OpenTelemetry exporter yet.
- Recommend Prometheus scraping or an OpenTelemetry Collector Prometheus receiver against Nova's existing `GET /metrics` endpoint.
- Add collector scrape guidance while preserving Nova's privacy/cardinality boundary: `tool` and `result` only, no query/entity/user/path/credential labels.
- Clarify the future bar for any native OTLP exporter: default-off, metrics-only first, reuse `ToolMetricsStore`, and avoid a second telemetry recorder.

## Basis
- Nova already has one privacy-safe metrics recorder and Prometheus text export.
- OpenTelemetry's Prometheus/OpenMetrics compatibility docs define scrape-format conversion into OTLP, and the collector ecosystem supports Prometheus receiver pipelines.
- A native exporter would add dependencies and lifecycle surface without a proven gap beyond collector scraping.

## Validation
- `uv run mkdocs build --strict`
- `bash scripts/check_config_reference.sh`
- `git diff --check`