### PR TITLE
Clean up stale docs references

### DIFF
--- a/.github/skills/eval-author/assets/eval-suite-template.yml
+++ b/.github/skills/eval-author/assets/eval-suite-template.yml
@@ -1,5 +1,5 @@
 version: 1
-name: nova-analyst-smoke
+name: nova-analyst-discovery
 purpose: Prove that analyst discovery uses semantic-first KPI lookup to find the canonical governed metric, model, and context for the target workflow.
 manifest_scope: target/manifest.json for the analytics project
 known_gaps:

--- a/.github/skills/eval-author/references/provider-patterns.md
+++ b/.github/skills/eval-author/references/provider-patterns.md
@@ -198,7 +198,7 @@ Default provider run:
 
 ```bash
 dbt-nova eval agent run \
-  --suite evals/analyst-agent.yml \
+  --suite evals/custom-agent-smoke.yml \
   --provider opencode \
   --manifest-path target/manifest.json \
   --case-id metric_lookup_flow \
@@ -210,7 +210,7 @@ and noninteractive execution is acceptable, use explicit custom provider args:
 
 ```bash
 dbt-nova eval agent run \
-  --suite evals/analyst-agent.yml \
+  --suite evals/custom-agent-smoke.yml \
   --provider custom \
   --provider-command opencode \
   --provider-args-json '["run","--format","json","--dangerously-skip-permissions","{prompt}"]' \
@@ -219,7 +219,7 @@ dbt-nova eval agent run \
   --fail-under 1.0
 
 dbt-nova eval agent run \
-  --suite evals/analyst-agent.yml \
+  --suite evals/custom-agent-smoke.yml \
   --provider custom \
   --provider-command claude \
   --provider-args-json '["-p","--dangerously-skip-permissions","--verbose","--output-format","stream-json","{prompt}"]' \
@@ -228,7 +228,7 @@ dbt-nova eval agent run \
   --fail-under 1.0
 
 dbt-nova eval agent run \
-  --suite evals/analyst-agent.yml \
+  --suite evals/custom-agent-smoke.yml \
   --provider custom \
   --provider-command codex \
   --provider-args-json '["exec","--json","--dangerously-bypass-approvals-and-sandbox","--skip-git-repo-check","--cd","{workdir}","{prompt}"]' \
@@ -244,9 +244,9 @@ Custom provider:
 
 ```bash
 dbt-nova eval agent run \
-  --suite evals/analyst-agent.yml \
+  --suite evals/custom-agent-smoke.yml \
   --provider custom \
-  --provider-command ./scripts/run-agent-eval.sh \
+  --provider-command /path/to/provider-wrapper.sh \
   --provider-args-json '["--prompt","{prompt}","--trace","{trace_path}","--manifest","{manifest_path}"]' \
   --manifest-path target/manifest.json
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented the trace file size guard `DBT_NOVA_TRACE_MAX_BYTES`, the exact
   Snowflake passphrase sentinel, and removed redundant direct dependency edges
   while preserving the intentional `ort-sys` release-stack pin.
+- Refreshed eval, trace, and warm-model examples so docs and packaged skills
+  use current starter-suite names, current CLI flags, and pinned Hugging Face
+  warmup checksum URLs.
 - Enforced `manifest_max_bytes` for local manifest paths and auto-discovered
   sibling `catalog.json` files before parsing.
 - Fixed storage loading so readers reuse complete published versions without

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -996,7 +996,7 @@ The response `data` includes `valid`, `path`, `suite_name`, `version`,
 `bridge_case_count`, `agent_case_count`, and `safety_policy`.
 
 ```json
-{"name":"validate_eval_suite","arguments":{"suite":"evals/analyst-smoke.yml"}}
+{"name":"validate_eval_suite","arguments":{"suite":"evals/starter.yml"}}
 ```
 
 ### `get_eval_gate`
@@ -1007,7 +1007,7 @@ Required:
 - `suite`: suite name used in telemetry
 
 ```json
