### PR TITLE
Harden agent-facing MCP contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Corrected agent-facing MCP contracts for entity detail, context selection,
+  readiness output, and recipe failure handling, and aligned persona-summary
+  documentation with the live three-level detail model.
 - Added opt-in `diff_entities` sections for manifest-native modelling
   comparison: `grain`, `indicators`, `governance`, `tests`, and `all`, while
   preserving the columns-only default.

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -822,7 +822,8 @@ Required:
 Optional:
 - `query_names` (list of SQL file names)
 - `query_indexes` (1-based indexes by execution order)
-- `stop_on_failure` (bool, default: `true`)
+- `stop_on_failure` (bool, default: `true`): stop after the first failed query;
+  set `false` to continue with the remaining selected queries
 - `include_sql` (bool)
 - SQL execution controls: `row_limit`, `byte_limit`, `wait_timeout_s`, `poll_interval_ms`, `max_poll_seconds`, `parameters`, `placeholder_types`, `sql_parameter_types`, `fetch_all_chunks`, `max_chunks`
 - `parameter_types` (legacy compatibility fallback alias; prefer `placeholder_types` and `sql_parameter_types`)

--- a/docs/features/persona-summaries.md
+++ b/docs/features/persona-summaries.md
@@ -1,19 +1,22 @@
 # Persona‑Aware Summary Payloads
 
-Status: **Implemented** (standard + full summaries live).
+Status: **Implemented** (`compact`, `standard`, and `full` detail levels are live).
 
 ## Why this exists
 
 Nova search/list results currently return more data than most agents need. This adds noise, slows decisions, and increases context usage. Persona‑aware summaries make discovery **fast, minimal, and decision‑ready**.
 
-## Two‑tier model
+## Detail model
 
-We standardize response detail to **two levels only**:
+Search, inventory, and entity inspection support three detail levels:
 
-- **Standard**: persona‑optimized summary (default)
-- **Full**: complete entity payload (same as `get_entity`)
+- **Compact**: identity, relation, grain, primary-key, and compact Nova signals
+- **Standard**: persona‑optimized summary
+- **Full**: complete entity payload (same as `get_entity` with `detail: "full"`)
 
-This removes compact/rich variants and makes tool flows predictable.
+When omitted, the active result profile selects the detail level. CLI/tool calls
+default to `standard`; MCP defaults to `compact`. An explicit `detail` value
+always overrides the profile.
 
 ## Summary payloads (Standard)
 
@@ -108,13 +111,24 @@ This removes compact/rich variants and makes tool flows predictable.
 - `relation_name` (or `database` + `schema`), `original_file_path`
 - `description` (truncated)
 
-## Canonical representation (no duplicates, low-noise)
+## Canonical representation and compatibility mirrors
 
-**Summaries never repeat the same concept** (no parallel lists of columns/roles/semantics).
-Summaries also strip null/empty values so agent context is compact by default.
+Summaries avoid parallel representations of columns, roles, and semantics, and
+strip null/empty values so agent context stays compact. Two v0.0.x compatibility
+mirrors remain:
 
-Full payloads return the **raw dbt manifest entity**, where `columns` is a map keyed by
-column name. We do not add duplicate column lists in summaries.
+- Analyst summaries expose `semantic_preview` both at the root and inside
+  `persona_payload`.
+- Engineer summaries expose `has_compiled_sql` both at the root and inside
+  `persona_payload`.
+
+These mirrors let generic consumers read root signals while persona-aware
+consumers keep a self-contained nested contract. They are retained for wire
+compatibility.
+
+Full payloads preserve the **complete dbt manifest entity** and add Nova's
+`provenance` object. Manifest fields are not rewritten; `columns` remains a map
+keyed by column name, and summaries do not add duplicate column lists.
 
 ## Computed fields
 
@@ -164,7 +178,7 @@ column name. We do not add duplicate column lists in summaries.
 
 - Summary `description`: ~120 chars
 - Measure/metric `description`: ~80 chars