-{"name":"get_eval_gate","arguments":{"suite":"analyst-smoke"}}
+{"name":"get_eval_gate","arguments":{"suite":"starter"}}
 ```
 
 ### `get_eval_history`
@@ -1025,7 +1025,7 @@ returned as assertion evidence. The `safety_policy.raw_provider_logs_enabled_env
 field names the explicit unsafe local opt-in for writing raw provider logs.
 
 ```json
-{"name":"get_eval_history","arguments":{"suite":"analyst-smoke","since":"2026-06-01"}}
+{"name":"get_eval_history","arguments":{"suite":"starter","since":"2026-06-01"}}
 ```
 
 ### `compare_eval_runs`
@@ -1074,7 +1074,7 @@ scope, case counts, pass rate, gate evidence, telemetry status, and known gaps.
 CLI runs also write `card.md` and prepend the same card to `report.md`.
 
 ```json
-{"name":"run_eval","arguments":{"suite":"evals/analyst-smoke.yml","telemetry":true,"fail_under":1.0}}
+{"name":"run_eval","arguments":{"suite":"evals/starter.yml","telemetry":true,"fail_under":1.0}}
 ```
 
 ### `init_eval_suite`
@@ -1091,7 +1091,7 @@ This file-write capability is disabled unless
 `DBT_NOVA_MCP_ENABLE_EVAL_WRITES=1` is set.
 
 ```json
-{"name":"init_eval_suite","arguments":{"persona":"analyst","out":"evals/analyst-smoke.yml"}}
+{"name":"init_eval_suite","arguments":{"persona":"analyst","out":"evals/custom-analyst-discovery.yml"}}
 ```
 
 ### `run_agent_eval`
@@ -1116,7 +1116,7 @@ The response `data.eval_card` includes provider metadata when available,
 including provider preset, command preset, and provider model.
 
 ```json
-{"name":"run_agent_eval","arguments":{"suite":"evals/analyst-smoke.yml","provider":"opencode","case_ids":["metric_lookup_flow"]}}
+{"name":"run_agent_eval","arguments":{"suite":"evals/starter.yml","provider":"opencode","case_ids":["analyst_revenue_lookup_flow"]}}
 ```
 
 ## Trace Review

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -211,6 +211,10 @@ Implementation note:
 | `run_eval` | Eval harness + loaded ManifestSearch |
 | `init_eval_suite` | Eval suite starter writer |
 | `run_agent_eval` | Eval harness + provider process |
+| `inspect_tool_trace` | Trace JSONL parser + path policy |
+| `summarize_tool_trace` | Trace summary renderer + path policy |
+| `redact_tool_trace` | Trace redactor + write safety gate |
+| `replay_tool_trace` | Trace replay harness + loaded ManifestSearch |
 | `get_metadata_score` | EntityStore + Indexes |
 | `get_metadata_audit` | Metadata Score + Selection/Gate Logic |
 | `get_agent_readiness` | Metadata Score + Nova metadata |

--- a/docs/features/agent-readiness.md
+++ b/docs/features/agent-readiness.md
@@ -224,7 +224,7 @@ provided eval gate report is blocked.
 Agent readiness can include the current eval gate status:
 
 ```bash
-dbt-nova eval gate analyst-smoke --json > out/eval-gate.json
+dbt-nova eval gate custom-analyst-discovery --json > out/eval-gate.json
 
 dbt-nova audit agent-readiness \
   --manifest-path target/manifest.json \

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -17,7 +17,7 @@ tools for realistic tasks.
 Generate a starter suite:
 
 ```bash
-dbt-nova eval init --persona analyst --out evals/analyst-smoke.yml
+dbt-nova eval init --persona analyst --out evals/custom-analyst-discovery.yml
 ```
 
 When using an agent to design or debug suites, use the packaged `eval-author`
@@ -29,7 +29,7 @@ The suite format is YAML or JSON. A minimal bridge suite looks like this:
 
 ```yaml
 version: 1
-name: analyst-smoke
+name: custom-analyst-discovery
 purpose: Prove that analyst discovery can find the canonical orders model and context.
 manifest_scope: target/manifest.json for the analytics project
 known_gaps:
@@ -55,7 +55,7 @@ cases:
 Validate suite shape before running against a manifest or provider:
 
 ```bash
-dbt-nova eval validate --suite evals/analyst-smoke.yml
+dbt-nova eval validate --suite evals/custom-analyst-discovery.yml
 ```
 
 ## Date Anchors
@@ -152,7 +152,7 @@ dbt-nova eval agent run \
 
 ```bash
 dbt-nova eval run \
-  --suite evals/analyst-smoke.yml \
+  --suite evals/custom-analyst-discovery.yml \
   --manifest-path /path/to/target/manifest.json \
   --fail-under 1.0 \
   --json
@@ -308,13 +308,13 @@ Bridge example:
 
 ```bash
 dbt-nova eval run \
-  --suite evals/analyst-smoke.yml \
+  --suite evals/custom-analyst-discovery.yml \
   --manifest-path target/manifest.json \
   --output-dir out/evals/before \
   --json
 
 dbt-nova eval run \
-  --suite evals/analyst-smoke.yml \
+  --suite evals/custom-analyst-discovery.yml \
   --manifest-path target/manifest.json \
   --output-dir out/evals/after \
   --json
@@ -328,14 +328,14 @@ Agent example:
 
 ```bash
 dbt-nova eval agent run \
-  --suite evals/analyst-agent.yml \
+  --suite evals/custom-agent-smoke.yml \
   --provider opencode \
   --manifest-path target/manifest.json \
   --output-dir out/agent-evals/before \
   --json
 
 dbt-nova eval agent run \
-  --suite evals/analyst-agent.yml \
+  --suite evals/custom-agent-smoke.yml \
   --provider opencode \
   --manifest-path target/manifest.json \
   --output-dir out/agent-evals/after \
@@ -411,7 +411,7 @@ runs where those raw artifacts are acceptable.
 
 ```yaml
 version: 1
-name: analyst-agent-smoke
+name: custom-agent-smoke
 agent_cases:
   - id: metric_lookup_flow
     task: Which canonical model and indicator should be used to analyze gross merchandise value?
@@ -534,7 +534,7 @@ Run against the default `opencode` adapter:
 
 ```bash
 dbt-nova eval agent run \
-  --suite evals/analyst-agent.yml \
+  --suite evals/custom-agent-smoke.yml \
   --provider opencode \
   --provider-model opencode/deepseek-v4-flash-free \
   --manifest-path /path/to/target/manifest.json \
@@ -581,7 +581,7 @@ line is auditable:
 
 ```bash
 dbt-nova eval agent run \
-  --suite evals/analyst-agent.yml \
+  --suite evals/custom-agent-smoke.yml \
   --provider custom \
   --provider-command opencode \
   --provider-args-json '["run","--format","json","--dangerously-skip-permissions","{prompt}"]' \
@@ -590,7 +590,7 @@ dbt-nova eval agent run \
   --fail-under 1.0
 
 dbt-nova eval agent run \
-  --suite evals/analyst-agent.yml \
+  --suite evals/custom-agent-smoke.yml \
   --provider custom \
   --provider-command claude \
   --provider-args-json '["-p","--dangerously-skip-permissions","--verbose","--output-format","stream-json","{prompt}"]' \
@@ -599,7 +599,7 @@ dbt-nova eval agent run \
   --fail-under 1.0
 
 dbt-nova eval agent run \