-- Full payloads are unmodified.
+- Full payloads preserve manifest fields and add Nova provenance.
 
 ## Example usage
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -390,7 +390,7 @@ pub struct RunRecipeParams {
     /// Optional explicit 1-based query order indexes to execute.
     #[serde(default)]
     pub query_indexes: Vec<usize>,
-    /// Continue executing remaining queries when one fails.
+    /// Stop executing after the first failed query. Set false to continue executing remaining selected queries.
     #[serde(default = "default_true")]
     pub stop_on_failure: bool,
     /// Include SQL text in response payload.

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -74,7 +74,7 @@ impl ServerHandler for DbtNovaServer {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::new("dbt-nova", env!("CARGO_PKG_VERSION")))
-            .with_instructions("DBT Manifest Search and Analysis MCP Server. Use 'search' for full-text discovery, 'search_indicator' for canonical measures and metrics, 'get_entity' for complete entity data, and 'execute_sql' to run warehouse queries with the configured SQL provider.")
+            .with_instructions("DBT Manifest Search and Analysis MCP Server. Use 'search' for full-text discovery, 'search_indicator' for canonical measures and metrics, 'get_entity' to inspect one entity at the needed detail level, and 'execute_sql' to run warehouse queries with the configured SQL provider.")
     }
 }
 
@@ -874,10 +874,10 @@ impl DbtNovaServer {
         .await
     }
 
-    /// Get complete entity data by `unique_id` or name. Returns ALL fields from the manifest.
+    /// Get entity data by `unique_id` or name at the requested detail level.
     #[tool(
         name = "get_entity",