-  --suite evals/analyst-agent.yml \
+  --suite evals/custom-agent-smoke.yml \
   --provider custom \
   --provider-command codex \
   --provider-args-json '["exec","--json","--dangerously-bypass-approvals-and-sandbox","--skip-git-repo-check","--cd","{workdir}","{prompt}"]' \
@@ -617,9 +617,9 @@ For another provider or a custom local wrapper, pass an explicit command:
 
 ```bash
 dbt-nova eval agent run \
-  --suite evals/analyst-agent.yml \
+  --suite evals/custom-agent-smoke.yml \
   --provider custom \
-  --provider-command ./scripts/run-agent-eval.sh \
+  --provider-command /path/to/provider-wrapper.sh \
   --provider-args-json '["--prompt","{prompt}","--workdir","{workdir}","--trace","{trace_path}"]' \
   --manifest-path /path/to/target/manifest.json
 ```
@@ -681,7 +681,7 @@ Suites can declare an advisory readiness threshold:
 
 ```yaml
 version: 1
-name: analyst-smoke
+name: custom-analyst-discovery
 gate:
   threshold: 0.9
 ```
@@ -689,7 +689,7 @@ gate:
 After running the full suite with `--telemetry`, check the latest run:
 
 ```bash
-dbt-nova eval gate analyst-smoke --json
+dbt-nova eval gate custom-analyst-discovery --json
 ```
 
 The gate scans the suite telemetry JSONL, selects the latest run, computes its
@@ -744,10 +744,10 @@ evidence.
 Use bridge evals as a fast metadata quality gate after producing a manifest:
 
 ```bash
-dbt-nova eval validate --suite evals/analyst-smoke.yml
+dbt-nova eval validate --suite evals/custom-analyst-discovery.yml
 
 dbt-nova eval run \
-  --suite evals/analyst-smoke.yml \
+  --suite evals/custom-analyst-discovery.yml \
   --manifest-path target/manifest.json \
   --output-dir out/nova-evals \
   --fail-under 0.95 \

--- a/docs/features/traces.md
+++ b/docs/features/traces.md
@@ -21,7 +21,7 @@ execute SQL.
 ## Capture A Trace
 
 ```bash
-DBT_NOVA_TRACE_TOOL_CALLS_PATH=out/tool-calls/analyst-smoke.jsonl \
+DBT_NOVA_TRACE_TOOL_CALLS_PATH=out/tool-calls/custom-analyst-discovery.jsonl \
 dbt-nova tool call search_indicator \
   --params-json '{"query":"gross margin","indicator_types":["metric"],"limit":5}' \
   --manifest-path target/manifest.json \
@@ -36,7 +36,7 @@ trace details.
 
 ```bash
 dbt-nova trace inspect \
-  --path out/tool-calls/analyst-smoke.jsonl \
+  --path out/tool-calls/custom-analyst-discovery.jsonl \
   --json
 ```
 
@@ -62,8 +62,8 @@ The JSON report includes:
 
 ```bash
 dbt-nova trace summarize \
-  --path out/tool-calls/analyst-smoke.jsonl \
-  --report-md-path out/tool-calls/analyst-smoke.trace.md
+  --path out/tool-calls/custom-analyst-discovery.jsonl \
+  --report-md-path out/tool-calls/custom-analyst-discovery.trace.md
 ```
 
 `trace summarize` produces a compact Markdown report for PR comments, release
@@ -93,8 +93,8 @@ JSONL writes require `DBT_NOVA_MCP_ENABLE_TRACE_WRITES=1`.
 
 ```bash
 dbt-nova trace redact \
-  --path out/tool-calls/analyst-smoke.jsonl \
-  --out out/tool-calls/analyst-smoke.redacted.jsonl \
+  --path out/tool-calls/custom-analyst-discovery.jsonl \
+  --out out/tool-calls/custom-analyst-discovery.redacted.jsonl \
   --json
 ```
 