-        description = "Fetch the full manifest object for a single entity. Use after search to inspect config, SQL, tags, meta, docs, and relation info. Provide resource_type when names are ambiguous."
+        description = "Inspect one manifest entity after discovery. Returns compact, standard, or full detail; omit detail to use the active result profile. Use full only when raw manifest fields are needed, and provide resource_type when names are ambiguous."
     )]
     #[instrument(level = "info", skip(self, params))]
     async fn get_entity(&self, params: Parameters<GetEntityParams>) -> ToolCallResponse {
@@ -1459,7 +1459,7 @@ impl DbtNovaServer {
     /// Get the manifest-level agent-readiness report.
     #[tool(
         name = "get_agent_readiness",
-        description = "Agent readiness audit. Returns the same agent_readiness.v1 JSON report as the CLI audit command without writing files or applying CLI exit semantics."
+        description = "Assess whether manifest metadata is ready for agent workflows. Returns score, band, gate status, persona results, blockers, prioritized improvements, suggested patches, eval seeds and status, and next actions; it does not validate warehouse answer correctness."
     )]
     #[instrument(level = "info", skip(self, params))]
     async fn get_agent_readiness(
@@ -1584,7 +1584,7 @@ impl DbtNovaServer {
     /// Get rich context for an entity.
     #[tool(
         name = "get_context",
-        description = "One-shot context bundle. Returns lineage, columns, tests, docs, and summary stats for an entity. Use when an agent needs full context quickly."
+        description = "Bundle selected lineage, columns, tests, docs, SQL, and summary data for one resolved entity. Use after discovery when several views are needed together; prefer a focused tool when only one view is required."
     )]
     #[instrument(level = "info", skip(self, params))]
     async fn get_context(&self, params: Parameters<GetContextParams>) -> ToolCallResponse {
@@ -1594,7 +1594,7 @@ impl DbtNovaServer {
         .await
     }
 
-    /// Execute SQL against a Databricks SQL warehouse.
+    /// Execute SQL against the configured warehouse provider.
     #[tool(
         name = "execute_sql",
         description = "Run SQL against the configured warehouse provider. Supports provider diagnostics with preflight_only=true and optional catalog/schema/relation checks."

--- a/src/tools/entity.rs
+++ b/src/tools/entity.rs
@@ -10,7 +10,7 @@ use rayon::prelude::*;
 use tracing::instrument;
 
 impl ManifestSearch {
-    /// Get complete entity data by `unique_id` or name. Returns ALL fields from the manifest.
+    /// Get entity data by `unique_id` or name at the requested detail level.
     ///
     /// # Errors
     /// Returns an error if the entity cannot be resolved, is ambiguous, or the manifest is unavailable.

--- a/tests/mcp_protocol.rs
+++ b/tests/mcp_protocol.rs
@@ -37,6 +37,7 @@ const MCP_SMOKE_ENV_REMOVE: &[&str] = &[
     "DBT_NOVA_MCP_ENABLE_MANIFEST_RELOAD",
     "DBT_NOVA_MCP_ENABLE_MANIFEST_WARM",
     "DBT_NOVA_MCP_ENABLE_STORAGE_ADMIN",
+    "DBT_NOVA_DISABLE_TOOL_SCHEMAS",
 ];
 
 async fn write_json_line(
@@ -131,6 +132,13 @@ fn relative_to_repo(path: &Path) -> String {
         .expect("test artifact should be under repo root")
         .to_string_lossy()
         .to_string()
+}
+
+fn listed_tool<'a>(tools: &'a [Value], name: &str) -> &'a Value {
+    tools
+        .iter()
+        .find(|tool| tool.get("name").and_then(Value::as_str) == Some(name))
+        .unwrap_or_else(|| panic!("tools/list response missing {name}"))
 }
 
 fn scrub_mcp_smoke_env(command: &mut Command) {
@@ -491,10 +499,43 @@ async fn mcp_stdio_round_trip_supports_initialize_and_tools_list() {
         .and_then(Value::as_array)
         .expect("tools/list response missing result.tools");
     assert_eq!(tools.len(), MCP_TOOL_COUNT);
-    let has_search = tools
-        .iter()
-        .any(|tool| tool.get("name").and_then(Value::as_str) == Some("search"));
-    assert!(has_search, "tools/list should include search tool");
+    let _search = listed_tool(tools, "search");
+
+    let get_entity = listed_tool(tools, "get_entity");
+    assert_eq!(
+        get_entity.get("description").and_then(Value::as_str),
+        Some(
+            "Inspect one manifest entity after discovery. Returns compact, standard, or full detail; omit detail to use the active result profile. Use full only when raw manifest fields are needed, and provide resource_type when names are ambiguous."
+        )
+    );
+
+    let get_context = listed_tool(tools, "get_context");
+    assert_eq!(
+        get_context.get("description").and_then(Value::as_str),
+        Some(
+            "Bundle selected lineage, columns, tests, docs, SQL, and summary data for one resolved entity. Use after discovery when several views are needed together; prefer a focused tool when only one view is required."
+        )
+    );
+
+    let get_agent_readiness = listed_tool(tools, "get_agent_readiness");
+    assert_eq!(
+        get_agent_readiness
+            .get("description")
+            .and_then(Value::as_str),
+        Some(
+            "Assess whether manifest metadata is ready for agent workflows. Returns score, band, gate status, persona results, blockers, prioritized improvements, suggested patches, eval seeds and status, and next actions; it does not validate warehouse answer correctness."
+        )
+    );
+
+    let run_recipe = listed_tool(tools, "run_recipe");
+    assert_eq!(
+        run_recipe
+            .pointer("/inputSchema/properties/stop_on_failure/description")
+            .and_then(Value::as_str),
+        Some(
+            "Stop executing after the first failed query. Set false to continue executing remaining selected queries."
+        )
+    );
 
     child.start_kill().expect("failed to terminate MCP child");
     let _ = child.wait().await;


### PR DESCRIPTION
## Summary

- correct the generated `stop_on_failure` schema description so it matches recipe execution behavior
- make `get_entity`, `get_context`, and `get_agent_readiness` selection boundaries accurate and decision-oriented
- align persona-summary docs with the live compact/standard/full model, additive provenance, and retained v0.0.x compatibility mirrors
- add protocol-level assertions for the agent-visible tool descriptions and recipe parameter schema

## Why

Several agent-facing descriptions had drifted from the implementation. The most important mismatch described `stop_on_failure` with the opposite behavior, while `get_entity` implied it always returned full detail. These changes harden the interface without changing runtime behavior, defaults, wire fields, or response shapes.

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo test --locked --test mcp_protocol mcp_stdio_round_trip_supports_initialize_and_tools_list`
- `bash scripts/check_config_reference.sh`
- `uv run mkdocs build --strict`
- `git diff --check`