@@ -125,7 +125,7 @@ Redacted output remains compatible with `trace inspect` and `trace summarize`.
 
 ```bash
 dbt-nova trace replay \
-  --path out/tool-calls/analyst-smoke.redacted.jsonl \
+  --path out/tool-calls/custom-analyst-discovery.redacted.jsonl \
   --manifest-path target/manifest.json \
   --json
 ```

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -19,7 +19,7 @@ dbt-nova
 ├── manifest warm [--manifest-path|--manifest-uri] [--storage-instance-id] [--vector] [--sparse] [--reranker] [--force] [--json]
 ├── tool call <tool_name> [--params-json|--params-file|--params-stdin] [--manifest-path|--manifest-uri] [--storage-instance-id] [--cleanup-storage-on-start] [--read-only] [--json]
 ├── audit agent-readiness [--manifest-path|--manifest-uri] [--storage-instance-id] [--cleanup-storage-on-start] [--read-only] [--personas-json] [--thresholds-json|--thresholds-file] [--eval-gate-json|--eval-gate-file] [--report-json-path] [--report-md-path] [--fail-on-blockers] [--json]
-├── audit metadata-score [--selection-mode] [--changed-files-json|--changed-files-file] [--entity-ids-json|--entity-ids-file] [--resource-types-json] [--personas-json] [--thresholds-json|--thresholds-file] [--manifest-path|--manifest-uri] [--storage-instance-id] [--report-json-path] [--report-md-path] [--fail-on-no-targets] [--json]
+├── audit metadata-score [--selection-mode] [--changed-files-json|--changed-files-file] [--entity-ids-json|--entity-ids-file] [--resource-types-json] [--personas-json] [--thresholds-json|--thresholds-file] [--include-breakdown] [--include-recommendations] [--manifest-path|--manifest-uri] [--storage-instance-id] [--report-json-path] [--report-md-path] [--fail-on-no-targets] [--json]
 ├── audit nova-meta [--project-dir] [--path <PATH>...] [--resource-kind] [--resource-name] [--column] [--json]
 ├── config show [--defaults] [--json]
 ├── config validate [--json]
@@ -33,7 +33,7 @@ dbt-nova
 ├── eval init --out <PATH> [--persona] [--force]
 ├── eval validate --suite <PATH> [--json]
 ├── eval run --suite <PATH> [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--telemetry] [--telemetry-retention] [--case-id <ID>...] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
-├── eval agent run --suite <PATH> [--provider] [--provider-command] [--provider-args-json] [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--telemetry] [--telemetry-retention] [--case-id <ID>...] [--timeout-secs] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
+├── eval agent run --suite <PATH> [--provider] [--provider-model] [--provider-command] [--provider-args-json] [--manifest-path|--manifest-uri] [--storage-instance-id] [--output-dir] [--telemetry] [--telemetry-retention] [--case-id <ID>...] [--timeout-secs] [--fail-under] [--cleanup-storage-on-start] [--read-only] [--json]
 ├── eval compare --before <PATH> --after <PATH> [--json]
 ├── eval gate <NAME> [--json]
 ├── eval history --suite <NAME> --since <YYYY-MM-DD>
@@ -177,20 +177,20 @@ findings.
 
 ```bash
 dbt-nova trace inspect \
-  --path out/nova-evals/tool-calls/analyst-smoke.jsonl \
+  --path out/nova-evals/tool-calls/custom-analyst-discovery.jsonl \
   --json
 
 dbt-nova trace summarize \
-  --path out/nova-evals/tool-calls/analyst-smoke.jsonl \
-  --report-md-path out/nova-evals/tool-calls/analyst-smoke.trace.md
+  --path out/nova-evals/tool-calls/custom-analyst-discovery.jsonl \
+  --report-md-path out/nova-evals/tool-calls/custom-analyst-discovery.trace.md
 
 dbt-nova trace redact \
-  --path out/nova-evals/tool-calls/analyst-smoke.jsonl \
-  --out out/nova-evals/tool-calls/analyst-smoke.redacted.jsonl \
+  --path out/nova-evals/tool-calls/custom-analyst-discovery.jsonl \
+  --out out/nova-evals/tool-calls/custom-analyst-discovery.redacted.jsonl \
   --json
 
 dbt-nova trace replay \
-  --path out/nova-evals/tool-calls/analyst-smoke.redacted.jsonl \
+  --path out/nova-evals/tool-calls/custom-analyst-discovery.redacted.jsonl \
   --manifest-path /path/to/target/manifest.json \
   --json
 ```
@@ -264,11 +264,11 @@ dbt-nova audit nova-meta \
 ### Run Nova bridge evals
 
 ```bash
-dbt-nova eval init --persona analyst --out evals/analyst-smoke.yml
-dbt-nova eval validate --suite evals/analyst-smoke.yml
+dbt-nova eval init --persona analyst --out evals/custom-analyst-discovery.yml
+dbt-nova eval validate --suite evals/custom-analyst-discovery.yml
 
 dbt-nova eval run \
-  --suite evals/analyst-smoke.yml \
+  --suite evals/custom-analyst-discovery.yml \
   --manifest-path /path/to/target/manifest.json \
   --fail-under 1.0 \
   --json
@@ -278,7 +278,7 @@ dbt-nova eval run \
 
 ```bash
 dbt-nova eval agent run \
-  --suite evals/analyst-agent.yml \
+  --suite evals/custom-agent-smoke.yml \
   --provider opencode \
   --manifest-path /path/to/target/manifest.json \
   --timeout-secs 600

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -303,7 +303,7 @@ You can control this behavior with:
 
 For direct Hugging Face fallback, you can enable checksum verification:
 
-- `DBT_NOVA_WARMUP_CHECKSUM_MODE=off|warn|required` (default: `off`)
+- `DBT_NOVA_WARMUP_CHECKSUM_MODE=off|warn|required` (default: `warn`)
 - `DBT_NOVA_WARMUP_CHECKSUM_FILE=/path/to/checksums.txt`
 - Template manifest: `scripts/warm_models.checksums.example`
 
@@ -316,11 +316,13 @@ Checksum manifest format is one entry per line:
 Example:
 
 ```text
-3f2c... https://huggingface.co/intfloat/multilingual-e5-base/resolve/main/onnx/model.onnx
+3f2c... https://huggingface.co/intfloat/multilingual-e5-base/resolve/d128750597153bb5987e10b1c3493a34e5a4502a/onnx/model.onnx
 ```
 
 `required` mode fails warmup if a checksum entry is missing or mismatched.
-`warn` mode logs and continues when entries are missing.
+`warn` mode logs and continues when entries are missing. Checksum entries must
+match the exact resolved URL, including pinned Hugging Face revision SHAs; update
+the template URLs if you override any `DBT_NOVA_WARMUP_*_REVISION` value.
 
 During direct Hugging Face seeding, downloads are validated against HTTP
 `Content-Length` before replacing cached files, and can be additionally guarded

--- a/docs/operations/eval-ci-templates.md
+++ b/docs/operations/eval-ci-templates.md
@@ -41,8 +41,8 @@ jobs:
       DBT_NOVA_INSTALL_REF: v0.0.6
       DBT_NOVA_VERSION: v0.0.6
       DBT_NOVA_VERIFY_SIGNATURE: "1"
-      NOVA_EVAL_SUITE: evals/analyst-smoke.yml
-      NOVA_EVAL_NAME: analyst-smoke
+      NOVA_EVAL_SUITE: evals/custom-analyst-discovery.yml
+      NOVA_EVAL_NAME: custom-analyst-discovery
       NOVA_EVAL_OUTPUT: out/nova-bridge-evals
     steps:
       - uses: actions/checkout@v4
@@ -161,8 +161,8 @@ jobs:
       DBT_NOVA_INSTALL_REF: v0.0.6
       DBT_NOVA_VERSION: v0.0.6
       DBT_NOVA_VERIFY_SIGNATURE: "1"
-      NOVA_AGENT_SUITE: evals/analyst-agent.yml
-      NOVA_AGENT_NAME: analyst-agent-smoke
+      NOVA_AGENT_SUITE: evals/custom-agent-smoke.yml
+      NOVA_AGENT_NAME: custom-agent-smoke
       NOVA_AGENT_OUTPUT: out/nova-agent-evals
       NOVA_AGENT_MODEL: opencode/deepseek-v4-flash-free
     steps:

--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -89,11 +89,11 @@ Use `dbt-nova eval run` to test that a manifest exposes the right search,
 indicator, context, lineage, recipe, and metadata-score evidence to agents:
 
 ```bash
-dbt-nova eval validate --suite evals/analyst-smoke.yml
+dbt-nova eval validate --suite evals/starter.yml
 
 dbt-nova eval run \
-  --suite evals/analyst-smoke.yml \
-  --manifest-path target/manifest.json \
+  --suite evals/starter.yml \
+  --manifest-path tests/fixtures/starter_eval_manifest.json \
   --output-dir out/nova-evals \
   --fail-under 0.95 \
   --json
@@ -104,9 +104,9 @@ how agents use Nova tools in practice:
 
 ```bash
 dbt-nova eval agent run \
-  --suite evals/analyst-agent.yml \
+  --suite evals/starter.yml \
   --provider opencode \
-  --manifest-path target/manifest.json \
+  --manifest-path tests/fixtures/starter_eval_manifest.json \
   --timeout-secs 600
 ```
 

--- a/scripts/warm_models.checksums.example
+++ b/scripts/warm_models.checksums.example
@@ -5,26 +5,27 @@
 #   DBT_NOVA_WARMUP_CHECKSUM_MODE=required
 #   DBT_NOVA_WARMUP_CHECKSUM_FILE=/path/to/warm_models.checksums.txt
 #
-# Direct HF fallback URLs queried by scripts/warm_models.sh.
-# In required mode, include an entry for every URL below.
+# Direct HF fallback URLs queried by scripts/warm_models.sh with default pinned
+# revisions. In required mode, include an entry for every URL below. If you
+# override DBT_NOVA_WARMUP_*_REVISION, update the matching URLs here too.
 
 # intfloat/multilingual-e5-base
-<sha256> https://huggingface.co/intfloat/multilingual-e5-base/resolve/main/onnx/model.onnx
-<sha256> https://huggingface.co/intfloat/multilingual-e5-base/resolve/main/tokenizer.json
-<sha256> https://huggingface.co/intfloat/multilingual-e5-base/resolve/main/config.json
-<sha256> https://huggingface.co/intfloat/multilingual-e5-base/resolve/main/special_tokens_map.json
-<sha256> https://huggingface.co/intfloat/multilingual-e5-base/resolve/main/tokenizer_config.json
+<sha256> https://huggingface.co/intfloat/multilingual-e5-base/resolve/d128750597153bb5987e10b1c3493a34e5a4502a/onnx/model.onnx
+<sha256> https://huggingface.co/intfloat/multilingual-e5-base/resolve/d128750597153bb5987e10b1c3493a34e5a4502a/tokenizer.json
+<sha256> https://huggingface.co/intfloat/multilingual-e5-base/resolve/d128750597153bb5987e10b1c3493a34e5a4502a/config.json
+<sha256> https://huggingface.co/intfloat/multilingual-e5-base/resolve/d128750597153bb5987e10b1c3493a34e5a4502a/special_tokens_map.json
+<sha256> https://huggingface.co/intfloat/multilingual-e5-base/resolve/d128750597153bb5987e10b1c3493a34e5a4502a/tokenizer_config.json
 
 # Qdrant/Splade_PP_en_v1
-<sha256> https://huggingface.co/Qdrant/Splade_PP_en_v1/resolve/main/model.onnx
-<sha256> https://huggingface.co/Qdrant/Splade_PP_en_v1/resolve/main/tokenizer.json
-<sha256> https://huggingface.co/Qdrant/Splade_PP_en_v1/resolve/main/config.json
-<sha256> https://huggingface.co/Qdrant/Splade_PP_en_v1/resolve/main/special_tokens_map.json
-<sha256> https://huggingface.co/Qdrant/Splade_PP_en_v1/resolve/main/tokenizer_config.json
+<sha256> https://huggingface.co/Qdrant/Splade_PP_en_v1/resolve/efcd182bc7eb351e81a9445752d4388c2bab500b/model.onnx
+<sha256> https://huggingface.co/Qdrant/Splade_PP_en_v1/resolve/efcd182bc7eb351e81a9445752d4388c2bab500b/tokenizer.json
+<sha256> https://huggingface.co/Qdrant/Splade_PP_en_v1/resolve/efcd182bc7eb351e81a9445752d4388c2bab500b/config.json
+<sha256> https://huggingface.co/Qdrant/Splade_PP_en_v1/resolve/efcd182bc7eb351e81a9445752d4388c2bab500b/special_tokens_map.json
+<sha256> https://huggingface.co/Qdrant/Splade_PP_en_v1/resolve/efcd182bc7eb351e81a9445752d4388c2bab500b/tokenizer_config.json
 
 # jinaai/jina-reranker-v2-base-multilingual
-<sha256> https://huggingface.co/jinaai/jina-reranker-v2-base-multilingual/resolve/main/onnx/model.onnx
-<sha256> https://huggingface.co/jinaai/jina-reranker-v2-base-multilingual/resolve/main/tokenizer.json
-<sha256> https://huggingface.co/jinaai/jina-reranker-v2-base-multilingual/resolve/main/config.json
-<sha256> https://huggingface.co/jinaai/jina-reranker-v2-base-multilingual/resolve/main/special_tokens_map.json
-<sha256> https://huggingface.co/jinaai/jina-reranker-v2-base-multilingual/resolve/main/tokenizer_config.json
+<sha256> https://huggingface.co/jinaai/jina-reranker-v2-base-multilingual/resolve/9cfeff2df7d40d1b78e75e5e9cebec92a99813c9/onnx/model.onnx
+<sha256> https://huggingface.co/jinaai/jina-reranker-v2-base-multilingual/resolve/9cfeff2df7d40d1b78e75e5e9cebec92a99813c9/tokenizer.json
+<sha256> https://huggingface.co/jinaai/jina-reranker-v2-base-multilingual/resolve/9cfeff2df7d40d1b78e75e5e9cebec92a99813c9/config.json
+<sha256> https://huggingface.co/jinaai/jina-reranker-v2-base-multilingual/resolve/9cfeff2df7d40d1b78e75e5e9cebec92a99813c9/special_tokens_map.json
+<sha256> https://huggingface.co/jinaai/jina-reranker-v2-base-multilingual/resolve/9cfeff2df7d40d1b78e75e5e9cebec92a99813c9/tokenizer_config.json


### PR DESCRIPTION
## Summary
- refresh eval/trace docs and eval-author examples to use the packaged starter suite or clearly custom suite names
- document current eval/audit CLI flags and trace tools in the docs/API examples
- update warm-model checksum examples to match pinned Hugging Face revisions and record the docs sweep in the changelog

## Validation
- `uv run mkdocs build --strict` (passes; existing Material/MkDocs 2.0 warning only)
- `bash scripts/check_config_reference.sh`
- `cargo test --locked docs_`
- CLI help checks for top-level, `audit metadata-score`, `eval`, `eval agent run`, and `trace`
- stale-pattern search for old eval names, stale MCP tool counts, `resolve/main`, and raw `cross_grain`
- `git diff --check`