### PR TITLE
deps: resolve all open Dependabot alerts and harden update automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      cargo-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      docs-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      actions-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,6 @@ jobs:
     name: reusable-assets-producer
     permissions:
       contents: read
-      id-token: write
     uses: ./.github/workflows/nova-build-assets.yml
     with:
       runner: ubuntu-22.04
@@ -371,7 +370,6 @@ jobs:
     name: reusable-assets-semantic-producer
     permissions:
       contents: read
-      id-token: write
     uses: ./.github/workflows/nova-build-assets.yml
     with:
       manifest_path: tests/fixtures/nova_manifest.json
@@ -386,7 +384,6 @@ jobs:
     name: reusable-assets-producer-structured-dbt
     permissions:
       contents: read
-      id-token: write
     uses: ./.github/workflows/nova-build-assets.yml
     with:
       dbt_generate_manifest: true
@@ -404,7 +401,6 @@ jobs:
     name: reusable-assets-producer-trusted-dbt
     permissions:
       contents: read
-      id-token: write
     uses: ./.github/workflows/nova-build-assets.yml
     with:
       dbt_generate_manifest: true
@@ -498,7 +494,6 @@ jobs:
     name: reusable-assets-remote-publish-dryrun
     permissions:
       contents: read
-      id-token: write
     uses: ./.github/workflows/nova-build-assets.yml
     with:
       manifest_path: tests/fixtures/nova_manifest.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,34 @@ jobs:
       - name: Test
         run: cargo test --locked --all-features
 
+      - name: Storage format compatibility with v0.0.6
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --locked --all-features --bin dbt-nova
+
+          legacy_dir="${RUNNER_TEMP}/dbt-nova-v0.0.6"
+          mkdir -p "${legacy_dir}"
+          base_url="https://github.com/joe-broadhead/dbt-nova/releases/download/v0.0.6"
+          curl --fail --location --silent --show-error \
+            --output "${legacy_dir}/dbt-nova-linux-x86_64.tar.gz" \
+            "${base_url}/dbt-nova-linux-x86_64.tar.gz"
+          (
+            cd "${legacy_dir}"
+            printf '%s  %s\n' \
+              '2c3fdd6e284c6b1f83006e08b7d16a8eea5adcb84b76ffbdfb5af64dadad530c' \
+              'dbt-nova-linux-x86_64.tar.gz' | sha256sum --check -
+            tar -xzf dbt-nova-linux-x86_64.tar.gz
+          )
+          legacy_binary="$(find "${legacy_dir}" -maxdepth 2 -type f -name dbt-nova | head -n 1)"
+          test -n "${legacy_binary}"
+          chmod +x "${legacy_binary}"
+
+          scripts/check_storage_format_compatibility.sh \
+            ./target/debug/dbt-nova \
+            "${legacy_binary}" \
+            tests/fixtures/nova_manifest.json
+
   macos-smoke:
     runs-on: macos-14
     timeout-minutes: 45
@@ -393,12 +421,15 @@ jobs:
       dbt_executable: python3
       dbt_allow_unsafe_executable: true
       dbt_command_args_json: >-
-        ["-c","from pathlib import Path; Path('target').mkdir(exist_ok=True); Path('target/manifest.json').write_text(Path('tests/fixtures/nova_manifest.json').read_text(encoding='utf-8'), encoding='utf-8')"]
+        ["-c","import os; from pathlib import Path; assert os.environ['NOVA_CI_SECRET'] == 'bundle-only-smoke'; Path('target').mkdir(exist_ok=True); Path('target/manifest.json').write_text(Path('tests/fixtures/nova_manifest.json').read_text(encoding='utf-8'), encoding='utf-8')"]
+      dbt_secret_env_map_json: '{"NOVA_CI_SECRET":"NOVA_CI_SECRET"}'
       storage_instance_id: ci-structured-dbt-smoke
       artifact_name_prefix: ci-structured-dbt-smoke
       retention_days: 1
       installer_repository: ${{ github.repository }}
       installer_ref: ${{ github.sha }}
+    secrets:
+      DBT_NOVA_SECRET_BUNDLE_JSON: ${{ '{"NOVA_CI_SECRET":"bundle-only-smoke"}' }}
 
   reusable-assets-producer-trusted-dbt:
     name: reusable-assets-producer-trusted-dbt
@@ -464,7 +495,8 @@ jobs:
       dbt_executable: python3
       dbt_allow_unsafe_executable: true
       dbt_command_args_json: >-
-        ["-c","from pathlib import Path; Path('target').mkdir(exist_ok=True); Path('target/manifest.json').write_text(Path('tests/fixtures/nova_manifest.json').read_text(encoding='utf-8'), encoding='utf-8')"]
+        ["-c","import os; from pathlib import Path; assert os.environ['NOVA_CI_SECRET'] == 'bundle-only-smoke'; Path('target').mkdir(exist_ok=True); Path('target/manifest.json').write_text(Path('tests/fixtures/nova_manifest.json').read_text(encoding='utf-8'), encoding='utf-8')"]
+      dbt_secret_env_map_json: '{"NOVA_CI_SECRET":"NOVA_CI_SECRET"}'
       storage_instance_id: ci-metadata-audit-structured
       artifact_name_prefix: ci-metadata-audit-structured
       retention_days: 1
@@ -473,6 +505,8 @@ jobs:
       selection_mode: changed
       changed_files_json: '["models/staging/traffic/stg__traffic_sessions.sql"]'
       thresholds_json: '{"entity":{"engineer":{"min_score":0,"severity":"required"}}}'
+    secrets:
+      DBT_NOVA_SECRET_BUNDLE_JSON: ${{ '{"NOVA_CI_SECRET":"bundle-only-smoke"}' }}
 
   reusable-metadata-audit-trusted-dbt:
     name: reusable-metadata-audit-trusted-dbt
@@ -721,7 +755,8 @@ jobs:
         run: |
           set -euo pipefail
           jq -e --arg storage_instance_id "${STORAGE_INSTANCE_ID}" '
-            .contract_version == "v1" and
+            .contract_version == "v2" and
+            .storage_format_version == "nova-storage-v2" and
             (.storage_instance_id == $storage_instance_id) and
             (.manifest_hash | type == "string" and length > 0) and
             (.manifest_version | type == "string" and length > 0) and
@@ -1216,7 +1251,8 @@ jobs:
           validate_metadata_contract() {
             local metadata_file="$1"
             jq -e --arg storage_instance_id "${STORAGE_INSTANCE_ID}" '
-              .contract_version == "v1" and
+              .contract_version == "v2" and
+              .storage_format_version == "nova-storage-v2" and
               (.storage_instance_id == $storage_instance_id) and
               (.manifest_hash | type == "string" and length > 0) and
               (.manifest_version | type == "string" and length > 0) and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,6 +356,7 @@ jobs:
     name: reusable-assets-producer
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/nova-build-assets.yml
     with:
       runner: ubuntu-22.04
@@ -370,6 +371,7 @@ jobs:
     name: reusable-assets-semantic-producer
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/nova-build-assets.yml
     with:
       manifest_path: tests/fixtures/nova_manifest.json
@@ -384,6 +386,7 @@ jobs:
     name: reusable-assets-producer-structured-dbt
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/nova-build-assets.yml
     with:
       dbt_generate_manifest: true
@@ -401,6 +404,7 @@ jobs:
     name: reusable-assets-producer-trusted-dbt
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/nova-build-assets.yml
     with:
       dbt_generate_manifest: true
@@ -494,6 +498,7 @@ jobs:
     name: reusable-assets-remote-publish-dryrun
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/nova-build-assets.yml
     with:
       manifest_path: tests/fixtures/nova_manifest.json

--- a/.github/workflows/nova-build-assets.yml
+++ b/.github/workflows/nova-build-assets.yml
@@ -164,17 +164,20 @@ on:
         default: false
     secrets:
       DBT_NOVA_SECRET_BUNDLE_JSON:
-        description: "Optional JSON object of secret-name -> secret-value pairs used by dbt_secret_env_map_json"
+        description: "JSON object of explicitly selected secret-name -> secret-value pairs used by dbt_secret_env_map_json"
         required: false
     outputs:
       manifest_hash:
-        description: "Manifest content hash (populated by producer build in follow-up step)"
+        description: "Storage-scoped manifest hash (populated by producer build)"
         value: ${{ jobs.build.outputs.manifest_hash }}
       manifest_version:
-        description: "Manifest version directory (populated by producer build in follow-up step)"
+        description: "Manifest version directory (populated by producer build)"
         value: ${{ jobs.build.outputs.manifest_version }}
+      storage_format_version:
+        description: "Nova persisted-storage compatibility identity"
+        value: ${{ jobs.build.outputs.storage_format_version }}
       entity_count:
-        description: "Entity count loaded from manifest (populated by producer build in follow-up step)"
+        description: "Entity count loaded from manifest (populated by producer build)"
         value: ${{ jobs.build.outputs.entity_count }}
       artifact_name_storage:
         description: "Planned storage artifact name"
@@ -771,6 +774,7 @@ jobs:
     outputs:
       manifest_hash: ${{ steps.collect.outputs.manifest_hash }}
       manifest_version: ${{ steps.collect.outputs.manifest_version }}
+      storage_format_version: ${{ steps.collect.outputs.storage_format_version }}
       entity_count: ${{ steps.collect.outputs.entity_count }}
       artifact_name_storage: ${{ steps.collect.outputs.artifact_name_storage }}
       artifact_name_models: ${{ steps.collect.outputs.artifact_name_models }}
@@ -1040,7 +1044,6 @@ jobs:
           INPUT_DBT_EXECUTABLE: ${{ needs.prepare.outputs.dbt_executable }}
           INPUT_DBT_ENV_JSON: ${{ needs.prepare.outputs.dbt_env_json }}
           INPUT_DBT_SECRET_ENV_MAP_JSON: ${{ needs.prepare.outputs.dbt_secret_env_map_json }}
-          INHERITED_SECRETS_JSON: ${{ toJSON(secrets) }}
           DBT_NOVA_SECRET_BUNDLE_JSON: ${{ secrets.DBT_NOVA_SECRET_BUNDLE_JSON || '' }}
         run: |
           set -euo pipefail
@@ -1057,7 +1060,6 @@ jobs:
           executable = os.environ["INPUT_DBT_EXECUTABLE"]
           plain_env = json.loads(os.environ["INPUT_DBT_ENV_JSON"])
           secret_env_map = json.loads(os.environ["INPUT_DBT_SECRET_ENV_MAP_JSON"])
-          inherited_secrets = json.loads(os.environ["INHERITED_SECRETS_JSON"])
           secret_bundle_raw = os.environ.get("DBT_NOVA_SECRET_BUNDLE_JSON", "").strip()
           if secret_bundle_raw:
               try:
@@ -1079,7 +1081,6 @@ jobs:
 
           runtime_env = os.environ.copy()
           for helper_var in (
-              "INHERITED_SECRETS_JSON",
               "INPUT_DBT_ENV_JSON",
               "INPUT_DBT_SECRET_ENV_MAP_JSON",
               "INPUT_DBT_COMMAND",
@@ -1102,10 +1103,12 @@ jobs:
           for env_name, secret_name in secret_env_map.items():
               secret_value = secret_bundle.get(secret_name)
               if not isinstance(secret_value, str) or not secret_value:
-                  secret_value = inherited_secrets.get(secret_name, "")
-              if not secret_value:
                   print(
-                      f"missing secret '{secret_name}' requested by dbt_secret_env_map_json for env var '{env_name}'",
+                      (
+                          f"missing secret '{secret_name}' requested by "
+                          f"dbt_secret_env_map_json for env var '{env_name}'. "
+                          "Add the key to DBT_NOVA_SECRET_BUNDLE_JSON."
+                      ),
                       file=sys.stderr,
                   )
                   sys.exit(1)
@@ -1240,9 +1243,10 @@ jobs:
 
           manifest_hash="$(jq -r '.data.manifest_hash // empty' out/manifest-load.json)"
           manifest_version="$(jq -r '.data.manifest_version // empty' out/manifest-load.json)"
+          storage_format_version="$(jq -r '.data.storage_format_version // empty' out/manifest-load.json)"
           entity_count="$(jq -r '.data.entity_count // 0' out/manifest-load.json)"
-          if [[ -z "${manifest_hash}" || -z "${manifest_version}" ]]; then
-            echo "manifest load output missing manifest_hash/manifest_version"
+          if [[ -z "${manifest_hash}" || -z "${manifest_version}" || -z "${storage_format_version}" ]]; then
+            echo "manifest load output missing manifest_hash/manifest_version/storage_format_version"
             exit 1
           fi
           hash_short="${manifest_hash:0:12}"
@@ -1316,7 +1320,8 @@ jobs:
 
           metadata_path="out/nova-build-metadata.json"
           jq -n \
-            --arg contract_version "v1" \
+            --arg contract_version "v2" \
+            --arg storage_format_version "${storage_format_version}" \
             --arg manifest_hash "${manifest_hash}" \
             --arg manifest_version "${manifest_version}" \
             --arg storage_instance_id "${DBT_NOVA_STORAGE_INSTANCE_ID}" \
@@ -1327,6 +1332,7 @@ jobs:
             --argjson entity_count "${entity_count}" \
             '{
               contract_version: $contract_version,
+              storage_format_version: $storage_format_version,
               manifest_hash: $manifest_hash,
               manifest_version: $manifest_version,
               entity_count: $entity_count,
@@ -1338,7 +1344,8 @@ jobs:
             }' > "${metadata_path}"
 
           jq -e '
-            .contract_version == "v1" and
+            .contract_version == "v2" and
+            (.storage_format_version | type == "string" and length > 0) and
             (.manifest_hash | type == "string" and length > 0) and
             (.manifest_version | type == "string" and length > 0) and
             (.entity_count | type == "number" and . >= 0) and
@@ -1352,6 +1359,7 @@ jobs:
           {
             echo "manifest_hash=${manifest_hash}"
             echo "manifest_version=${manifest_version}"
+            echo "storage_format_version=${storage_format_version}"
             echo "entity_count=${entity_count}"
             echo "artifact_name_storage=${artifact_name_storage}"
             echo "artifact_name_models=${artifact_name_models}"
@@ -1371,7 +1379,8 @@ jobs:
             echo "- artifact_name_manifest: \`${artifact_name_manifest}\`"
             echo "- artifact_name_bootstrap: \`${artifact_name_bootstrap}\`"
             echo "- artifact_name_publish_summary: \`${artifact_name_publish_summary}\`"
-            echo "- contract_version: \`v1\`"
+            echo "- contract_version: \`v2\`"
+            echo "- storage_format_version: \`${storage_format_version}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Package storage directory
@@ -1953,10 +1962,11 @@ jobs:
           }
           
           manifest_hash="$(jq -r '.manifest_hash // empty' "${metadata_source}")"
+          storage_format_version="$(jq -r '.storage_format_version // empty' "${metadata_source}")"
           dbt_nova_version="$(jq -r '.dbt_nova_version // empty' "${metadata_source}")"
           build_timestamp="$(jq -r '.build_timestamp // empty' "${metadata_source}")"
-          if [[ -z "${manifest_hash}" || -z "${dbt_nova_version}" || -z "${build_timestamp}" ]]; then
-            echo "metadata contract is missing manifest_hash/dbt_nova_version/build_timestamp"
+          if [[ -z "${manifest_hash}" || -z "${storage_format_version}" || -z "${dbt_nova_version}" || -z "${build_timestamp}" ]]; then
+            echo "metadata contract is missing manifest_hash/storage_format_version/dbt_nova_version/build_timestamp"
             exit 1
           fi
           
@@ -1968,7 +1978,8 @@ jobs:
             local metadata_uri_value="$5"
             local models_uri_value="$6"
             jq -n \
-              --arg contract_version "v1" \
+              --arg contract_version "v2" \
+              --arg storage_format_version "${storage_format_version}" \
               --arg profile "${profile}" \
               --arg storage_instance_id "${DBT_NOVA_STORAGE_INSTANCE_ID}" \
               --arg manifest_uri "${manifest_uri_value}" \
@@ -1980,6 +1991,7 @@ jobs:
               --arg build_timestamp "${build_timestamp}" \
               '{
                 contract_version: $contract_version,
+                storage_format_version: $storage_format_version,
                 profile: $profile,
                 storage_instance_id: $storage_instance_id,
                 manifest_uri: $manifest_uri,

--- a/.github/workflows/nova-build-assets.yml
+++ b/.github/workflows/nova-build-assets.yml
@@ -23,7 +23,7 @@ on:
         type: string
         default: "joe-broadhead/dbt-nova"
       installer_ref:
-        description: "Git ref to checkout for installer_repository (defaults to resolved reusable workflow ref)"
+        description: "Git ref to fetch for installer_repository (defaults to resolved reusable workflow ref)"
         required: false
         type: string
         default: ""
@@ -598,6 +598,11 @@ jobs:
                 echo "gcp_workload_identity_provider and gcp_service_account must both be set when using OIDC-backed GCS publish."
                 exit 1
               fi
+              if [[ "${installer_install_mode}" != "release" ]]; then
+                echo "OIDC-backed GCS publish requires installer_install_mode=release."
+                echo "Source builds can execute build scripts and must not run in an OIDC-enabled publish job."
+                exit 1
+              fi
               if [[ "${dbt_generate_manifest}" == "true" ]]; then
                 echo "OIDC-backed GCS publish cannot run in the same reusable workflow job that generates a manifest from caller dbt code."
                 echo "Generate and validate the manifest before invoking this workflow, or publish with non-OIDC credentials until publish is split into a separate job."
@@ -664,6 +669,10 @@ jobs:
           if [[ -z "${installer_ref}" ]]; then
             echo "failed to resolve immutable installer ref for '${installer_repository}'."
             echo "Set installer_ref explicitly when invoking the reusable workflow."
+            exit 1
+          fi
+          if ! git check-ref-format --branch "${installer_ref}" >/dev/null 2>&1; then
+            echo "installer_ref is not a valid Git ref or full commit SHA: '${installer_ref}'."
             exit 1
           fi
           if [[ "${allow_mutable_installer_ref}" != "true" ]]; then
@@ -909,14 +918,50 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "installed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout installer source
+      - name: Fetch installer source at resolved commit
+        id: fetch_installer_source
         if: ${{ needs.prepare.outputs.installer_install_mode == 'source' || (needs.prepare.outputs.installer_install_mode == 'auto' && steps.install_release.outputs.installed != 'true') }}
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
-        with:
-          repository: ${{ needs.prepare.outputs.installer_repository }}
-          ref: ${{ needs.prepare.outputs.installer_ref }}
-          path: .nova-installer-source
-          fetch-depth: 1
+        shell: bash
+        env:
+          INSTALLER_SERVER_URL: ${{ github.server_url }}
+          INSTALLER_REPOSITORY: ${{ needs.prepare.outputs.installer_repository }}
+          INSTALLER_REF: ${{ needs.prepare.outputs.installer_ref }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" || -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]]; then
+            echo "Source installer mode refuses to run with GitHub OIDC credentials available."
+            echo "Use installer_install_mode=release or remove id-token: write from the caller job."
+            exit 1
+          fi
+
+          source_dir="${GITHUB_WORKSPACE}/.nova-installer-source"
+          rm -rf "${source_dir}"
+          git init --quiet "${source_dir}"
+          installer_origin="${INSTALLER_SERVER_URL%/}/${INSTALLER_REPOSITORY}.git"
+          git -C "${source_dir}" remote add origin "${installer_origin}"
+
+          auth_header="$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 | tr -d '\r\n')"
+          echo "::add-mask::${auth_header}"
+          git -C "${source_dir}" \
+            -c "http.extraHeader=AUTHORIZATION: basic ${auth_header}" \
+            fetch --quiet --force --depth=1 --no-tags origin "${INSTALLER_REF}"
+          unset GH_TOKEN auth_header
+
+          resolved_sha="$(git -C "${source_dir}" rev-parse 'FETCH_HEAD^{commit}')"
+          if [[ "${INSTALLER_REF}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            expected_sha="$(printf '%s' "${INSTALLER_REF}" | tr '[:upper:]' '[:lower:]')"
+            if [[ "${resolved_sha}" != "${expected_sha}" ]]; then
+              echo "Installer source resolved to ${resolved_sha}, expected ${INSTALLER_REF}."
+              exit 1
+            fi
+          fi
+
+          git -C "${source_dir}" -c advice.detachedHead=false checkout --quiet --detach "${resolved_sha}"
+          git -C "${source_dir}" remote remove origin
+          rm -rf "${source_dir}/.git"
+          echo "resolved_sha=${resolved_sha}" >> "$GITHUB_OUTPUT"
 
       - name: Validate installer source
         if: ${{ needs.prepare.outputs.installer_install_mode == 'source' || (needs.prepare.outputs.installer_install_mode == 'auto' && steps.install_release.outputs.installed != 'true') }}
@@ -981,8 +1026,6 @@ jobs:
           warm_script=""
           if [[ -f ".nova-installer-source/scripts/warm_models.sh" ]]; then
             warm_script=".nova-installer-source/scripts/warm_models.sh"
-          elif [[ -f "scripts/warm_models.sh" ]]; then
-            warm_script="scripts/warm_models.sh"
           fi
 
           if [[ -z "${warm_script}" ]]; then
@@ -1006,7 +1049,6 @@ jobs:
           INPUT_DBT_EXECUTABLE: ${{ needs.prepare.outputs.dbt_executable }}
           INPUT_DBT_ENV_JSON: ${{ needs.prepare.outputs.dbt_env_json }}
           INPUT_DBT_SECRET_ENV_MAP_JSON: ${{ needs.prepare.outputs.dbt_secret_env_map_json }}
-          INHERITED_SECRETS_JSON: ${{ toJSON(secrets) }}
           DBT_NOVA_SECRET_BUNDLE_JSON: ${{ secrets.DBT_NOVA_SECRET_BUNDLE_JSON || '' }}
         run: |
           set -euo pipefail
@@ -1023,7 +1065,6 @@ jobs:
           executable = os.environ["INPUT_DBT_EXECUTABLE"]
           plain_env = json.loads(os.environ["INPUT_DBT_ENV_JSON"])
           secret_env_map = json.loads(os.environ["INPUT_DBT_SECRET_ENV_MAP_JSON"])
-          inherited_secrets = json.loads(os.environ["INHERITED_SECRETS_JSON"])
           secret_bundle_raw = os.environ.get("DBT_NOVA_SECRET_BUNDLE_JSON", "").strip()
           if secret_bundle_raw:
               try:
@@ -1045,7 +1086,6 @@ jobs:
 
           runtime_env = os.environ.copy()
           for helper_var in (
-              "INHERITED_SECRETS_JSON",
               "INPUT_DBT_ENV_JSON",
               "INPUT_DBT_SECRET_ENV_MAP_JSON",
               "INPUT_DBT_COMMAND",
@@ -1068,10 +1108,12 @@ jobs:
           for env_name, secret_name in secret_env_map.items():
               secret_value = secret_bundle.get(secret_name)
               if not isinstance(secret_value, str) or not secret_value:
-                  secret_value = inherited_secrets.get(secret_name, "")
-              if not secret_value:
                   print(
-                      f"missing secret '{secret_name}' requested by dbt_secret_env_map_json for env var '{env_name}'",
+                      (
+                          f"missing secret '{secret_name}' requested by "
+                          f"dbt_secret_env_map_json for env var '{env_name}'. "
+                          "Provide it via DBT_NOVA_SECRET_BUNDLE_JSON."
+                      ),
                       file=sys.stderr,
                   )
                   sys.exit(1)
@@ -2263,7 +2305,7 @@ jobs:
           ARTIFACT_NAME_BOOTSTRAP: ${{ steps.collect.outputs.artifact_name_bootstrap }}
           ARTIFACT_NAME_PUBLISH_SUMMARY: ${{ steps.collect.outputs.artifact_name_publish_summary }}
           ARTIFACT_NAME_MODELS: ${{ steps.collect.outputs.artifact_name_models }}
-        run: bash "${RUNNER_TEMP}/nova_optional_publish.sh"
+        run: /bin/bash "${RUNNER_TEMP}/nova_optional_publish.sh"
 
       - name: Upload bootstrap contract artifact
         if: ${{ steps.publish.outputs.published_targets != '' }}

--- a/.github/workflows/nova-build-assets.yml
+++ b/.github/workflows/nova-build-assets.yml
@@ -598,11 +598,6 @@ jobs:
                 echo "gcp_workload_identity_provider and gcp_service_account must both be set when using OIDC-backed GCS publish."
                 exit 1
               fi
-              if [[ "${installer_install_mode}" != "release" ]]; then
-                echo "OIDC-backed GCS publish requires installer_install_mode=release."
-                echo "Source builds can execute build scripts and must not run in an OIDC-enabled publish job."
-                exit 1
-              fi
               if [[ "${dbt_generate_manifest}" == "true" ]]; then
                 echo "OIDC-backed GCS publish cannot run in the same reusable workflow job that generates a manifest from caller dbt code."
                 echo "Generate and validate the manifest before invoking this workflow, or publish with non-OIDC credentials until publish is split into a separate job."
@@ -930,12 +925,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" || -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]]; then
-            echo "Source installer mode refuses to run with GitHub OIDC credentials available."
-            echo "Use installer_install_mode=release or remove id-token: write from the caller job."
-            exit 1
-          fi
-
           source_dir="${GITHUB_WORKSPACE}/.nova-installer-source"
           rm -rf "${source_dir}"
           git init --quiet "${source_dir}"
@@ -1026,6 +1015,8 @@ jobs:
           warm_script=""
           if [[ -f ".nova-installer-source/scripts/warm_models.sh" ]]; then
             warm_script=".nova-installer-source/scripts/warm_models.sh"
+          elif [[ -f "scripts/warm_models.sh" ]]; then
+            warm_script="scripts/warm_models.sh"
           fi
 
           if [[ -z "${warm_script}" ]]; then
@@ -1049,6 +1040,7 @@ jobs:
           INPUT_DBT_EXECUTABLE: ${{ needs.prepare.outputs.dbt_executable }}
           INPUT_DBT_ENV_JSON: ${{ needs.prepare.outputs.dbt_env_json }}
           INPUT_DBT_SECRET_ENV_MAP_JSON: ${{ needs.prepare.outputs.dbt_secret_env_map_json }}
+          INHERITED_SECRETS_JSON: ${{ toJSON(secrets) }}
           DBT_NOVA_SECRET_BUNDLE_JSON: ${{ secrets.DBT_NOVA_SECRET_BUNDLE_JSON || '' }}
         run: |
           set -euo pipefail
@@ -1065,6 +1057,7 @@ jobs:
           executable = os.environ["INPUT_DBT_EXECUTABLE"]
           plain_env = json.loads(os.environ["INPUT_DBT_ENV_JSON"])
           secret_env_map = json.loads(os.environ["INPUT_DBT_SECRET_ENV_MAP_JSON"])
+          inherited_secrets = json.loads(os.environ["INHERITED_SECRETS_JSON"])
           secret_bundle_raw = os.environ.get("DBT_NOVA_SECRET_BUNDLE_JSON", "").strip()
           if secret_bundle_raw:
               try:
@@ -1086,6 +1079,7 @@ jobs:
 
           runtime_env = os.environ.copy()
           for helper_var in (
+              "INHERITED_SECRETS_JSON",
               "INPUT_DBT_ENV_JSON",
               "INPUT_DBT_SECRET_ENV_MAP_JSON",
               "INPUT_DBT_COMMAND",
@@ -1108,12 +1102,10 @@ jobs:
           for env_name, secret_name in secret_env_map.items():
               secret_value = secret_bundle.get(secret_name)
               if not isinstance(secret_value, str) or not secret_value:
+                  secret_value = inherited_secrets.get(secret_name, "")
+              if not secret_value:
                   print(
-                      (
-                          f"missing secret '{secret_name}' requested by "
-                          f"dbt_secret_env_map_json for env var '{env_name}'. "
-                          "Provide it via DBT_NOVA_SECRET_BUNDLE_JSON."
-                      ),
+                      f"missing secret '{secret_name}' requested by dbt_secret_env_map_json for env var '{env_name}'",
                       file=sys.stderr,
                   )
                   sys.exit(1)

--- a/.github/workflows/nova-metadata-audit.yml
+++ b/.github/workflows/nova-metadata-audit.yml
@@ -19,7 +19,7 @@ on:
         type: string
         default: "joe-broadhead/dbt-nova"
       installer_ref:
-        description: "Git ref to checkout for installer_repository (defaults to resolved reusable workflow ref)"
+        description: "Git ref to fetch for installer_repository (defaults to resolved reusable workflow ref)"
         required: false
         type: string
         default: ""
@@ -183,7 +183,7 @@ on:
         type: string
         default: "joe-broadhead/dbt-nova"
       installer_ref:
-        description: "Git ref to checkout for installer_repository (defaults to resolved reusable workflow ref)"
+        description: "Git ref to fetch for installer_repository (defaults to resolved reusable workflow ref)"
         required: false
         type: string
         default: ""
@@ -359,6 +359,7 @@ jobs:
           import json
           import os
           import re
+          import subprocess
           import sys
 
           def fail(message: str) -> None:
@@ -477,6 +478,14 @@ jobs:
               installer_ref = current_sha
           if not installer_repository or not installer_ref:
               fail("failed to resolve installer_repository/installer_ref; set installer_ref explicitly.")
+          valid_ref = subprocess.run(
+              ["git", "check-ref-format", "--branch", installer_ref],
+              stdout=subprocess.DEVNULL,
+              stderr=subprocess.DEVNULL,
+              check=False,
+          )
+          if valid_ref.returncode != 0:
+              fail(f"installer_ref is not a valid Git ref or full commit SHA: {installer_ref!r}.")
           if allow_mutable_installer_ref != "true":
               immutable_ref = (
                   re.fullmatch(r"[0-9a-fA-F]{40}", installer_ref)
@@ -654,14 +663,50 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "installed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout installer source
+      - name: Fetch installer source at resolved commit
+        id: fetch_installer_source
         if: ${{ needs.prepare.outputs.installer_install_mode == 'source' || (needs.prepare.outputs.installer_install_mode == 'auto' && steps.install_release.outputs.installed != 'true') }}
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
-        with:
-          repository: ${{ needs.prepare.outputs.installer_repository }}
-          ref: ${{ needs.prepare.outputs.installer_ref }}
-          path: .nova-installer-source
-          fetch-depth: 1
+        shell: bash
+        env:
+          INSTALLER_SERVER_URL: ${{ github.server_url }}
+          INSTALLER_REPOSITORY: ${{ needs.prepare.outputs.installer_repository }}
+          INSTALLER_REF: ${{ needs.prepare.outputs.installer_ref }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" || -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]]; then
+            echo "Source installer mode refuses to run with GitHub OIDC credentials available."
+            echo "Use installer_install_mode=release or remove id-token: write from the caller job."
+            exit 1
+          fi
+
+          source_dir="${GITHUB_WORKSPACE}/.nova-installer-source"
+          rm -rf "${source_dir}"
+          git init --quiet "${source_dir}"
+          installer_origin="${INSTALLER_SERVER_URL%/}/${INSTALLER_REPOSITORY}.git"
+          git -C "${source_dir}" remote add origin "${installer_origin}"
+
+          auth_header="$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 | tr -d '\r\n')"
+          echo "::add-mask::${auth_header}"
+          git -C "${source_dir}" \
+            -c "http.extraHeader=AUTHORIZATION: basic ${auth_header}" \
+            fetch --quiet --force --depth=1 --no-tags origin "${INSTALLER_REF}"
+          unset GH_TOKEN auth_header
+
+          resolved_sha="$(git -C "${source_dir}" rev-parse 'FETCH_HEAD^{commit}')"
+          if [[ "${INSTALLER_REF}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            expected_sha="$(printf '%s' "${INSTALLER_REF}" | tr '[:upper:]' '[:lower:]')"
+            if [[ "${resolved_sha}" != "${expected_sha}" ]]; then
+              echo "Installer source resolved to ${resolved_sha}, expected ${INSTALLER_REF}."
+              exit 1
+            fi
+          fi
+
+          git -C "${source_dir}" -c advice.detachedHead=false checkout --quiet --detach "${resolved_sha}"
+          git -C "${source_dir}" remote remove origin
+          rm -rf "${source_dir}/.git"
+          echo "resolved_sha=${resolved_sha}" >> "$GITHUB_OUTPUT"
 
       - name: Install Rust toolchain
         if: ${{ needs.prepare.outputs.installer_install_mode == 'source' || (needs.prepare.outputs.installer_install_mode == 'auto' && steps.install_release.outputs.installed != 'true') }}
@@ -707,7 +752,6 @@ jobs:
           INPUT_DBT_EXECUTABLE: ${{ needs.prepare.outputs.dbt_executable }}
           INPUT_DBT_ENV_JSON: ${{ needs.prepare.outputs.dbt_env_json }}
           INPUT_DBT_SECRET_ENV_MAP_JSON: ${{ needs.prepare.outputs.dbt_secret_env_map_json }}
-          INHERITED_SECRETS_JSON: ${{ toJSON(secrets) }}
           DBT_NOVA_SECRET_BUNDLE_JSON: ${{ secrets.DBT_NOVA_SECRET_BUNDLE_JSON || '' }}
         run: |
           set -euo pipefail
@@ -723,7 +767,6 @@ jobs:
           executable = os.environ["INPUT_DBT_EXECUTABLE"]
           plain_env = json.loads(os.environ["INPUT_DBT_ENV_JSON"])
           secret_env_map = json.loads(os.environ["INPUT_DBT_SECRET_ENV_MAP_JSON"])
-          inherited_secrets = json.loads(os.environ["INHERITED_SECRETS_JSON"])
           secret_bundle_raw = os.environ.get("DBT_NOVA_SECRET_BUNDLE_JSON", "").strip()
           if secret_bundle_raw:
               try:
@@ -745,7 +788,6 @@ jobs:
 
           runtime_env = os.environ.copy()
           for helper_var in (
-              "INHERITED_SECRETS_JSON",
               "INPUT_DBT_ENV_JSON",
               "INPUT_DBT_SECRET_ENV_MAP_JSON",
               "INPUT_DBT_COMMAND",
@@ -768,14 +810,11 @@ jobs:
           for env_name, secret_name in secret_env_map.items():
               secret_value = secret_bundle.get(secret_name)
               if not isinstance(secret_value, str) or not secret_value:
-                  secret_value = inherited_secrets.get(secret_name, "")
-              if not secret_value:
                   print(
                       (
                           f"missing secret '{secret_name}' requested by "
                           f"dbt_secret_env_map_json for env var '{env_name}'. "
-                          "Provide it via DBT_NOVA_SECRET_BUNDLE_JSON or "
-                          "same-owner inherited workflow secrets."
+                          "Provide it via DBT_NOVA_SECRET_BUNDLE_JSON."
                       ),
                       file=sys.stderr,
                   )

--- a/.github/workflows/nova-metadata-audit.yml
+++ b/.github/workflows/nova-metadata-audit.yml
@@ -141,7 +141,7 @@ on:
         default: ""
     secrets:
       DBT_NOVA_SECRET_BUNDLE_JSON:
-        description: "Optional JSON object of secret-name -> secret-value pairs used by dbt_secret_env_map_json"
+        description: "JSON object of explicitly selected secret-name -> secret-value pairs used by dbt_secret_env_map_json"
         required: false
     outputs:
       gate_status:
@@ -746,7 +746,6 @@ jobs:
           INPUT_DBT_EXECUTABLE: ${{ needs.prepare.outputs.dbt_executable }}
           INPUT_DBT_ENV_JSON: ${{ needs.prepare.outputs.dbt_env_json }}
           INPUT_DBT_SECRET_ENV_MAP_JSON: ${{ needs.prepare.outputs.dbt_secret_env_map_json }}
-          INHERITED_SECRETS_JSON: ${{ toJSON(secrets) }}
           DBT_NOVA_SECRET_BUNDLE_JSON: ${{ secrets.DBT_NOVA_SECRET_BUNDLE_JSON || '' }}
         run: |
           set -euo pipefail
@@ -762,7 +761,6 @@ jobs:
           executable = os.environ["INPUT_DBT_EXECUTABLE"]
           plain_env = json.loads(os.environ["INPUT_DBT_ENV_JSON"])
           secret_env_map = json.loads(os.environ["INPUT_DBT_SECRET_ENV_MAP_JSON"])
-          inherited_secrets = json.loads(os.environ["INHERITED_SECRETS_JSON"])
           secret_bundle_raw = os.environ.get("DBT_NOVA_SECRET_BUNDLE_JSON", "").strip()
           if secret_bundle_raw:
               try:
@@ -784,7 +782,6 @@ jobs:
 
           runtime_env = os.environ.copy()
           for helper_var in (
-              "INHERITED_SECRETS_JSON",
               "INPUT_DBT_ENV_JSON",
               "INPUT_DBT_SECRET_ENV_MAP_JSON",
               "INPUT_DBT_COMMAND",
@@ -807,14 +804,11 @@ jobs:
           for env_name, secret_name in secret_env_map.items():
               secret_value = secret_bundle.get(secret_name)
               if not isinstance(secret_value, str) or not secret_value:
-                  secret_value = inherited_secrets.get(secret_name, "")
-              if not secret_value:
                   print(
                       (
                           f"missing secret '{secret_name}' requested by "
                           f"dbt_secret_env_map_json for env var '{env_name}'. "
-                          "Provide it via DBT_NOVA_SECRET_BUNDLE_JSON or "
-                          "same-owner inherited workflow secrets."
+                          "Add the key to DBT_NOVA_SECRET_BUNDLE_JSON."
                       ),
                       file=sys.stderr,
                   )

--- a/.github/workflows/nova-metadata-audit.yml
+++ b/.github/workflows/nova-metadata-audit.yml
@@ -675,12 +675,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" || -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]]; then
-            echo "Source installer mode refuses to run with GitHub OIDC credentials available."
-            echo "Use installer_install_mode=release or remove id-token: write from the caller job."
-            exit 1
-          fi
-
           source_dir="${GITHUB_WORKSPACE}/.nova-installer-source"
           rm -rf "${source_dir}"
           git init --quiet "${source_dir}"
@@ -752,6 +746,7 @@ jobs:
           INPUT_DBT_EXECUTABLE: ${{ needs.prepare.outputs.dbt_executable }}
           INPUT_DBT_ENV_JSON: ${{ needs.prepare.outputs.dbt_env_json }}
           INPUT_DBT_SECRET_ENV_MAP_JSON: ${{ needs.prepare.outputs.dbt_secret_env_map_json }}
+          INHERITED_SECRETS_JSON: ${{ toJSON(secrets) }}
           DBT_NOVA_SECRET_BUNDLE_JSON: ${{ secrets.DBT_NOVA_SECRET_BUNDLE_JSON || '' }}
         run: |
           set -euo pipefail
@@ -767,6 +762,7 @@ jobs:
           executable = os.environ["INPUT_DBT_EXECUTABLE"]
           plain_env = json.loads(os.environ["INPUT_DBT_ENV_JSON"])
           secret_env_map = json.loads(os.environ["INPUT_DBT_SECRET_ENV_MAP_JSON"])
+          inherited_secrets = json.loads(os.environ["INHERITED_SECRETS_JSON"])
           secret_bundle_raw = os.environ.get("DBT_NOVA_SECRET_BUNDLE_JSON", "").strip()
           if secret_bundle_raw:
               try:
@@ -788,6 +784,7 @@ jobs:
 
           runtime_env = os.environ.copy()
           for helper_var in (
+              "INHERITED_SECRETS_JSON",
               "INPUT_DBT_ENV_JSON",
               "INPUT_DBT_SECRET_ENV_MAP_JSON",
               "INPUT_DBT_COMMAND",
@@ -810,11 +807,14 @@ jobs:
           for env_name, secret_name in secret_env_map.items():
               secret_value = secret_bundle.get(secret_name)
               if not isinstance(secret_value, str) or not secret_value:
+                  secret_value = inherited_secrets.get(secret_name, "")
+              if not secret_value:
                   print(
                       (
                           f"missing secret '{secret_name}' requested by "
                           f"dbt_secret_env_map_json for env var '{env_name}'. "
-                          "Provide it via DBT_NOVA_SECRET_BUNDLE_JSON."
+                          "Provide it via DBT_NOVA_SECRET_BUNDLE_JSON or "
+                          "same-owner inherited workflow secrets."
                       ),
                       file=sys.stderr,
                   )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   JSON Web Token handling, Tantivy/LRU, the Google Cloud Storage SDK, and the
   documentation toolchain, and removed advisory exemptions made obsolete by
   the upgrades.
+- Hardened reusable workflows by eliminating bulk inherited-secret exposure,
+  fetching source installs at a resolved commit without persistent checkout
+  credentials, validating installer refs, refusing source compilation in
+  OIDC-capable jobs, avoiding caller-provided warm scripts in release mode, and
+  removing unnecessary OIDC grants from PR CI.
 - Corrected agent-facing MCP contracts for entity detail, context selection,
   readiness output, and recipe failure handling, and aligned persona-summary
   documentation with the live three-level detail model.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   documentation toolchain, and removed advisory exemptions made obsolete by
   the upgrades.
 - Hardened reusable workflow source installs by resolving refs to a detached
-  commit, using step-scoped fetch credentials, validating installer refs, and
-  removing unnecessary OIDC grants from PR CI, while preserving inherited-secret
-  fallback, source+OIDC compatibility, and caller warm-script fallback.
+  commit, using step-scoped fetch credentials, and validating installer refs,
+  while preserving inherited-secret fallback, source+OIDC compatibility, caller
+  warm-script fallback, and caller `id-token` grants required by the reusable
+  asset workflow.
 - Corrected agent-facing MCP contracts for entity detail, context selection,
   readiness output, and recipe failure handling, and aligned persona-summary
   documentation with the live three-level detail model.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Hardened the dependency supply chain by updating OpenSSL, Rand, Tar, Rkyv,
+  JSON Web Token handling, Tantivy/LRU, the Google Cloud Storage SDK, and the
+  documentation toolchain, and removed advisory exemptions made obsolete by
+  the upgrades.
 - Corrected agent-facing MCP contracts for entity detail, context selection,
   readiness output, and recipe failure handling, and aligned persona-summary
   documentation with the live three-level detail model.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   JSON Web Token handling, Tantivy/LRU, the Google Cloud Storage SDK, and the
   documentation toolchain, and removed advisory exemptions made obsolete by
   the upgrades.
-- Hardened reusable workflows by eliminating bulk inherited-secret exposure,
-  fetching source installs at a resolved commit without persistent checkout
-  credentials, validating installer refs, refusing source compilation in
-  OIDC-capable jobs, avoiding caller-provided warm scripts in release mode, and
-  removing unnecessary OIDC grants from PR CI.
+- Hardened reusable workflow source installs by resolving refs to a detached
+  commit, using step-scoped fetch credentials, validating installer refs, and
+  removing unnecessary OIDC grants from PR CI, while preserving inherited-secret
+  fallback, source+OIDC compatibility, and caller warm-script fallback.
 - Corrected agent-facing MCP contracts for entity detail, context selection,
   readiness output, and recipe failure handling, and aligned persona-summary
   documentation with the live three-level detail model.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the upgrades.
 - Hardened reusable workflow source installs by resolving refs to a detached
   commit, using step-scoped fetch credentials, and validating installer refs,
-  while preserving inherited-secret fallback, source+OIDC compatibility, caller
-  warm-script fallback, and caller `id-token` grants required by the reusable
-  asset workflow.
+  while preserving source+OIDC compatibility, caller warm-script fallback, and
+  caller `id-token` grants required by the reusable asset workflow. Reusable
+  dbt invocation now resolves only explicitly selected values from
+  `DBT_NOVA_SECRET_BUNDLE_JSON`; whole inherited secret contexts are no longer
+  serialized into workflow jobs.
+- Added a Nova-owned persisted-storage format identity, v2 prebuilt metadata and
+  bootstrap contracts, legacy v1 read compatibility, and a release-binary CI
+  gate so index-engine upgrades retain rollback versions and fail explicitly
+  across incompatible producer/consumer generations.
 - Corrected agent-facing MCP contracts for entity detail, context selection,
   readiness output, and recipe failure handling, and aligned persona-summary
   documentation with the live three-level detail model.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -337,28 +337,6 @@ dependencies = [
  "compression-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -442,6 +420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -478,7 +457,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -508,14 +487,14 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
- "http-body 1.0.1",
- "lru 0.16.3",
+ "http-body 1.1.0",
+ "lru",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "url",
 ]
@@ -608,13 +587,13 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "p256",
  "percent-encoding",
  "ring",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "time",
  "tracing",
@@ -644,12 +623,12 @@ dependencies = [
  "crc-fast",
  "hex",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "md-5",
  "pin-project-lite",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -678,7 +657,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "percent-encoding",
  "pin-project-lite",
@@ -695,9 +674,9 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
@@ -755,7 +734,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "pin-project-lite",
  "pin-utils",
@@ -793,7 +772,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "itoa",
  "num-integer",
@@ -840,9 +819,9 @@ dependencies = [
  "form_urlencoded",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -854,7 +833,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower",
  "tower-layer",
@@ -871,11 +850,11 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -892,12 +871,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -935,12 +908,6 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -993,6 +960,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+dependencies = [
+ "darling 0.20.11",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,6 +1020,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1089,6 +1099,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytes-utils"
@@ -1242,6 +1255,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,16 +1351,6 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1396,9 +1405,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
 dependencies = [
  "crc",
- "digest",
+ "digest 0.10.7",
  "rustversion",
  "spin",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -1519,6 +1537,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,6 +1630,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "datasketches"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
+
+[[package]]
 name = "dbt-nova"
 version = "0.0.6"
 dependencies = [
@@ -1608,10 +1650,10 @@ dependencies = [
  "fastembed",
  "filetime",
  "flate2",
- "fs4",
+ "fs4 0.8.4",
  "google-cloud-storage",
  "hf-hub",
- "hmac",
+ "hmac 0.12.1",
  "insta",
  "jsonschema",
  "jsonwebtoken",
@@ -1631,7 +1673,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "simple_asn1",
  "sqlparser",
  "tantivy",
@@ -1674,17 +1716,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
- "zeroize",
-]
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1746,9 +1777,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1785,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "downcast-rs"
-version = "1.2.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "duckdb"
@@ -1824,10 +1866,10 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der 0.6.1",
+ "der",
  "elliptic-curve",
  "rfc6979",
- "signature",
+ "signature 1.6.4",
 ]
 
 [[package]]
@@ -1844,12 +1886,12 @@ checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
  "crypto-bigint 0.4.9",
- "der 0.6.1",
- "digest",
+ "der",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
- "pkcs8 0.9.0",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -1872,19 +1914,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -2062,6 +2106,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2216,77 +2270,221 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-auth"
-version = "0.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe54dd8b6eb2bcd5390998238bcc39d1daed4dbb70df2845832532540384fc41"
+checksum = "f54aab44c16b8463ae11b165a87c3d484780231f157bb1ed65843d591beb5abd"
 dependencies = [
  "async-trait",
- "base64 0.21.7",
- "google-cloud-metadata",
- "google-cloud-token",
- "home",
- "jsonwebtoken",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "time",
- "tokio",
- "tracing",
- "urlencoding",
-]
-
-[[package]]
-name = "google-cloud-metadata"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc279bfb50487d7bcd900e8688406475fc750fe474a835b2ab9ade9eb1fc90e2"
-dependencies = [
- "reqwest 0.11.27",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
-name = "google-cloud-storage"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abf8bc6677b763a553fa47dc43a6bc49e62eb4f4b2eed812622f0e653670c07"
-dependencies = [
- "anyhow",
- "async-stream",
- "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
- "futures-util",
- "google-cloud-auth",
- "google-cloud-metadata",
- "google-cloud-token",
+ "chrono",
+ "google-cloud-gax",
  "hex",
- "once_cell",
- "percent-encoding",
- "pkcs8 0.10.2",
- "regex",
- "reqwest 0.11.27",
- "reqwest-middleware",
- "ring",
+ "hmac 0.13.0",
+ "http 1.4.0",
+ "reqwest 0.13.4",
+ "rustc_version",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
- "sha2",
- "thiserror 1.0.69",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
  "time",
  "tokio",
- "tracing",
  "url",
 ]
 
 [[package]]
-name = "google-cloud-token"
-version = "0.1.2"
+name = "google-cloud-gax"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c12ba8b21d128a2ce8585955246977fbce4415f680ebf9199b6f9d6d725f"
+checksum = "b9a46dd0fd026bbc4a5d84e6ab0c941cee6e3b057976a0bb107fdb5238ce598f"
+dependencies = [
+ "bytes",
+ "futures",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "http 1.4.0",
+ "pin-project",
+ "rand 0.10.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-gax-internal"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb04c54317ace06d489213f761797240b3046142a9b7ce6b9a82a9d134e193d1"
+dependencies = [
+ "bytes",
+ "futures",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "h2",
+ "http 1.4.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "hyper",
+ "lazy_static",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-types",
+ "reqwest 0.13.4",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
+ "tower",
+ "tracing",
+ "tracing-opentelemetry",
+]
+
+[[package]]
+name = "google-cloud-iam-v1"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cdf5acc7ef946ee2db7a7f62bd436d8395a6543b4beef110cdc061fcf578bb"
 dependencies = [
  "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-type",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-longrunning"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6ce05df0aea2c08472983ce2bbbed9483cbb637b89ff69a7c4ef94371fe4f2"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-lro"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cca2b991d619525d72a170ca7f413cb520872702442da22ac9af650a8e786"
+dependencies = [
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-longrunning",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "serde",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-rpc"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2162c08a89118130979ba261080e960e44cdcb2d6e2ab8ca9b1da245285d353"
+dependencies = [
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9227f65175fa91a6e41f246797917697efdadfe09dd8ea84ad8b737a71efbd28"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "crc32c",
+ "futures",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-iam-v1",
+ "google-cloud-longrunning",
+ "google-cloud-lro",
+ "google-cloud-rpc",
+ "google-cloud-type",
+ "google-cloud-wkt",
+ "hex",
+ "http 1.4.0",
+ "http-body 1.1.0",
+ "md5",
+ "percent-encoding",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "google-cloud-type"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63acc3a92a85f96bab021c3a3e29b53bbacc97651e1b524d4c2991960a63eb82"
+dependencies = [
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "google-cloud-wkt"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fccf98cfd5481a5f5a285181ab0c62123d7d47cd2bb7299448440649349e4e7"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -2302,28 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2331,7 +2510,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2375,8 +2554,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2445,16 +2622,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
+name = "hmac"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "windows-sys 0.61.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2497,9 +2674,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -2514,7 +2691,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "pin-project-lite",
 ]
 
@@ -2531,47 +2708,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hyper"
-version = "0.14.32"
+name = "hybrid-array"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
+ "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2584,7 +2745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
@@ -2596,16 +2757,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-timeout"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "bytes",
- "hyper 0.14.32",
- "native-tls",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
  "tokio",
- "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2619,13 +2780,13 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http-body 1.1.0",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2771,6 +2932,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
@@ -2808,15 +2980,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
+name = "inventory"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
+ "rustversion",
 ]
 
 [[package]]
@@ -2875,6 +3044,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2948,7 +3126,7 @@ dependencies = [
  "referencing",
  "regex",
  "regex-syntax",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "rustls",
  "serde",
  "serde_json",
@@ -2958,17 +3136,20 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
+ "aws-lc-rs",
  "base64 0.22.1",
+ "getrandom 0.2.17",
  "js-sys",
  "pem",
- "ring",
  "serde",
  "serde_json",
+ "signature 2.2.0",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -3048,9 +3229,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libduckdb-sys"
@@ -3081,7 +3262,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "redox_syscall 0.7.3",
 ]
@@ -3121,15 +3302,6 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
@@ -3145,9 +3317,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.6"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -3197,16 +3369,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
-name = "measure_time"
-version = "0.8.3"
+name = "md5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbefd235b0aadd181626f281e1d684e116972988c14c264e42069d5e8a5775cc"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
+
+[[package]]
+name = "measure_time"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55d61e72fc3ab704396c5fa16f4c184db37978ae4e94ca8959693a235fc0e"
 dependencies = [
- "instant",
  "log",
 ]
 
@@ -3259,9 +3436,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -3517,7 +3694,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "once_cell",
  "onig_sys",
@@ -3545,7 +3722,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3583,10 +3760,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.5",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ort"
@@ -3610,7 +3832,7 @@ checksum = "0f2f6427193c808010b126bef45ebd33f8dee43770223a1200f84d3734d6c656"
 dependencies = [
  "flate2",
  "pkg-config",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "ureq",
 ]
@@ -3623,9 +3845,9 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "ownedbytes"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a059efb063b8f425b948e042e6b9bd85edfe60e913630ed727b23e2dfcc558"
+checksum = "2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -3638,7 +3860,7 @@ checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3687,19 +3909,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -3719,18 +3952,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -3833,7 +4056,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags",
  "num-traits",
  "rand 0.9.5",
  "rand_chacha 0.9.0",
@@ -3842,6 +4065,38 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -3911,9 +4166,9 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3926,13 +4181,14 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.1",
  "lru-slab",
  "rand 0.10.2",
  "rand_pcg",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -3951,7 +4207,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -4063,16 +4319,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rand_distr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
-dependencies = [
- "num-traits",
- "rand 0.8.7",
-]
-
-[[package]]
 name = "rand_pcg"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4153,7 +4399,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -4162,7 +4408,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -4276,49 +4522,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-tls",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "mime_guess",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
@@ -4329,9 +4532,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -4344,7 +4547,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tower",
@@ -4359,56 +4562,46 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
- "sync_wrapper 1.0.2",
+ "serde_urlencoded",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
-]
-
-[[package]]
-name = "reqwest-middleware"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a735987236a8e238bf0296c7e351b999c188ccc11477f311b82b55c93984216"
-dependencies = [
- "anyhow",
- "async-trait",
- "http 0.2.12",
- "reqwest 0.11.27",
- "serde",
- "task-local-extensions",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4418,7 +4611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint 0.4.9",
- "hmac",
+ "hmac 0.12.1",
  "zeroize",
 ]
 
@@ -4432,7 +4625,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -4463,7 +4656,7 @@ dependencies = [
  "bytecheck 0.8.2",
  "bytes",
  "hashbrown 0.17.1",
- "indexmap",
+ "indexmap 2.13.0",
  "munge",
  "ptr_meta 0.3.1",
  "rancor",
@@ -4507,7 +4700,7 @@ dependencies = [
  "chrono",
  "futures",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "pastey",
  "pin-project-lite",
@@ -4567,12 +4760,6 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -4592,7 +4779,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4605,7 +4792,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -4614,9 +4801,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4641,15 +4828,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4665,7 +4843,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
@@ -4695,7 +4873,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4748,6 +4926,18 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "schemars_derive 0.8.22",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
  "serde",
  "serde_json",
 ]
@@ -4809,9 +4999,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
  "base16ct",
- "der 0.6.1",
+ "der",
  "generic-array",
- "pkcs8 0.9.0",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -4822,8 +5012,8 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.10.1",
+ "bitflags",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4892,9 +5082,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -4939,12 +5129,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -4959,7 +5181,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4970,7 +5192,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5004,7 +5237,16 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
  "rand_core 0.6.4",
 ]
 
@@ -5040,9 +5282,9 @@ dependencies = [
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.2.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+checksum = "05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea"
 dependencies = [
  "serde",
 ]
@@ -5061,22 +5303,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5103,17 +5335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]
@@ -5158,7 +5380,7 @@ checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
 dependencies = [
  "bytes",
  "futures-util",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "pin-project-lite",
 ]
@@ -5257,10 +5479,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "0.1.2"
+name = "syn"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "sync_wrapper"
@@ -5283,27 +5510,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5311,37 +5517,38 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tantivy"
-version = "0.22.1"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96599ea6fccd844fc833fed21d2eecac2e6a7c1afd9e044057391d78b1feb141"
+checksum = "edde6a10743fff00a4e1a8c9ef020bf5f3cbad301b7d2d39f2b07f123c4eac07"
 dependencies = [
  "aho-corasick",
  "arc-swap",
  "base64 0.22.1",
  "bitpacking",
+ "bon",
  "byteorder",
  "census",
  "crc32fast",
  "crossbeam-channel",
+ "datasketches",
  "downcast-rs",
  "fastdivide",
  "fnv",
- "fs4",
+ "fs4 0.13.1",
  "htmlescape",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "levenshtein_automata",
  "log",
- "lru 0.12.5",
+ "lru",
  "lz4_flex",
  "measure_time",
  "memmap2",
- "num_cpus",
  "once_cell",
  "oneshot",
  "rayon",
  "regex",
  "rust-stemmers",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "serde",
  "serde_json",
  "sketches-ddsketch",
@@ -5354,30 +5561,31 @@ dependencies = [
  "tantivy-stacker",
  "tantivy-tokenizer-api",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
+ "typetag",
  "uuid",
  "winapi",
 ]
 
 [[package]]
 name = "tantivy-bitpacker"
-version = "0.6.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284899c2325d6832203ac6ff5891b297fc5239c3dc754c5bc1977855b23c10df"
+checksum = "4fed3d674429bcd2de5d0a6d1aa5495fed8afd9c5ecce993019caf7615f53fa4"
 dependencies = [
  "bitpacking",
 ]
 
 [[package]]
 name = "tantivy-columnar"
-version = "0.3.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12722224ffbe346c7fec3275c699e508fd0d4710e629e933d5736ec524a1f44e"
+checksum = "c57166f5bcfd478f370ab8445afb4678dce44801fa5ce5c451aaf8595583c5dc"
 dependencies = [
  "downcast-rs",
  "fastdivide",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "serde",
  "tantivy-bitpacker",
  "tantivy-common",
@@ -5387,9 +5595,9 @@ dependencies = [
 
 [[package]]
 name = "tantivy-common"
-version = "0.7.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8019e3cabcfd20a1380b491e13ff42f57bb38bf97c3d5fa5c07e50816e0621f4"
+checksum = "bbf10915aa75da3c3b0d58b58853d2e889efbaf32d4982a4c3715dde6bba23e5"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -5411,19 +5619,25 @@ dependencies = [
 
 [[package]]
 name = "tantivy-query-grammar"
-version = "0.22.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847434d4af57b32e309f4ab1b4f1707a6c566656264caa427ff4285c4d9d0b82"
+checksum = "dfadb8526b6da90704feb293b0701a6aae62ea14983143344be2dc5ce30f1d82"
 dependencies = [
+ "fnv",
  "nom",
+ "ordered-float",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "tantivy-sstable"
-version = "0.3.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69578242e8e9fc989119f522ba5b49a38ac20f576fc778035b96cc94f41f98e"
+checksum = "8a2cfc3ac5164cbadc28965ffb145a8f47582a60ae5897859ad8d4316596c606"
 dependencies = [
+ "futures-util",
+ "itertools 0.14.0",
  "tantivy-bitpacker",
  "tantivy-common",
  "tantivy-fst",
@@ -5432,20 +5646,19 @@ dependencies = [
 
 [[package]]
 name = "tantivy-stacker"
-version = "0.3.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56d6ff5591fc332739b3ce7035b57995a3ce29a93ffd6012660e0949c956ea8"
+checksum = "6cbb051742da9d53ca9e8fff43a9b10e319338b24e2c0e15d0372df19ffeb951"
 dependencies = [
  "murmurhash32",
- "rand_distr",
  "tantivy-common",
 ]
 
 [[package]]
 name = "tantivy-tokenizer-api"
-version = "0.3.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0dcade25819a89cfe6f17d932c9cedff11989936bf6dd4f336d50392053b04"
+checksum = "eac258c2c6390673f2685813afeeafcb8c4e0ee7de8dd3fc46838dcc37263f98"
 dependencies = [
  "serde",
 ]
@@ -5465,15 +5678,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "task-local-extensions"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
-dependencies = [
- "pin-utils",
 ]
 
 [[package]]
@@ -5646,9 +5850,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -5656,30 +5860,20 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5731,7 +5925,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -5747,6 +5941,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "http 1.4.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "rustls-native-certs",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5754,9 +5986,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.13.0",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "slab",
+ "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5769,12 +6004,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "iri-string",
  "pin-project-lite",
@@ -5842,6 +6077,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5879,10 +6128,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
+name = "typeid"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "typetag"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c90e86058a30d42a1a928dfb4b49bb33c98c3a2b4909492e6b0881cd94798ec2"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f153acc4e99a5f2a5aefa09fb078be54e26271b2813f6041200b224c098d8328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "typify"
@@ -5996,6 +6275,12 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -6058,9 +6343,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",
@@ -6230,16 +6515,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -6254,9 +6539,9 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
 
@@ -6329,7 +6614,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6435,15 +6720,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6490,28 +6766,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6533,12 +6792,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6555,12 +6808,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6581,22 +6828,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6617,12 +6852,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6639,12 +6868,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6665,12 +6888,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6689,28 +6906,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6725,7 +6926,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "log",
  "once_cell",
@@ -6764,7 +6965,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -6794,8 +6995,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "indexmap",
+ "bitflags",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -6814,7 +7015,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",
@@ -6924,6 +7125,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -6967,7 +7182,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap",
+ "indexmap 2.13.0",
  "memchr",
  "zopfli",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,7 +1614,7 @@ dependencies = [
  "hmac",
  "insta",
  "jsonschema",
- "jsonwebtoken",
+ "jsonwebtoken 10.4.0",
  "memmap2",
  "moka",
  "ort-sys",
@@ -1623,8 +1623,8 @@ dependencies = [
  "rayon",
  "regress",
  "reqwest 0.12.28",
- "rkyv 0.8.15",
- "rkyv_derive 0.8.15",
+ "rkyv 0.8.17",
+ "rkyv_derive 0.8.17",
  "rmcp",
  "schemars 0.8.22",
  "schemars 1.2.1",
@@ -1827,7 +1827,7 @@ dependencies = [
  "der 0.6.1",
  "elliptic-curve",
  "rfc6979",
- "signature",
+ "signature 1.6.4",
 ]
 
 [[package]]
@@ -1893,7 +1893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2205,11 +2205,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2223,7 +2225,7 @@ dependencies = [
  "google-cloud-metadata",
  "google-cloud-token",
  "home",
- "jsonwebtoken",
+ "jsonwebtoken 9.3.1",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -2390,6 +2392,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2423,7 +2431,7 @@ dependencies = [
  "dirs",
  "indicatif",
  "log",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2835,7 +2843,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2961,6 +2969,23 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "base64 0.22.1",
+ "getrandom 0.2.17",
+ "js-sys",
+ "pem",
+ "serde",
+ "serde_json",
+ "signature 2.2.0",
+ "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -3371,7 +3396,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3533,15 +3558,14 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3565,9 +3589,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -3828,7 +3852,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.11.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -3915,14 +3939,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -3945,7 +3970,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3980,9 +4005,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3991,9 +4016,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4061,7 +4086,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4439,19 +4473,19 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.15"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
  "bytecheck 0.8.2",
  "bytes",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "munge",
  "ptr_meta 0.3.1",
  "rancor",
  "rend 0.5.3",
- "rkyv_derive 0.8.15",
+ "rkyv_derive 0.8.17",
  "tinyvec",
  "uuid",
 ]
@@ -4469,9 +4503,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.15"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4542,7 +4576,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rkyv 0.7.46",
  "serde",
  "serde_json",
@@ -4592,7 +4626,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4660,7 +4694,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4988,6 +5022,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
  "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
  "rand_core 0.6.4",
 ]
 
@@ -5441,9 +5484,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -5469,7 +5512,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5613,7 +5656,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rayon",
  "rayon-cond",
  "regex",
@@ -6312,7 +6355,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6907,6 +6950,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,7 +1614,7 @@ dependencies = [
  "hmac",
  "insta",
  "jsonschema",
- "jsonwebtoken 10.4.0",
+ "jsonwebtoken",
  "memmap2",
  "moka",
  "ort-sys",
@@ -1827,7 +1827,7 @@ dependencies = [
  "der 0.6.1",
  "elliptic-curve",
  "rfc6979",
- "signature 1.6.4",
+ "signature",
 ]
 
 [[package]]
@@ -2225,7 +2225,7 @@ dependencies = [
  "google-cloud-metadata",
  "google-cloud-token",
  "home",
- "jsonwebtoken 9.3.1",
+ "jsonwebtoken",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -2969,23 +2969,6 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "10.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
-dependencies = [
- "base64 0.22.1",
- "getrandom 0.2.17",
- "js-sys",
- "pem",
- "serde",
- "serde_json",
- "signature 2.2.0",
- "simple_asn1",
- "zeroize",
 ]
 
 [[package]]
@@ -5026,15 +5009,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6950,20 +6924,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ tokio = { version = "1.0", features = ["full"] }
 tokio-util = "0.7"
 thiserror = "1.0"
 sqlparser = { version = "0.60", features = ["visitor"] }
-tantivy = "0.22"
+tantivy = "0.26.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 rayon = "1.10"
@@ -41,7 +41,7 @@ memmap2 = "0.9"
 blake3 = "1.5"
 fs4 = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking", "gzip"] }
-jsonwebtoken = "9"
+jsonwebtoken = { version = "10.4", features = ["aws_lc_rs"] }
 base64 = "0.22"
 sha2 = "0.10"
 hmac = "0.12"
@@ -54,7 +54,7 @@ tar = "0.4"
 jsonschema = "0.40.2"
 aws-config = { version = "1.1", optional = true, features = ["behavior-version-latest"] }
 aws-sdk-s3 = { version = "1.1", optional = true, default-features = false, features = ["default-https-client", "http-1x", "rt-tokio", "sigv4a"] }
-google-cloud-storage = { version = "0.17", optional = true }
+google-cloud-storage = { version = "1.17", optional = true }
 fastembed = { version = "3.14.1", optional = true, default-features = false, features = ["online", "ort-download-binaries"] }
 ort-sys = "=2.0.0-rc.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ memmap2 = "0.9"
 blake3 = "1.5"
 fs4 = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking", "gzip"] }
-jsonwebtoken = "10"
+jsonwebtoken = "9"
 base64 = "0.22"
 sha2 = "0.10"
 hmac = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ memmap2 = "0.9"
 blake3 = "1.5"
 fs4 = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking", "gzip"] }
-jsonwebtoken = "9"
+jsonwebtoken = "10"
 base64 = "0.22"
 sha2 = "0.10"
 hmac = "0.12"

--- a/README.md
+++ b/README.md
@@ -276,10 +276,10 @@ for trusted advanced cases (for example internal CI fixtures). Keep
 `dbt_command_args_json` are mutually exclusive.
 
 Use `dbt_env_json` and `dbt_secret_env_map_json` to pass profile-specific
-env/secret variables generically (Databricks, BigQuery, Snowflake, DuckDB, etc.). For
-cross-owner reusable workflow calls, pass one declared secret
-`DBT_NOVA_SECRET_BUNDLE_JSON` (JSON object of key->value) and reference those keys
-in `dbt_secret_env_map_json`.
+env/secret variables generically (Databricks, BigQuery, Snowflake, DuckDB, etc.).
+Pass one explicitly constructed `DBT_NOVA_SECRET_BUNDLE_JSON` secret (a JSON
+object of key-to-value pairs) and reference only those keys in
+`dbt_secret_env_map_json`. Nova does not serialize inherited workflow secrets.
 
 Most teams keep a repo-local `workflow_dispatch` wrapper around this reusable
 workflow, then add release/tag triggers later after validating publish paths
@@ -295,6 +295,9 @@ Recommended consumer setup:
 - keep `DBT_NOVA_STORAGE_READ_ONLY` unset for first-run hydration and use `DBT_NOVA_ARTIFACT_FETCH_POLICY=if_missing`
 - switch to `DBT_NOVA_STORAGE_READ_ONLY=true` plus `DBT_NOVA_ARTIFACT_FETCH_POLICY=never` only after assets already exist locally
 - keep versioned bootstrap URIs only for rollback/debugging
+- for storage-format upgrades, deploy the new consumer binary before publishing
+  assets with the new producer; current Nova accepts legacy v1 artifacts, while
+  legacy consumers reject v2 contracts
 - after a producer publishes new assets, run `reload_manifest` with no arguments
   to adopt the new asset set without editing MCP config; changing live source,
   refresh, or storage settings from MCP requires `DBT_NOVA_MCP_ENABLE_MANIFEST_RELOAD=1`

--- a/README.md
+++ b/README.md
@@ -264,6 +264,10 @@ safe default, and use `installer_install_mode=source` for older runner images
 or unreleased installer commits. Reusable workflows reject branch-like
 `installer_ref` values by default; use a release tag or full commit SHA, and set
 `allow_mutable_installer_ref: true` only for trusted development runs.
+Source installs resolve the requested ref once, check out the resulting commit
+without persisting workflow credentials, and remove Git metadata before build.
+They fail closed when the caller grants `id-token: write`; use a signed release
+install for any OIDC-capable job.
 
 If you generate manifests in the reusable workflow (`dbt_generate_manifest: true`),
 prefer structured invocation with `dbt_command_args_json` (and optional
@@ -274,10 +278,11 @@ for trusted advanced cases (for example internal CI fixtures). Keep
 `dbt_command_args_json` are mutually exclusive.
 
 Use `dbt_env_json` and `dbt_secret_env_map_json` to pass profile-specific
-env/secret variables generically (Databricks, BigQuery, Snowflake, DuckDB, etc.). For
-cross-owner reusable workflow calls, pass one declared secret
-`DBT_NOVA_SECRET_BUNDLE_JSON` (JSON object of key->value) and reference those keys
-in `dbt_secret_env_map_json`.
+env/secret variables generically (Databricks, BigQuery, Snowflake, DuckDB, etc.).
+Pass the declared `DBT_NOVA_SECRET_BUNDLE_JSON` secret (a JSON object of
+key-to-value entries) and reference only those keys in
+`dbt_secret_env_map_json`; the reusable workflows never enumerate inherited
+repository or organization secrets.
 
 Most teams keep a repo-local `workflow_dispatch` wrapper around this reusable
 workflow, then add release/tag triggers later after validating publish paths

--- a/README.md
+++ b/README.md
@@ -266,8 +266,6 @@ or unreleased installer commits. Reusable workflows reject branch-like
 `allow_mutable_installer_ref: true` only for trusted development runs.
 Source installs resolve the requested ref once, check out the resulting commit
 without persisting workflow credentials, and remove Git metadata before build.
-They fail closed when the caller grants `id-token: write`; use a signed release
-install for any OIDC-capable job.
 
 If you generate manifests in the reusable workflow (`dbt_generate_manifest: true`),
 prefer structured invocation with `dbt_command_args_json` (and optional
@@ -278,11 +276,10 @@ for trusted advanced cases (for example internal CI fixtures). Keep
 `dbt_command_args_json` are mutually exclusive.
 
 Use `dbt_env_json` and `dbt_secret_env_map_json` to pass profile-specific
-env/secret variables generically (Databricks, BigQuery, Snowflake, DuckDB, etc.).
-Pass the declared `DBT_NOVA_SECRET_BUNDLE_JSON` secret (a JSON object of
-key-to-value entries) and reference only those keys in
-`dbt_secret_env_map_json`; the reusable workflows never enumerate inherited
-repository or organization secrets.
+env/secret variables generically (Databricks, BigQuery, Snowflake, DuckDB, etc.). For
+cross-owner reusable workflow calls, pass one declared secret
+`DBT_NOVA_SECRET_BUNDLE_JSON` (JSON object of key->value) and reference those keys
+in `dbt_secret_env_map_json`.
 
 Most teams keep a repo-local `workflow_dispatch` wrapper around this reusable
 workflow, then add release/tag triggers later after validating publish paths

--- a/deny.toml
+++ b/deny.toml
@@ -5,12 +5,8 @@ yanked = "deny"
 unmaintained = "transitive"
 unsound = "transitive"
 ignore = [
-  { id = "RUSTSEC-2024-0384", reason = "owner=@joe-broadhead; review_by=2026-09-30; transitive via tantivy -> measure_time -> instant. No upstream fix; upgrade tantivy when feasible." },
   { id = "RUSTSEC-2024-0436", reason = "owner=@joe-broadhead; review_by=2026-09-30; transitive via fastembed -> tokenizers -> paste. No safe upgrade; monitor tokenizers." },
   { id = "RUSTSEC-2025-0119", reason = "owner=@joe-broadhead; review_by=2026-09-30; transitive via fastembed -> hf-hub -> indicatif -> number_prefix. No safe upgrade; monitor hf-hub/indicatif." },
-  { id = "RUSTSEC-2025-0134", reason = "owner=@joe-broadhead; review_by=2026-09-30; transitive via google-cloud-storage -> reqwest 0.11 -> rustls-pemfile. Upgrade gcs stack when available." },
-  { id = "RUSTSEC-2026-0002", reason = "owner=@joe-broadhead; review_by=2026-09-30; transitive via tantivy -> lru 0.12. Upgrade tantivy to pull lru >=0.16.3." },
-  { id = "RUSTSEC-2026-0097", reason = "owner=@joe-broadhead; review_by=2026-09-30; transitive via fastembed/tokenizers, tantivy/rand_distr, rmcp, and proptest. No semver-compatible upstream fix is available in the current graph. dbt-nova uses tracing_subscriber::fmt() and does not define a custom log::Log or call rand::rng() from logger code, so the reported UB path is not reachable in this codebase. Remove once upstreams move to rand >=0.9.3 or >=0.10.1." },
 ]
 unused-ignored-advisory = "warn"
 

--- a/dependency-watchlist.toml
+++ b/dependency-watchlist.toml
@@ -14,13 +14,3 @@ current_state = "Cargo.toml pins ort-sys = \"=2.0.0-rc.4\"."
 upgrade_trigger = "fastembed/ort ecosystem supports stable (non-RC) ort-sys without local patching."
 upgrade_plan = "Upgrade fastembed + ort-sys together, run full CI/release checks, then remove the exact RC pin."
 state_checks = ["cargo_toml_has_ort_sys_rc_pin", "cargo_lock_has_ort_sys_rc4"]
-
-[[item]]
-id = "reqwest-transitive-split"
-owner = "@joe-broadhead"
-review_by = "2026-09-30"
-summary = "Dependency graph currently contains reqwest 0.11, 0.12, and 0.13."
-current_state = "reqwest 0.11 is pulled transitively by google-cloud-storage, dbt-nova uses reqwest 0.12 directly, and jsonschema currently pulls reqwest 0.13."
-upgrade_trigger = "google-cloud-storage and jsonschema stacks converge on reqwest 0.12+ or 0.13+ without forcing multiple major lines."
-upgrade_plan = "Upgrade GCS/jsonschema dependencies together where possible, confirm cargo-deny and provider integration tests pass, then collapse to the smallest supported reqwest version set."
-state_checks = ["cargo_toml_has_reqwest_012_direct", "cargo_lock_has_reqwest_011", "cargo_lock_has_reqwest_012", "cargo_lock_has_reqwest_013"]

--- a/docs/configuration/manifest-sources.md
+++ b/docs/configuration/manifest-sources.md
@@ -153,7 +153,9 @@ ready. Without that opt-in, MCP reloads can refresh only the current source.
 
 ## Versioned Indexes & Atomic Swaps
 
-Nova keeps versioned index directories per manifest content hash:
+Nova keeps versioned index directories per storage-scoped manifest hash. The
+scope includes manifest content, pruning/search configuration, and Nova's
+persisted-storage format identity:
 
 ```
 <storage_root>/instances/<instance_id>/versions/<hash>/
@@ -168,7 +170,7 @@ The active version is tracked in:
 When `DBT_NOVA_MANIFEST_REFRESH_SECS` is enabled, Nova:
 
 1. Resolves the manifest source (local or cached remote).
-2. Computes the content hash.
+2. Computes the storage-scoped manifest hash.
 3. Builds new indexes in a new version directory in the background.
 4. Atomically swaps the active version once ready (no downtime).
 5. Keeps the previous version available for in-flight requests.

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -34,6 +34,8 @@ Operational defaults:
   - read-only consumer behavior from extracted artifacts
   - native remote consumer behavior via `file://` artifact URIs
   - negative-path behavior (missing/mismatched storage + invalid metadata)
+  - persisted-storage upgrade and rollback behavior against the released
+    `v0.0.6` binary
 - **Note:** sets `DBT_NOVA_STRICT_SCHEMA=1` so schema parsing failures break the build
 - **Note:** release artifacts ship with default features enabled, so lint/test jobs now exercise `--all-features` for parity.
 
@@ -46,8 +48,8 @@ Operational defaults:
   (`dbt_command_args_json`, optional `dbt_executable`,
   optional `dbt_allow_unsafe_executable`) or trusted shell
   invocation (`dbt_command`), plus `dbt_env_json`,
-  `dbt_secret_env_map_json`, optional workflow_call secret bundle
-  (`DBT_NOVA_SECRET_BUNDLE_JSON`), optional installer source override
+  `dbt_secret_env_map_json`, workflow_call secret bundle
+  (`DBT_NOVA_SECRET_BUNDLE_JSON`, required when the map is non-empty), optional installer source override
   (`installer_repository`, `installer_ref`, `installer_install_mode`,
   `allow_mutable_installer_ref` for trusted branch-ref development runs), optional models artifact, staged/full semantic warmup
   (`search_warm_strategy`), configurable build timeout
@@ -67,7 +69,8 @@ Operational defaults:
   fetched with step-scoped credentials, and stripped of Git metadata before
   compilation.
 - **Outputs:** manifest metadata (`manifest_hash`, `manifest_version`,
-  `entity_count`), artifact names (including manifest/bootstrap), and optional
+  `storage_format_version`, `entity_count`), artifact names (including
+  manifest/bootstrap), and optional
   remote publish metadata (`published_targets`,
   `artifact_name_publish_summary`). Legacy `published_*_uris` outputs remain
   for compatibility and currently return `{}`; consumers should read the
@@ -90,10 +93,9 @@ Operational defaults:
   `installer_install_mode`, `allow_mutable_installer_ref` for trusted branch-ref
   development runs), plus optional runner selection (`runner` or
   `runner_labels_json`)
-- **Secret contract:** `dbt_secret_env_map_json` resolves keys from
-  `DBT_NOVA_SECRET_BUNDLE_JSON` first, then same-owner inherited workflow
-  secrets; downstream wrappers should prefer the bundle pattern for cross-owner
-  calls and provider-neutral secret schemas
+- **Secret contract:** `dbt_secret_env_map_json` resolves only keys explicitly
+  included in `DBT_NOVA_SECRET_BUNDLE_JSON`; whole inherited secret contexts are
+  never serialized into the called workflow
 - **Audit inputs:** `selection_mode` (`project|changed|entities`),
   `changed_files_json`, `entity_ids_json`, `resource_types_json`,
   `personas_json`, `thresholds_json`, `include_breakdown`,

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -65,11 +65,7 @@ Operational defaults:
   exclusive when `dbt_generate_manifest=true`
 - **Source-install safety:** requested refs are validated, resolved to a commit,
   fetched with step-scoped credentials, and stripped of Git metadata before
-  compilation. Source mode fails closed when GitHub OIDC request credentials
-  are present; OIDC-capable jobs must use signed release mode.
-- **Secret contract:** mapped dbt secrets come only from the explicitly passed
-  `DBT_NOVA_SECRET_BUNDLE_JSON`; the workflow does not serialize inherited
-  repository or organization secrets.
+  compilation.
 - **Outputs:** manifest metadata (`manifest_hash`, `manifest_version`,
   `entity_count`), artifact names (including manifest/bootstrap), and optional
   remote publish metadata (`published_targets`,
@@ -94,9 +90,10 @@ Operational defaults:
   `installer_install_mode`, `allow_mutable_installer_ref` for trusted branch-ref
   development runs), plus optional runner selection (`runner` or
   `runner_labels_json`)
-- **Secret contract:** `dbt_secret_env_map_json` resolves keys only from
-  `DBT_NOVA_SECRET_BUNDLE_JSON`; downstream wrappers should pass that explicit
-  bundle for same-owner and cross-owner calls
+- **Secret contract:** `dbt_secret_env_map_json` resolves keys from
+  `DBT_NOVA_SECRET_BUNDLE_JSON` first, then same-owner inherited workflow
+  secrets; downstream wrappers should prefer the bundle pattern for cross-owner
+  calls and provider-neutral secret schemas
 - **Audit inputs:** `selection_mode` (`project|changed|entities`),
   `changed_files_json`, `entity_ids_json`, `resource_types_json`,
   `personas_json`, `thresholds_json`, `include_breakdown`,

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -63,6 +63,13 @@ Operational defaults:
   shell semantics.
 - **Validation:** `dbt_command` and `dbt_command_args_json` are mutually
   exclusive when `dbt_generate_manifest=true`
+- **Source-install safety:** requested refs are validated, resolved to a commit,
+  fetched with step-scoped credentials, and stripped of Git metadata before
+  compilation. Source mode fails closed when GitHub OIDC request credentials
+  are present; OIDC-capable jobs must use signed release mode.
+- **Secret contract:** mapped dbt secrets come only from the explicitly passed
+  `DBT_NOVA_SECRET_BUNDLE_JSON`; the workflow does not serialize inherited
+  repository or organization secrets.
 - **Outputs:** manifest metadata (`manifest_hash`, `manifest_version`,
   `entity_count`), artifact names (including manifest/bootstrap), and optional
   remote publish metadata (`published_targets`,
@@ -87,10 +94,9 @@ Operational defaults:
   `installer_install_mode`, `allow_mutable_installer_ref` for trusted branch-ref
   development runs), plus optional runner selection (`runner` or
   `runner_labels_json`)
-- **Secret contract:** `dbt_secret_env_map_json` resolves keys from
-  `DBT_NOVA_SECRET_BUNDLE_JSON` first, then same-owner inherited workflow
-  secrets; downstream wrappers should prefer the bundle pattern for cross-owner
-  calls and provider-neutral secret schemas
+- **Secret contract:** `dbt_secret_env_map_json` resolves keys only from
+  `DBT_NOVA_SECRET_BUNDLE_JSON`; downstream wrappers should pass that explicit
+  bundle for same-owner and cross-owner calls
 - **Audit inputs:** `selection_mode` (`project|changed|entities`),
   `changed_files_json`, `entity_ids_json`, `resource_types_json`,
   `personas_json`, `thresholds_json`, `include_breakdown`,

--- a/docs/features/metadata-audit.md
+++ b/docs/features/metadata-audit.md
@@ -169,11 +169,8 @@ jobs:
       DBT_NOVA_SECRET_BUNDLE_JSON: ${{ secrets.DBT_NOVA_SECRET_BUNDLE_JSON }}
 ```
 
-Secret resolution order for `dbt_secret_env_map_json` values:
-
-1. keys in `DBT_NOVA_SECRET_BUNDLE_JSON`
-2. inherited workflow secrets for same-owner calls
-
-Use `DBT_NOVA_SECRET_BUNDLE_JSON` as the default integration pattern for
-cross-owner reusable workflow calls or when you want one portable secret schema
-across Databricks, BigQuery, Snowflake, DuckDB, and mixed-profile repos.
+`dbt_secret_env_map_json` resolves values only from keys in
+`DBT_NOVA_SECRET_BUNDLE_JSON`. Nova does not enumerate inherited repository or
+organization secrets. Use the bundle for same-owner and cross-owner calls to
+keep one explicit, portable secret schema across Databricks, BigQuery,
+Snowflake, DuckDB, and mixed-profile repos.

--- a/docs/features/metadata-audit.md
+++ b/docs/features/metadata-audit.md
@@ -169,8 +169,11 @@ jobs:
       DBT_NOVA_SECRET_BUNDLE_JSON: ${{ secrets.DBT_NOVA_SECRET_BUNDLE_JSON }}
 ```
 
-`dbt_secret_env_map_json` resolves values only from keys in
-`DBT_NOVA_SECRET_BUNDLE_JSON`. Nova does not enumerate inherited repository or
-organization secrets. Use the bundle for same-owner and cross-owner calls to
-keep one explicit, portable secret schema across Databricks, BigQuery,
-Snowflake, DuckDB, and mixed-profile repos.
+Secret resolution order for `dbt_secret_env_map_json` values:
+
+1. keys in `DBT_NOVA_SECRET_BUNDLE_JSON`
+2. inherited workflow secrets for same-owner calls
+
+Use `DBT_NOVA_SECRET_BUNDLE_JSON` as the default integration pattern for
+cross-owner reusable workflow calls or when you want one portable secret schema
+across Databricks, BigQuery, Snowflake, DuckDB, and mixed-profile repos.

--- a/docs/features/metadata-audit.md
+++ b/docs/features/metadata-audit.md
@@ -169,11 +169,8 @@ jobs:
       DBT_NOVA_SECRET_BUNDLE_JSON: ${{ secrets.DBT_NOVA_SECRET_BUNDLE_JSON }}
 ```
 
-Secret resolution order for `dbt_secret_env_map_json` values:
-
-1. keys in `DBT_NOVA_SECRET_BUNDLE_JSON`
-2. inherited workflow secrets for same-owner calls
-
-Use `DBT_NOVA_SECRET_BUNDLE_JSON` as the default integration pattern for
-cross-owner reusable workflow calls or when you want one portable secret schema
-across Databricks, BigQuery, Snowflake, DuckDB, and mixed-profile repos.
+`dbt_secret_env_map_json` resolves only keys in
+`DBT_NOVA_SECRET_BUNDLE_JSON`. Construct that bundle explicitly in the caller so
+the reusable workflow receives only the credentials needed for the selected dbt
+profile. This provider-neutral contract works across same-owner and cross-owner
+calls without exposing unrelated inherited secrets.

--- a/docs/operations/dependency-watchlist.md
+++ b/docs/operations/dependency-watchlist.md
@@ -54,19 +54,6 @@ CI and monthly automation fail if:
   - update lockfile
   - run full CI and release build checks
 
-### `reqwest` transitive split (`0.11` + `0.12` + `0.13`)
-
-- **Current state:** all three versions are present in `Cargo.lock`.
-- **Why:** `google-cloud-storage` transitively pulls `reqwest 0.11` while Nova
-  directly uses `reqwest 0.12`; `jsonschema` currently pulls `reqwest 0.13`.
-- **Upgrade trigger:** upstream GCS and `jsonschema` stacks converge on
-  compatible `reqwest` major versions.
-- **Upgrade criteria:**
-  - upgrade GCS/jsonschema dependencies where possible
-  - keep `cargo deny` green
-  - pass provider integration tests
-  - collapse to the smallest supported `reqwest` version set in lockfile
-
 ## Local Verification
 
 ```bash

--- a/docs/operations/ops.md
+++ b/docs/operations/ops.md
@@ -17,8 +17,10 @@ Use the `health` tool to verify readiness and see the active manifest details:
 - `ready`: healthy active index serving traffic
 - `refreshing`: rebuilding in background while serving the existing active index
 - `failed`: initial manifest load failed (common after bad JSON, bad permissions, or temporary source failure)
-- `manifest.hash`: content hash of the active manifest (`ready` / `refreshing`)
+- `manifest.hash`: storage-scoped hash of the active manifest, including
+  content and storage-affecting configuration (`ready` / `refreshing`)
 - `manifest.version`: version directory name (hash prefix)
+- `manifest.storage_format_version`: persisted-storage compatibility identity
 - `manifest.age_ms`: age of the manifest file based on its `modified_ms`
 - `manifest.loaded_at_ms`: when this index version was built
 - `manifest.loaded_age_ms`: time since build

--- a/docs/operations/prebuilt-assets.md
+++ b/docs/operations/prebuilt-assets.md
@@ -49,9 +49,6 @@ Reusable workflows reject branch-like installer refs unless
 `allow_mutable_installer_ref: true` is set for a trusted development run.
 Source installs resolve the requested ref to one commit, use credentials only
 during that fetch, and remove the source checkout's Git metadata before build.
-They refuse to run whenever the job exposes GitHub OIDC request credentials.
-Remove `id-token: write` for source-based development jobs; use
-`installer_install_mode: release` when OIDC is required.
 
 ```yaml
 name: Build Nova Assets
@@ -89,7 +86,7 @@ Alternative producer inputs:
 - `runner_labels_json` (JSON array of runner labels, overriding `runner` when
   a self-hosted pool requires multiple labels)
 - workflow_call secret `DBT_NOVA_SECRET_BUNDLE_JSON` (optional JSON object of
-  the exact `secret-name -> secret-value` entries exposed to the workflow)
+  `secret-name -> secret-value` entries for cross-owner reusable workflow calls)
 
 Structured mode is the recommended default:
 
@@ -160,9 +157,9 @@ does not forward the dbt secret bundle into the later publish shell.
 Notes:
 
 - `dbt_env_json` values are plain strings.
-- `dbt_secret_env_map_json` values are looked up only in
-  `DBT_NOVA_SECRET_BUNDLE_JSON`; inherited repository and organization secrets
-  are never enumerated.
+- `dbt_secret_env_map_json` values are looked up in this order:
+  1) keys in `DBT_NOVA_SECRET_BUNDLE_JSON` (when provided),
+  2) inherited workflow secrets (`secrets: inherit`, same-owner/org calls).
 - Missing mapped secrets fail fast before dbt invocation.
 - Use trusted `dbt_command` only when you explicitly need shell semantics.
 - Keep `search_warm_strategy: staged` for large manifests or memory-constrained
@@ -177,8 +174,8 @@ Secret setup patterns:
 
 | Call pattern | How secrets are resolved |
 |---|---|
-| Same-owner or cross-owner reusable call | Pass one `DBT_NOVA_SECRET_BUNDLE_JSON` secret containing only the required keys and map them via `dbt_secret_env_map_json` |
-| `secrets: inherit` | Not enumerated by Nova; explicitly pass `DBT_NOVA_SECRET_BUNDLE_JSON` instead |
+| Same org/user, reusable workflow call | `secrets: inherit` can expose caller secrets directly |
+| Cross-owner call or strict least-privilege | Pass one `DBT_NOVA_SECRET_BUNDLE_JSON` secret and map keys via `dbt_secret_env_map_json` |
 | No dbt manifest generation | `dbt_secret_env_map_json` is not required |
 
 Publish target auth requirements:
@@ -189,10 +186,9 @@ Publish target auth requirements:
 | `gcs` | Token via one of `DBT_NOVA_GCP_ACCESS_TOKEN`, `DBT_NOVA_BIGQUERY_ACCESS_TOKEN`, `GCP_ACCESS_TOKEN`, `GOOGLE_OAUTH_ACCESS_TOKEN`, or GitHub OIDC via `gcp_workload_identity_provider` + `gcp_service_account` |
 | `dbfs` | `DATABRICKS_HOST` and `DATABRICKS_ACCESS_TOKEN` |
 
-OIDC-backed GCS publish requires `installer_install_mode: release` and is not
-allowed in the same reusable job that generates a manifest from caller dbt
-code. Generate the manifest before calling the reusable workflow and use a
-signed Nova release binary, or use token-based GCS credentials for that run.
+OIDC-backed GCS publish is intentionally not allowed in the same reusable job
+that generates a manifest from caller dbt code. Generate the manifest before
+calling the reusable workflow, or use token-based GCS credentials for that run.
 
 Common downstream pattern: keep a repo-local `workflow_dispatch` wrapper and
 call this reusable workflow from it. This lets each repo set its own target

--- a/docs/operations/prebuilt-assets.md
+++ b/docs/operations/prebuilt-assets.md
@@ -47,6 +47,11 @@ aligned with the workflow ref. `v0.0.6` includes the runner override inputs; use
 `v0.0.6`, a newer release tag, or an immutable commit SHA when passing them.
 Reusable workflows reject branch-like installer refs unless
 `allow_mutable_installer_ref: true` is set for a trusted development run.
+Source installs resolve the requested ref to one commit, use credentials only
+during that fetch, and remove the source checkout's Git metadata before build.
+They refuse to run whenever the job exposes GitHub OIDC request credentials.
+Remove `id-token: write` for source-based development jobs; use
+`installer_install_mode: release` when OIDC is required.
 
 ```yaml
 name: Build Nova Assets
@@ -84,7 +89,7 @@ Alternative producer inputs:
 - `runner_labels_json` (JSON array of runner labels, overriding `runner` when
   a self-hosted pool requires multiple labels)
 - workflow_call secret `DBT_NOVA_SECRET_BUNDLE_JSON` (optional JSON object of
-  `secret-name -> secret-value` entries for cross-owner reusable workflow calls)
+  the exact `secret-name -> secret-value` entries exposed to the workflow)
 
 Structured mode is the recommended default:
 
@@ -148,15 +153,16 @@ jobs:
 ```
 
 For DBFS publish with `publish_dry_run: false`, `DATABRICKS_HOST` and
-`DATABRICKS_ACCESS_TOKEN` must be present at publish time. The example above
-wires both through `dbt_env_json` + `dbt_secret_env_map_json`.
+`DATABRICKS_ACCESS_TOKEN` must already be present in the runner environment at
+publish time. The example above maps them into the dbt invocation only; Nova
+does not forward the dbt secret bundle into the later publish shell.
 
 Notes:
 
 - `dbt_env_json` values are plain strings.
-- `dbt_secret_env_map_json` values are looked up in this order:
-  1) keys in `DBT_NOVA_SECRET_BUNDLE_JSON` (when provided),
-  2) inherited workflow secrets (`secrets: inherit`, same-owner/org calls).
+- `dbt_secret_env_map_json` values are looked up only in
+  `DBT_NOVA_SECRET_BUNDLE_JSON`; inherited repository and organization secrets
+  are never enumerated.
 - Missing mapped secrets fail fast before dbt invocation.
 - Use trusted `dbt_command` only when you explicitly need shell semantics.
 - Keep `search_warm_strategy: staged` for large manifests or memory-constrained
@@ -171,8 +177,8 @@ Secret setup patterns:
 
 | Call pattern | How secrets are resolved |
 |---|---|
-| Same org/user, reusable workflow call | `secrets: inherit` can expose caller secrets directly |
-| Cross-owner call or strict least-privilege | Pass one `DBT_NOVA_SECRET_BUNDLE_JSON` secret and map keys via `dbt_secret_env_map_json` |
+| Same-owner or cross-owner reusable call | Pass one `DBT_NOVA_SECRET_BUNDLE_JSON` secret containing only the required keys and map them via `dbt_secret_env_map_json` |
+| `secrets: inherit` | Not enumerated by Nova; explicitly pass `DBT_NOVA_SECRET_BUNDLE_JSON` instead |
 | No dbt manifest generation | `dbt_secret_env_map_json` is not required |
 
 Publish target auth requirements:
@@ -183,9 +189,10 @@ Publish target auth requirements:
 | `gcs` | Token via one of `DBT_NOVA_GCP_ACCESS_TOKEN`, `DBT_NOVA_BIGQUERY_ACCESS_TOKEN`, `GCP_ACCESS_TOKEN`, `GOOGLE_OAUTH_ACCESS_TOKEN`, or GitHub OIDC via `gcp_workload_identity_provider` + `gcp_service_account` |
 | `dbfs` | `DATABRICKS_HOST` and `DATABRICKS_ACCESS_TOKEN` |
 
-OIDC-backed GCS publish is intentionally not allowed in the same reusable job
-that generates a manifest from caller dbt code. Generate the manifest before
-calling the reusable workflow, or use token-based GCS credentials for that run.
+OIDC-backed GCS publish requires `installer_install_mode: release` and is not
+allowed in the same reusable job that generates a manifest from caller dbt
+code. Generate the manifest before calling the reusable workflow and use a
+signed Nova release binary, or use token-based GCS credentials for that run.
 
 Common downstream pattern: keep a repo-local `workflow_dispatch` wrapper and
 call this reusable workflow from it. This lets each repo set its own target

--- a/docs/operations/prebuilt-assets.md
+++ b/docs/operations/prebuilt-assets.md
@@ -20,15 +20,24 @@ read-only reuse after local materialization.
 7. Use the produced stable bootstrap alias in consumer env (`DBT_NOVA_BOOTSTRAP_URI`).
 8. On first consumer run, keep `DBT_NOVA_STORAGE_READ_ONLY` unset and hydrate locally with `DBT_NOVA_ARTIFACT_FETCH_POLICY=if_missing`.
 9. Switch to strict read-only only after local artifacts already exist (`DBT_NOVA_STORAGE_READ_ONLY=true`, `DBT_NOVA_ARTIFACT_FETCH_POLICY=never`).
+10. For a storage-format upgrade, deploy consumers before publishing with the
+    upgraded producer.
 
 ## What this solves
 
 - Removes repeated index builds on consumer jobs.
 - Makes consumer startup deterministic.
-- Enforces a strict contract (`storage_instance_id` + manifest content hash).
+- Enforces a strict contract (`storage_instance_id` + storage-scoped manifest
+  hash + storage format).
 
-## v1 boundaries
+## Contract boundaries
 
+- Producers emit metadata/bootstrap contract `v2` with an explicit
+  `storage_format_version`.
+- Current consumers continue to accept legacy `v1` artifacts produced by Nova
+  `v0.0.6`.
+- Legacy consumers reject `v2` contracts before extracting an index they cannot
+  read. Upgrade consumers before producers during a format transition.
 - Producer workflow + GitHub Artifacts are supported.
 - Optional models distribution is controlled by `models_distribution_mode`.
 - Consumers can hydrate artifacts locally on first run, then optionally switch
@@ -85,8 +94,9 @@ Alternative producer inputs:
   `ubuntu-22.04`)
 - `runner_labels_json` (JSON array of runner labels, overriding `runner` when
   a self-hosted pool requires multiple labels)
-- workflow_call secret `DBT_NOVA_SECRET_BUNDLE_JSON` (optional JSON object of
-  `secret-name -> secret-value` entries for cross-owner reusable workflow calls)
+- workflow_call secret `DBT_NOVA_SECRET_BUNDLE_JSON` (required when
+  `dbt_secret_env_map_json` is non-empty; explicitly selected
+  `secret-name -> secret-value` entries for any reusable workflow call)
 
 Structured mode is the recommended default:
 
@@ -157,9 +167,10 @@ does not forward the dbt secret bundle into the later publish shell.
 Notes:
 
 - `dbt_env_json` values are plain strings.
-- `dbt_secret_env_map_json` values are looked up in this order:
-  1) keys in `DBT_NOVA_SECRET_BUNDLE_JSON` (when provided),
-  2) inherited workflow secrets (`secrets: inherit`, same-owner/org calls).
+- `dbt_secret_env_map_json` values are looked up only in
+  `DBT_NOVA_SECRET_BUNDLE_JSON`.
+- Build the bundle explicitly in the caller. Unrelated inherited secrets are
+  never serialized into the reusable workflow job.
 - Missing mapped secrets fail fast before dbt invocation.
 - Use trusted `dbt_command` only when you explicitly need shell semantics.
 - Keep `search_warm_strategy: staged` for large manifests or memory-constrained
@@ -174,8 +185,7 @@ Secret setup patterns:
 
 | Call pattern | How secrets are resolved |
 |---|---|
-| Same org/user, reusable workflow call | `secrets: inherit` can expose caller secrets directly |
-| Cross-owner call or strict least-privilege | Pass one `DBT_NOVA_SECRET_BUNDLE_JSON` secret and map keys via `dbt_secret_env_map_json` |
+| Any reusable workflow call with mapped dbt credentials | Pass one explicitly constructed `DBT_NOVA_SECRET_BUNDLE_JSON` and map its keys via `dbt_secret_env_map_json` |
 | No dbt manifest generation | `dbt_secret_env_map_json` is not required |
 
 Publish target auth requirements:
@@ -428,12 +438,14 @@ Recommended consumer pattern:
 
 Use `health` to verify runtime decisions:
 
+- `manifest.storage_format_version`
 - `artifact_consumer.enabled`
 - `artifact_consumer.storage_read_only`
 - `artifact_consumer.consumer_mode_hint`
 - `artifact_consumer.guidance`
 - `artifact_consumer.fetch_policy`
 - `artifact_consumer.metadata_validated`
+- `artifact_consumer.metadata_storage_format_version`
 - `artifact_consumer.storage_materialized`
 - `artifact_consumer.models_materialized`
 - `artifact_consumer.last_evaluated_at_ms`
@@ -441,6 +453,7 @@ Use `health` to verify runtime decisions:
 - `bootstrap.enabled`
 - `bootstrap.uri`
 - `bootstrap.contract_version`
+- `bootstrap.storage_format_version`
 - `bootstrap.loaded`
 - `bootstrap.validated`
 - `bootstrap.applied_fields`
@@ -505,11 +518,15 @@ tar -xzf <artifact_name_storage>.tar.gz
 
 ## Compatibility guidance
 
-- Keep producer and consumer on the same released Nova version when possible.
+- Upgrade consumers before producers when `storage_format_version` changes.
+  New consumers can read retained legacy storage; old consumers cannot read a
+  newly written Tantivy format.
+- Keep producer and consumer on the same released Nova version after rollout.
 - `storage_instance_id` must match between producer and consumer.
-- Consumer manifest content must match the producer-built manifest hash.
-  Path differences are allowed; content differences are not.
-- Metadata contract version must be compatible (`v1` currently).
+- Consumer manifest content and storage-affecting configuration must match the
+  producer-built scoped hash. Path differences are allowed.
+- Metadata/bootstrap `v2` requires `storage_format_version`; current consumers
+  also accept legacy `v1` contracts.
 
 ## Failure modes and fixes
 
@@ -517,7 +534,7 @@ tar -xzf <artifact_name_storage>.tar.gz
 | --- | --- | --- |
 | `Storage is read-only; cannot materialize storage artifacts on first-run hydration` | Cold machine is configured with `DBT_NOVA_STORAGE_READ_ONLY=true` and `DBT_NOVA_ARTIFACT_FETCH_POLICY=if_missing|always` | First hydrate with writable storage (`DBT_NOVA_STORAGE_READ_ONLY=false` or unset), then switch to `DBT_NOVA_STORAGE_READ_ONLY=true` with `DBT_NOVA_ARTIFACT_FETCH_POLICY=never` after assets exist locally |
 | `Storage is read-only and no reusable index is available` | Missing storage files, mismatched `storage_instance_id`, or manifest content mismatch | Re-download artifacts, verify instance id, verify manifest is identical to producer input |
-| Metadata contract validation fails | Missing/corrupt `nova-build-metadata.json` or unsupported contract version | Re-run producer and consume both storage + metadata artifacts together |
+| Metadata contract validation fails | Missing/corrupt metadata, unsupported contract version, or incompatible storage format | Upgrade the consumer first, then re-run the producer and consume storage + metadata artifacts together |
 | Health passes but embeddings are missing | Models artifact not provided in consumer setup | Native mode: set `DBT_NOVA_MODELS_ARTIFACT_URI` to the producer models artifact URI. Manual mode: extract models artifact and set `DBT_NOVA_EMBEDDINGS_CACHE_DIR`. |
 
 ## Related docs

--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -129,6 +129,14 @@ Logging privacy:
 - MCP tool logs include tool name, success/failure, duration, and request ID
   when one is available. Tool response payload contracts are unchanged.
 
+## Reusable Workflow Secrets
+
+Reusable dbt generation resolves mapped credentials only from the caller-built
+`DBT_NOVA_SECRET_BUNDLE_JSON` secret. `dbt_secret_env_map_json` selects the keys
+passed to the dbt subprocess, and Nova removes the bundle itself from that
+subprocess environment. The workflows do not serialize or enumerate inherited
+repository and organization secrets.
+
 ## Advisory Exceptions
 
 The following RustSec advisories are explicitly ignored in `deny.toml` with documented rationale.
@@ -137,19 +145,14 @@ dependency refreshes. Each ignore entry includes `owner=...` and `review_by=YYYY
 metadata in the `reason` field. CI enforces that review dates are not expired via
 `scripts/check_advisory_ignores.sh`.
 
-- `RUSTSEC-2024-0384`: `instant` via `tantivy` -> `measure_time`
 - `RUSTSEC-2024-0436`: `paste` via `fastembed` -> `tokenizers`
 - `RUSTSEC-2025-0119`: `number_prefix` via `fastembed` -> `hf-hub` -> `indicatif`
-- `RUSTSEC-2025-0134`: `rustls-pemfile` via `google-cloud-storage` -> `reqwest 0.11`
-- `RUSTSEC-2026-0002`: `lru 0.12` via `tantivy`
-- `RUSTSEC-2026-0097`: `rand` via `fastembed`/`tokenizers`, `tantivy`/`rand_distr`,
-  `rmcp`, and `proptest`
 
 ## Dependency Watchlist
 
-Beyond RustSec advisories, Nova tracks known dependency constraints (for example,
-the `ort-sys` RC pin and the `reqwest` 0.11/0.12/0.13 transitive split) in a
-machine-readable watchlist with owners, review dates, and upgrade triggers.
+Beyond RustSec advisories, Nova tracks known dependency constraints such as the
+`ort-sys` RC pin in a machine-readable watchlist with owners, review dates, and
+upgrade triggers.
 
 - Watchlist file: `dependency-watchlist.toml`
 - Validation script: `scripts/check_dependency_watchlist.sh`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs==1.6.1
-mkdocs-material==9.5.39
+mkdocs-material==9.7.7
 mkdocs-minify-plugin==0.8.0
-pymdown-extensions==10.8.1
+pymdown-extensions==11.0
 Pygments<2.20

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs==1.6.1
 mkdocs-material==9.5.39
 mkdocs-minify-plugin==0.8.0
-pymdown-extensions==10.8.1
+pymdown-extensions==10.21.4
 Pygments<2.20

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs==1.6.1
 mkdocs-material==9.5.39
 mkdocs-minify-plugin==0.8.0
-pymdown-extensions==11.0
+pymdown-extensions==10.8.1
 Pygments<2.20

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs==1.6.1
 mkdocs-material==9.5.39
 mkdocs-minify-plugin==0.8.0
-pymdown-extensions==10.21.4
+pymdown-extensions==11.0
 Pygments<2.20

--- a/scripts/check_storage_format_compatibility.sh
+++ b/scripts/check_storage_format_compatibility.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 3 ]]; then
+  echo "usage: $0 <current-binary> <legacy-binary> <manifest.json>" >&2
+  exit 2
+fi
+
+current_binary="$1"
+legacy_binary="$2"
+manifest_path="$3"
+
+for binary in "${current_binary}" "${legacy_binary}"; do
+  if [[ ! -x "${binary}" ]]; then
+    echo "binary is not executable: ${binary}" >&2
+    exit 2
+  fi
+done
+if [[ ! -f "${manifest_path}" ]]; then
+  echo "manifest does not exist: ${manifest_path}" >&2
+  exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 2
+fi
+
+workspace="$(mktemp -d)"
+trap 'rm -rf "${workspace}"' EXIT
+
+storage_dir="${workspace}/storage"
+instance_id="storage-format-compat"
+legacy_load="${workspace}/legacy-load.json"
+current_legacy_read="${workspace}/current-legacy-read.json"
+current_remote_hydration="${workspace}/current-remote-hydration.json"
+current_load="${workspace}/current-load.json"
+legacy_rollback="${workspace}/legacy-rollback.json"
+legacy_contract_rejection="${workspace}/legacy-contract-rejection.json"
+
+run_load() {
+  local binary="$1"
+  local output="$2"
+  shift 2
+  DBT_NOVA_SEARCH_ENABLE_VECTOR=false \
+    DBT_NOVA_SEARCH_ENABLE_SPARSE=false \
+    DBT_NOVA_SEARCH_ENABLE_RERANKER=false \
+    DBT_NOVA_STORAGE_DIR="${storage_dir}" \
+    "${binary}" manifest load \
+      --manifest-path "${manifest_path}" \
+      --storage-instance-id "${instance_id}" \
+      --json \
+      "$@" > "${output}"
+  jq -e '.status == "success"' "${output}" >/dev/null
+}
+
+run_load "${legacy_binary}" "${legacy_load}"
+legacy_version="$(jq -r '.data.manifest_version' "${legacy_load}")"
+
+run_load "${current_binary}" "${current_legacy_read}" --read-only
+jq -e --arg version "${legacy_version}" '
+  .data.manifest_version == $version and
+  .data.storage_format_version == "nova-storage-v1" and
+  .data.reused.entity_store == true and
+  .data.reused.tantivy == true and
+  .data.reused.indexes == true
+' "${current_legacy_read}" >/dev/null
+
+# Consumer-first rollout must also work on a cold host. A current writable
+# consumer validates the v1-scoped hash, hydrates the old archive, and rebuilds
+# it into the current format without mutating the retained v1 generation.
+legacy_manifest_hash="$(jq -r '.data.manifest_hash' "${legacy_load}")"
+legacy_storage_archive="${workspace}/legacy-storage.tar.gz"
+legacy_metadata_path="${workspace}/legacy-metadata.json"
+COPYFILE_DISABLE=1 tar --exclude='*.lock' -czf "${legacy_storage_archive}" \
+  -C "$(dirname "${storage_dir}")" "$(basename "${storage_dir}")"
+jq -n \
+  --arg manifest_hash "${legacy_manifest_hash}" \
+  --arg manifest_version "${legacy_version}" \
+  '{
+    contract_version: "v1",
+    manifest_hash: $manifest_hash,
+    manifest_version: $manifest_version,
+    entity_count: 0,
+    storage_instance_id: "storage-format-compat",
+    dbt_nova_version: "0.0.6",
+    build_timestamp: "2026-01-01T00:00:00Z",
+    artifact_name_storage: "legacy-storage",
+    artifact_name_models: ""
+  }' > "${legacy_metadata_path}"
+
+remote_storage_dir="${workspace}/remote-storage"
+DBT_NOVA_SEARCH_ENABLE_VECTOR=false \
+  DBT_NOVA_SEARCH_ENABLE_SPARSE=false \
+  DBT_NOVA_SEARCH_ENABLE_RERANKER=false \
+  DBT_NOVA_STORAGE_DIR="${remote_storage_dir}" \
+  DBT_NOVA_STORAGE_ARTIFACT_URI="file://${legacy_storage_archive}" \
+  DBT_NOVA_METADATA_ARTIFACT_URI="file://${legacy_metadata_path}" \
+  DBT_NOVA_ARTIFACT_FETCH_POLICY=always \
+  "${current_binary}" manifest load \
+    --manifest-path "${manifest_path}" \
+    --storage-instance-id "${instance_id}" \
+    --json > "${current_remote_hydration}"
+jq -e '
+  .status == "success" and
+  .data.storage_format_version == "nova-storage-v2" and
+  .data.reused.entity_store == false and
+  .data.reused.tantivy == false and
+  .data.reused.indexes == false
+' "${current_remote_hydration}" >/dev/null
+
+run_load "${current_binary}" "${current_load}"
+current_version="$(jq -r '.data.manifest_version' "${current_load}")"
+current_format="$(jq -r '.data.storage_format_version // empty' "${current_load}")"
+
+if [[ -z "${legacy_version}" || -z "${current_version}" ]]; then
+  echo "manifest load did not return version identifiers" >&2
+  exit 1
+fi
+if [[ "${legacy_version}" == "${current_version}" ]]; then
+  echo "storage format change did not produce a distinct manifest version" >&2
+  exit 1
+fi
+if [[ "${current_format}" != "nova-storage-v2" ]]; then
+  echo "unexpected current storage format: ${current_format}" >&2
+  exit 1
+fi
+jq -e '
+  .data.reused.entity_store == false and
+  .data.reused.tantivy == false and
+  .data.reused.indexes == false
+' "${current_load}" >/dev/null
+
+# The legacy binary must recover its retained format-specific version even
+# after the current binary advances manifest.current.json.
+run_load "${legacy_binary}" "${legacy_rollback}" --read-only
+jq -e --arg version "${legacy_version}" '
+  .data.manifest_version == $version and
+  .data.reused.entity_store == true and
+  .data.reused.tantivy == true and
+  .data.reused.indexes == true
+' "${legacy_rollback}" >/dev/null
+
+# A cold legacy consumer cannot read the new Tantivy format. The v2 metadata
+# contract must stop it before archive extraction with an explicit upgrade cue.
+metadata_path="${workspace}/nova-build-metadata.json"
+storage_archive="${workspace}/storage.tar.gz"
+printf 'not-read-before-contract-validation' > "${storage_archive}"
+jq -n \
+  --arg manifest_hash "${current_version}" \
+  '{
+    contract_version: "v2",
+    storage_format_version: "nova-storage-v2",
+    manifest_hash: $manifest_hash,
+    manifest_version: $manifest_hash,
+    entity_count: 0,
+    storage_instance_id: "storage-format-compat",
+    dbt_nova_version: "0.0.6",
+    build_timestamp: "2026-01-01T00:00:00Z",
+    artifact_name_storage: "storage-format-compat",
+    artifact_name_models: ""
+  }' > "${metadata_path}"
+
+set +e
+DBT_NOVA_SEARCH_ENABLE_VECTOR=false \
+  DBT_NOVA_SEARCH_ENABLE_SPARSE=false \
+  DBT_NOVA_SEARCH_ENABLE_RERANKER=false \
+  DBT_NOVA_STORAGE_DIR="${workspace}/legacy-cold-storage" \
+  DBT_NOVA_STORAGE_ARTIFACT_URI="file://${storage_archive}" \
+  DBT_NOVA_METADATA_ARTIFACT_URI="file://${metadata_path}" \
+  DBT_NOVA_ARTIFACT_FETCH_POLICY=if_missing \
+  "${legacy_binary}" manifest load \
+    --manifest-path "${manifest_path}" \
+    --storage-instance-id "${instance_id}" \
+    --json > "${legacy_contract_rejection}" 2>/dev/null
+legacy_contract_status="$?"
+set -e
+
+if [[ "${legacy_contract_status}" -eq 0 ]]; then
+  echo "legacy consumer unexpectedly accepted the v2 prebuilt contract" >&2
+  exit 1
+fi
+jq -e '
+  .status == "error" and
+  (.error.error | contains("unsupported prebuilt metadata contract_version"))
+' "${legacy_contract_rejection}" >/dev/null
+
+echo "storage compatibility passed: legacy=${legacy_version} current=${current_version} format=${current_format}"

--- a/src/cli/eval_cmd/tests/mcp_execution.rs
+++ b/src/cli/eval_cmd/tests/mcp_execution.rs
@@ -242,6 +242,9 @@ fn eval_mcp_writable_paths_reject_absolute_parent_traversal() {
 #[tokio::test]
 async fn bridge_eval_writes_result_artifacts() {
     let temp_dir = TempDir::new().expect("output dir");
+    let manifest_path = temp_dir.path().join("manifest.json");
+    std::fs::copy(fixture_manifest_path("nova_manifest.json"), &manifest_path)
+        .expect("copy manifest fixture");
     let suite_path = temp_dir.path().join("suite.yml");
     std::fs::write(
         &suite_path,
@@ -265,11 +268,7 @@ cases:
     let output_dir = temp_dir.path().join("out");
     let result = run_eval_command(&EvalRunArgs {
         suite: suite_path.display().to_string(),
-        manifest_path: Some(
-            fixture_manifest_path("nova_manifest.json")
-                .display()
-                .to_string(),
-        ),
+        manifest_path: Some(manifest_path.display().to_string()),
         output_dir: Some(output_dir.display().to_string()),
         fail_under: Some(1.0),
         telemetry: true,

--- a/src/cli/manifest.rs
+++ b/src/cli/manifest.rs
@@ -28,6 +28,7 @@ pub struct ManifestLoadData {
     pub entity_count: usize,
     pub manifest_hash: String,
     pub manifest_version: String,
+    pub storage_format_version: String,
     pub storage_path: String,
     pub elapsed_ms: u128,
     pub reused: ReuseInfo,
@@ -295,6 +296,10 @@ fn print_human_summary(payload: &ManifestLoadData) {
     println!("  entity_count: {}", payload.entity_count);
     println!("  manifest_hash: {}", payload.manifest_hash);
     println!("  manifest_version: {}", payload.manifest_version);
+    println!(
+        "  storage_format_version: {}",
+        payload.storage_format_version
+    );
     println!("  storage_path: {}", payload.storage_path);
     println!("  elapsed_ms: {}", payload.elapsed_ms);
     println!("  entity_store_reused: {}", payload.reused.entity_store);
@@ -354,6 +359,7 @@ fn payload_from_result(
         entity_count: search.entity_count(),
         manifest_hash: search.manifest_hash.clone(),
         manifest_version: search.manifest_version.clone(),
+        storage_format_version: search.storage_format_version.clone(),
         storage_path: storage_path.to_string_lossy().to_string(),
         elapsed_ms: result.elapsed_ms,
         reused: ReuseInfo {
@@ -836,6 +842,7 @@ mod tests {
     use crate::cli::args::{ManifestLoadArgs, ManifestReloadArgs, ManifestWarmArgs};
     use crate::config::DbtNovaConfig;
     use crate::config::SearchConfig;
+    use crate::config::search::STORAGE_FORMAT_VERSION;
     use crate::manifest::rkyv_embeddings::save_embeddings;
     use crate::manifest::rkyv_sparse_embeddings::save_sparse_embeddings;
     use crate::manifest::rkyv_types::{
@@ -1272,6 +1279,10 @@ mod tests {
         assert!(parsed["data"]["entity_count"].as_u64().is_some());
         assert!(parsed["data"]["manifest_hash"].as_str().is_some());
         assert!(parsed["data"]["manifest_version"].as_str().is_some());
+        assert_eq!(
+            parsed["data"]["storage_format_version"],
+            serde_json::json!(STORAGE_FORMAT_VERSION)
+        );
         assert!(parsed["data"]["storage_path"].as_str().is_some());
         assert!(parsed["data"]["reused"].is_object());
         assert!(parsed["data"]["search_ready"].is_object());

--- a/src/config/search.rs
+++ b/src/config/search.rs
@@ -605,7 +605,15 @@ impl SearchConfig {
     /// Deterministic fingerprint for search-index-affecting config.
     #[must_use]
     pub fn index_fingerprint(&self) -> String {
-        if self.extended_meta.fields.is_empty() {
+        self.index_fingerprint_for_format(Some(STORAGE_FORMAT_VERSION))
+    }
+
+    pub(crate) fn legacy_index_fingerprint(&self) -> String {
+        self.index_fingerprint_for_format(None)
+    }
+
+    fn index_fingerprint_for_format(&self, storage_format_version: Option<&str>) -> String {
+        if storage_format_version.is_none() && self.extended_meta.fields.is_empty() {
             return String::new();
         }
 
@@ -625,19 +633,36 @@ impl SearchConfig {
             .collect::<Vec<_>>();
         fields.sort_by_key(std::string::ToString::to_string);
 
-        let payload = json!({
-            "extended_meta": {
-                "fields": fields,
-                "max_fields": self.extended_meta.max_fields,
-                "max_values_per_field": self.extended_meta.max_values_per_field,
-                "max_bytes_per_value": self.extended_meta.max_bytes_per_value,
-            }
+        let extended_meta = json!({
+            "fields": fields,
+            "max_fields": self.extended_meta.max_fields,
+            "max_values_per_field": self.extended_meta.max_values_per_field,
+            "max_bytes_per_value": self.extended_meta.max_bytes_per_value,
         });
+        let payload = if let Some(storage_format_version) = storage_format_version {
+            json!({
+                "storage_format_version": storage_format_version,
+                "extended_meta": extended_meta,
+            })
+        } else {
+            json!({
+                "extended_meta": extended_meta,
+            })
+        };
         blake3::hash(payload.to_string().as_bytes())
             .to_hex()
             .to_string()
     }
 }
+
+/// Nova-owned compatibility identity for persisted storage and lexical indexes.
+///
+/// Increment this value whenever a dependency or schema change makes newly
+/// written storage unreadable by an older Nova binary.
+pub const STORAGE_FORMAT_VERSION: &str = "nova-storage-v2";
+/// Persisted-storage identity emitted by Nova releases before explicit
+/// storage-format versioning was introduced.
+pub const LEGACY_STORAGE_FORMAT_VERSION: &str = "nova-storage-v1";
 
 /// Semantic startup behavior when manifest-scoped caches are missing.
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Default)]

--- a/src/config/search/tests.rs
+++ b/src/config/search/tests.rs
@@ -243,7 +243,7 @@ fn metadata_support_env_overrides_apply() {
 fn extended_meta_is_default_off() {
     let config = SearchConfig::default();
     assert!(config.extended_meta.fields.is_empty());
-    assert_eq!(config.index_fingerprint(), "");
+    assert_eq!(config.index_fingerprint().len(), 64);
     config.validate().expect("default config should validate");
 }
 

--- a/src/manifest/bootstrap.rs
+++ b/src/manifest/bootstrap.rs
@@ -51,6 +51,7 @@ fn bootstrap_disabled_status() -> JsonValue {
         "enabled": false,
         "uri": "",
         "contract_version": JsonValue::Null,
+        "storage_format_version": JsonValue::Null,
         "loaded": false,
         "validated": false,
         "applied_fields": [],
@@ -126,6 +127,7 @@ pub fn apply_bootstrap_defaults(config: &mut DbtNovaConfig) -> Result<BootstrapR
     ensure_regular_file("DBT_NOVA_BOOTSTRAP_URI", &local_path)?;
     let raw = read_small_text_file(Path::new(&local_path), config.manifest_max_bytes)?;
     let bootstrap = PrebuiltAssetsBootstrap::from_json_str(&raw)?;
+    let storage_format_version = bootstrap.effective_storage_format_version().to_string();
     validate_models_metadata_contract(config, &bootstrap)?;
 
     let mut applied_fields = Vec::new();
@@ -164,6 +166,7 @@ pub fn apply_bootstrap_defaults(config: &mut DbtNovaConfig) -> Result<BootstrapR
         "enabled": true,
         "uri": sanitize_uri(&bootstrap_uri),
         "contract_version": bootstrap.contract_version,
+        "storage_format_version": storage_format_version,
         "loaded": true,
         "validated": true,
         "applied_fields": applied_fields,
@@ -223,7 +226,8 @@ mod tests {
 
     fn write_bootstrap(path: &std::path::Path) {
         let payload = r#"{
-  "contract_version":"v1",
+  "contract_version":"v2",
+  "storage_format_version":"nova-storage-v2",
   "profile":"prod",
   "storage_instance_id":"analytics-prod",
   "manifest_uri":"dbfs:/FileStore/manifests/prod/manifest.json",
@@ -240,7 +244,8 @@ mod tests {
     fn write_bootstrap_with_uris(path: &std::path::Path, metadata_uri: &str, models_uri: &str) {
         let payload = format!(
             r#"{{
-  "contract_version":"v1",
+  "contract_version":"v2",
+  "storage_format_version":"nova-storage-v2",
   "profile":"prod",
   "storage_instance_id":"analytics-prod",
   "manifest_uri":"dbfs:/FileStore/manifests/prod/manifest.json",
@@ -258,7 +263,8 @@ mod tests {
     fn write_metadata(path: &std::path::Path, artifact_name_models: &str) {
         let payload = format!(
             r#"{{
-  "contract_version":"v1",
+  "contract_version":"v2",
+  "storage_format_version":"nova-storage-v2",
   "manifest_hash":"abc123",
   "manifest_version":"abc123",
   "entity_count":1,
@@ -308,6 +314,14 @@ mod tests {
 
         let resolution = apply_bootstrap_defaults(&mut config).expect("bootstrap loaded");
         assert_eq!(resolution.status["enabled"], serde_json::json!(true));
+        assert_eq!(
+            resolution.status["contract_version"],
+            serde_json::json!("v2")
+        );
+        assert_eq!(
+            resolution.status["storage_format_version"],
+            serde_json::json!("nova-storage-v2")
+        );
         assert_eq!(
             config.storage_instance_id, "analytics-prod",
             "bootstrap should fill missing storage instance id"

--- a/src/manifest/loader.rs
+++ b/src/manifest/loader.rs
@@ -12,7 +12,7 @@ use serde_json::Value as JsonValue;
 use crate::config::DbtNovaConfig;
 use crate::error::{DbtNovaError, Result};
 use crate::manifest::bootstrap::prepare_runtime_config;
-use crate::manifest::prebuilt_assets_resolver::materialize_file_artifacts;
+use crate::manifest::prebuilt_assets_resolver::materialize_file_artifacts_with_legacy_hash;
 use crate::manifest::rkyv_indexes;
 use crate::manifest::rkyv_types::{PersistedIndexes, RKYV_SCHEMA_VERSION};
 use crate::manifest::search::{
@@ -40,13 +40,13 @@ use runtime::has_apparent_malformed_ref;
 use runtime::{
     build_column_lineage_aliases, build_manifest_health, combine_index_build_results, panic_message,
 };
-#[cfg(test)]
-use storage::acquire_build_lock;
 use storage::{
     MANIFEST_SIGNATURE_FILENAME, acquire_in_use_locks, current_time_ms,
-    manifest_signature_matches_for_reuse, read_current_version, read_manifest_signature,
+    manifest_signature_matches_for_runtime_read, read_current_version, read_manifest_signature,
     select_storage_version_or_lock, write_current_version, write_manifest_signature,
 };
+#[cfg(test)]
+use storage::{acquire_build_lock, manifest_signature_matches_for_reuse};
 
 /// Structured output from manifest loading/index build.
 pub struct ManifestLoadResult {
@@ -76,6 +76,7 @@ struct ReuseArtifacts {
     entities: Option<EntityStore>,
     reuse_store: bool,
     tantivy_opened: Option<TantivySearcher>,
+    open_errors: Vec<String>,
 }
 
 struct CachedIndexData {
@@ -326,6 +327,10 @@ fn prepare_storage(
     signature.prune_fingerprint = config.manifest_prune_fingerprint();
     signature.search_index_fingerprint = config.search.index_fingerprint();
     let version_hash = scoped_manifest_hash(&signature);
+    let mut legacy_signature = signature.clone();
+    legacy_signature.search_index_fingerprint = config.search.legacy_index_fingerprint();
+    legacy_signature.storage_format_version.clear();
+    let legacy_version_hash = scoped_manifest_hash(&legacy_signature);
     let mut version_id = version_hash.chars().take(12).collect::<String>();
     if version_id.is_empty() {
         version_id = "unknown".to_string();
@@ -344,8 +349,12 @@ fn prepare_storage(
         signature_path,
     )?;
     let can_materialize = selected.build_lock.is_some();
-    let artifact_consumer_status =
-        evaluate_artifact_consumer_status(config, can_materialize, &target_version_hash)?;
+    let artifact_consumer_status = evaluate_artifact_consumer_status(
+        config,
+        can_materialize,
+        &target_version_hash,
+        &legacy_version_hash,
+    )?;
 
     Ok(StoragePreparation {
         instance_root,
@@ -364,6 +373,7 @@ fn evaluate_artifact_consumer_status(
     config: &DbtNovaConfig,
     can_materialize: bool,
     target_version_hash: &str,
+    legacy_version_hash: &str,
 ) -> Result<JsonValue> {
     let mut artifact_consumer_status = build_artifact_consumer_status(config, None, None);
     if !can_materialize || !config.remote_artifact_mode_enabled() {
@@ -371,7 +381,11 @@ fn evaluate_artifact_consumer_status(
     }
 
     let evaluated_at_ms = current_time_ms();
-    let materialization = materialize_file_artifacts(config, target_version_hash)?;
+    let materialization = materialize_file_artifacts_with_legacy_hash(
+        config,
+        target_version_hash,
+        legacy_version_hash,
+    )?;
     if let Some(outcome) = materialization {
         let last_materialized_at_ms = if outcome.storage_materialized || outcome.models_materialized
         {
@@ -454,6 +468,41 @@ fn apply_catalog_signature(
     Ok(())
 }
 
+fn open_reusable_artifacts(
+    config: &DbtNovaConfig,
+    storage_dir: &Path,
+    entities: &mut Option<EntityStore>,
+    reuse_store: &mut bool,
+    tantivy_opened: &mut Option<TantivySearcher>,
+    open_errors: &mut Vec<String>,
+) {
+    match EntityStore::open(storage_dir) {
+        Ok(store) => {
+            *entities = Some(store);
+            *reuse_store = true;
+        }
+        Err(error) => {
+            warn!(
+                storage_dir = %storage_dir.display(),
+                error = %error,
+                "failed to open reusable entity store"
+            );
+            open_errors.push(format!("entity store: {error}"));
+        }
+    }
+    match TantivySearcher::open(storage_dir, &config.search) {
+        Ok(opened) => *tantivy_opened = opened,
+        Err(error) => {
+            warn!(
+                storage_dir = %storage_dir.display(),
+                error = %error,
+                "failed to open reusable Tantivy index"
+            );
+            open_errors.push(format!("Tantivy index: {error}"));
+        }
+    }
+}
+
 fn load_reusable_artifacts(
     config: &DbtNovaConfig,
     instance_root: &Path,
@@ -469,39 +518,42 @@ fn load_reusable_artifacts(
     let mut reuse_store = false;
     let mut tantivy_opened: Option<TantivySearcher> = None;
     let mut matched_signature = false;
+    let mut open_errors = Vec::new();
 
     if let Some(current) = &current_version {
         let current_dir = versions_root.join(current);
         let current_sig_path = current_dir.join(MANIFEST_SIGNATURE_FILENAME);
         if let Some(existing) = read_manifest_signature(&current_sig_path)?
-            && manifest_signature_matches_for_reuse(&existing, signature)
+            && manifest_signature_matches_for_runtime_read(config, &existing, signature)
         {
             storage_dir = current_dir;
             signature_path = current_sig_path;
             matched_signature = true;
-            if let Ok(store) = EntityStore::open(&storage_dir) {
-                entities = Some(store);
-                reuse_store = true;
-            }
-            if let Ok(opened) = TantivySearcher::open(&storage_dir, &config.search) {
-                tantivy_opened = opened;
-            }
+            open_reusable_artifacts(
+                config,
+                &storage_dir,
+                &mut entities,
+                &mut reuse_store,
+                &mut tantivy_opened,
+                &mut open_errors,
+            );
         }
     }
 
     if !matched_signature
         && let Some(existing) = read_manifest_signature(initial_signature_path)?
-        && manifest_signature_matches_for_reuse(&existing, signature)
+        && manifest_signature_matches_for_runtime_read(config, &existing, signature)
     {
         storage_dir = initial_storage_dir.to_path_buf();
         signature_path = initial_signature_path.to_path_buf();
-        if let Ok(store) = EntityStore::open(&storage_dir) {
-            entities = Some(store);
-            reuse_store = true;
-        }
-        if let Ok(opened) = TantivySearcher::open(&storage_dir, &config.search) {
-            tantivy_opened = opened;
-        }
+        open_reusable_artifacts(
+            config,
+            &storage_dir,
+            &mut entities,
+            &mut reuse_store,
+            &mut tantivy_opened,
+            &mut open_errors,
+        );
     }
 
     Ok(ReuseArtifacts {
@@ -511,6 +563,7 @@ fn load_reusable_artifacts(
         entities,
         reuse_store,
         tantivy_opened,
+        open_errors,
     })
 }
 
@@ -630,9 +683,14 @@ fn ensure_build_reuse_state(
     }
     if config.storage_read_only && needs_build {
         storage.build_lock.take();
-        return Err(DbtNovaError::ServerError(
-            "Storage is read-only and no reusable index is available".to_string(),
-        ));
+        let detail = if reused.open_errors.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", reused.open_errors.join("; "))
+        };
+        return Err(DbtNovaError::ServerError(format!(
+            "Storage is read-only and no reusable index is available{detail}"
+        )));
     }
     Ok(())
 }
@@ -999,6 +1057,10 @@ fn assemble_manifest_search(context: AssembleContext) -> ManifestSearch {
         in_use_locks,
         manifest_source_uri,
     } = context;
+    let storage_format_version = storage
+        .signature
+        .effective_storage_format_version()
+        .to_string();
     ManifestSearch {
         config,
         entities: Arc::new(entities),
@@ -1036,6 +1098,7 @@ fn assemble_manifest_search(context: AssembleContext) -> ManifestSearch {
         manifest_len: storage.signature.len,
         manifest_modified_ms: storage.signature.modified_ms,
         manifest_version: storage.version_id,
+        storage_format_version,
         loaded_at_ms: current_time_ms(),
         vector_breaker: runtime.vector_breaker,
         sparse_breaker: runtime.sparse_breaker,
@@ -1090,6 +1153,9 @@ fn build_artifact_consumer_status(
         "models_uri": sanitize_uri(&config.models_artifact_uri),
         "metadata_validated": outcome.is_some(),
         "metadata_contract_version": outcome.map(|value| value.metadata.contract_version.clone()),
+        "metadata_storage_format_version": outcome.map(|value| {
+            value.metadata.effective_storage_format_version().to_string()
+        }),
         "storage_materialized": outcome.is_some_and(|value| value.storage_materialized),
         "models_materialized": outcome.is_some_and(|value| value.models_materialized),
         "last_evaluated_at_ms": last_evaluated_at_ms,
@@ -1330,6 +1396,7 @@ mod tests {
             content_hash: "same-hash".to_string(),
             prune_fingerprint: String::new(),
             search_index_fingerprint: String::new(),
+            storage_format_version: String::new(),
             source_uri: "file:///new/path".to_string(),
         };
         let existing = ManifestSignature {
@@ -1339,6 +1406,7 @@ mod tests {
             content_hash: "same-hash".to_string(),
             prune_fingerprint: String::new(),
             search_index_fingerprint: String::new(),
+            storage_format_version: String::new(),
             source_uri: "file:///old/path".to_string(),
         };
         assert!(
@@ -1356,6 +1424,7 @@ mod tests {
             content_hash: "expected-hash".to_string(),
             prune_fingerprint: String::new(),
             search_index_fingerprint: String::new(),
+            storage_format_version: String::new(),
             source_uri: "file:///new/path".to_string(),
         };
         let different_hash = ManifestSignature {
@@ -1365,6 +1434,7 @@ mod tests {
             content_hash: "different-hash".to_string(),
             prune_fingerprint: String::new(),
             search_index_fingerprint: String::new(),
+            storage_format_version: String::new(),
             source_uri: "file:///old/path".to_string(),
         };
         let missing_hash = ManifestSignature {
@@ -1374,6 +1444,7 @@ mod tests {
             content_hash: String::new(),
             prune_fingerprint: String::new(),
             search_index_fingerprint: String::new(),
+            storage_format_version: String::new(),
             source_uri: "file:///old/path".to_string(),
         };
         assert!(!manifest_signature_matches_for_reuse(
@@ -1395,6 +1466,7 @@ mod tests {
             content_hash: "same-hash".to_string(),
             prune_fingerprint: "fingerprint-a".to_string(),
             search_index_fingerprint: String::new(),
+            storage_format_version: String::new(),
             source_uri: "file:///new/path".to_string(),
         };
         let existing = ManifestSignature {
@@ -1404,6 +1476,7 @@ mod tests {
             content_hash: "same-hash".to_string(),
             prune_fingerprint: "fingerprint-b".to_string(),
             search_index_fingerprint: String::new(),
+            storage_format_version: String::new(),
             source_uri: "file:///old/path".to_string(),
         };
         assert!(!manifest_signature_matches_for_reuse(&existing, &expected));
@@ -1566,6 +1639,7 @@ mod tests {
             manifest_signature(&manifest_path, manifest_path.to_string_lossy().as_ref())
                 .expect("manifest signature");
         signature.prune_fingerprint = config.manifest_prune_fingerprint();
+        signature.search_index_fingerprint = config.search.index_fingerprint();
         let expected_hash = scoped_manifest_hash(&signature);
 
         assert_ne!(expected_hash, signature.content_hash);

--- a/src/manifest/loader/storage.rs
+++ b/src/manifest/loader/storage.rs
@@ -8,6 +8,7 @@ use fs4::FileExt;
 use serde::{Deserialize, Serialize};
 
 use crate::config::DbtNovaConfig;
+use crate::config::search::{LEGACY_STORAGE_FORMAT_VERSION, STORAGE_FORMAT_VERSION};
 use crate::error::{DbtNovaError, Result};
 use crate::manifest::rkyv_indexes;
 use crate::manifest::search::InUseLocks;
@@ -72,6 +73,23 @@ pub(super) fn manifest_signature_matches_for_reuse(
         && existing.content_hash == expected.content_hash
         && existing.prune_fingerprint == expected.prune_fingerprint
         && existing.search_index_fingerprint == expected.search_index_fingerprint
+        && existing.effective_storage_format_version()
+            == expected.effective_storage_format_version()
+}
+
+pub(super) fn manifest_signature_matches_for_runtime_read(
+    config: &DbtNovaConfig,
+    existing: &ManifestSignature,
+    expected: &ManifestSignature,
+) -> bool {
+    manifest_signature_matches_for_reuse(existing, expected)
+        || (config.storage_read_only
+            && existing.effective_storage_format_version() == LEGACY_STORAGE_FORMAT_VERSION
+            && expected.effective_storage_format_version() == STORAGE_FORMAT_VERSION
+            && !existing.content_hash.is_empty()
+            && existing.content_hash == expected.content_hash
+            && existing.prune_fingerprint == expected.prune_fingerprint
+            && existing.search_index_fingerprint == config.search.legacy_index_fingerprint())
 }
 
 pub(super) fn read_current_version(path: &Path) -> Result<Option<String>> {
@@ -190,18 +208,24 @@ pub(super) fn select_storage_version_or_lock(
         build_lock: None,
     };
 
-    if storage_version_has_lockless_read_artifacts(
+    if let Some(published) = find_lockless_storage_version(
         config,
         instance_root,
         versions_root,
         &selection.signature,
         &selection.storage_dir,
         &selection.signature_path,
+        &selection.version_id,
     )? {
         tracing::info!(
-            version_id = %selection.version_id,
+            requested_version_id = %selection.version_id,
+            served_version_id = %published.version_id,
             "serving complete storage version without acquiring build lock"
         );
+        selection.signature = published.signature;
+        selection.version_id = published.version_id;
+        selection.storage_dir = published.storage_dir;
+        selection.signature_path = published.signature_path;
         return Ok(selection);
     }
 
@@ -240,28 +264,45 @@ fn serve_current_or_wait_for_build_lock(
     acquire_build_lock(instance_root, config.storage_build_lock_wait_secs).map(Some)
 }
 
-fn storage_version_has_lockless_read_artifacts(
+fn find_lockless_storage_version(
     config: &DbtNovaConfig,
     instance_root: &Path,
     versions_root: &Path,
     signature: &ManifestSignature,
     initial_storage_dir: &Path,
     initial_signature_path: &Path,
-) -> Result<bool> {
+    initial_version_id: &str,
+) -> Result<Option<PublishedStorageVersion>> {
     if let Some(current) = read_current_version(instance_root)? {
-        let current_dir = versions_root.join(current);
+        let current_dir = versions_root.join(&current);
         let current_sig_path = current_dir.join(MANIFEST_SIGNATURE_FILENAME);
-        if storage_signature_matches(&current_sig_path, signature)?
-            && storage_dir_has_lockless_read_artifacts(config, &current_dir, signature)
+        if let Some(current_signature) = read_manifest_signature(&current_sig_path)?
+            && manifest_signature_matches_for_runtime_read(config, &current_signature, signature)
+            && storage_dir_has_lockless_read_artifacts(config, &current_dir, &current_signature)
         {
-            return Ok(true);
+            return Ok(Some(PublishedStorageVersion {
+                version_id: current,
+                storage_dir: current_dir,
+                signature_path: current_sig_path,
+                signature: current_signature,
+            }));
         }
     }
 
-    Ok(
-        storage_signature_matches(initial_signature_path, signature)?
-            && storage_dir_has_lockless_read_artifacts(config, initial_storage_dir, signature),
-    )
+    let Some(initial_signature) = read_manifest_signature(initial_signature_path)? else {
+        return Ok(None);
+    };
+    if manifest_signature_matches_for_runtime_read(config, &initial_signature, signature)
+        && storage_dir_has_lockless_read_artifacts(config, initial_storage_dir, &initial_signature)
+    {
+        return Ok(Some(PublishedStorageVersion {
+            version_id: initial_version_id.to_string(),
+            storage_dir: initial_storage_dir.to_path_buf(),
+            signature_path: initial_signature_path.to_path_buf(),
+            signature: initial_signature,
+        }));
+    }
+    Ok(None)
 }
 
 fn load_complete_published_storage_version(
@@ -286,12 +327,6 @@ fn load_complete_published_storage_version(
         signature_path,
         signature,
     }))
-}
-
-fn storage_signature_matches(path: &Path, signature: &ManifestSignature) -> Result<bool> {
-    Ok(read_manifest_signature(path)?
-        .as_ref()
-        .is_some_and(|existing| manifest_signature_matches_for_reuse(existing, signature)))
 }
 
 fn storage_dir_has_lockless_read_artifacts(
@@ -331,4 +366,44 @@ fn acquire_in_use_lock(lock_dir: &Path) -> Result<File> {
     file.lock_shared()
         .map_err(|e| DbtNovaError::ServerError(format!("Storage in-use lock failed: {e}")))?;
     Ok(file)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_read_accepts_legacy_storage_only_in_read_only_mode() {
+        let mut config = DbtNovaConfig::default();
+        let expected = ManifestSignature {
+            content_hash: "same-hash".to_string(),
+            search_index_fingerprint: config.search.index_fingerprint(),
+            storage_format_version: STORAGE_FORMAT_VERSION.to_string(),
+            ..ManifestSignature::default()
+        };
+        let existing = ManifestSignature {
+            content_hash: "same-hash".to_string(),
+            search_index_fingerprint: config.search.legacy_index_fingerprint(),
+            ..ManifestSignature::default()
+        };
+
+        assert!(!manifest_signature_matches_for_runtime_read(
+            &config, &existing, &expected
+        ));
+
+        config.storage_read_only = true;
+        assert!(manifest_signature_matches_for_runtime_read(
+            &config, &existing, &expected
+        ));
+
+        let mismatched = ManifestSignature {
+            content_hash: "different-hash".to_string(),
+            ..existing
+        };
+        assert!(!manifest_signature_matches_for_runtime_read(
+            &config,
+            &mismatched,
+            &expected
+        ));
+    }
 }

--- a/src/manifest/prebuilt_assets.rs
+++ b/src/manifest/prebuilt_assets.rs
@@ -1,16 +1,20 @@
 use serde::{Deserialize, Serialize};
 
+use crate::config::search::{LEGACY_STORAGE_FORMAT_VERSION, STORAGE_FORMAT_VERSION};
 use crate::error::{DbtNovaError, Result};
 
 /// Supported prebuilt-asset metadata contract version.
-pub const PREBUILT_ASSETS_CONTRACT_VERSION: &str = "v1";
+pub const PREBUILT_ASSETS_CONTRACT_VERSION: &str = "v2";
 /// Supported bootstrap contract version.
-pub const PREBUILT_BOOTSTRAP_CONTRACT_VERSION: &str = "v1";
+pub const PREBUILT_BOOTSTRAP_CONTRACT_VERSION: &str = "v2";
+const LEGACY_PREBUILT_CONTRACT_VERSION: &str = "v1";
 
 /// Metadata contract emitted by the reusable prebuilt-assets workflow.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct PrebuiltAssetsMetadata {
     pub contract_version: String,
+    #[serde(default)]
+    pub storage_format_version: String,
     pub manifest_hash: String,
     pub manifest_version: String,
     pub entity_count: u64,
@@ -25,6 +29,8 @@ pub struct PrebuiltAssetsMetadata {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct PrebuiltAssetsBootstrap {
     pub contract_version: String,
+    #[serde(default)]
+    pub storage_format_version: String,
     #[serde(default)]
     pub profile: String,
     pub storage_instance_id: String,
@@ -58,12 +64,12 @@ impl PrebuiltAssetsMetadata {
     ///
     /// Returns an error when required contract fields are missing/invalid.
     pub fn validate(&self) -> Result<()> {
-        if self.contract_version != PREBUILT_ASSETS_CONTRACT_VERSION {
-            return Err(DbtNovaError::InvalidParams(format!(
-                "unsupported prebuilt metadata contract_version '{}' (expected '{}')",
-                self.contract_version, PREBUILT_ASSETS_CONTRACT_VERSION
-            )));
-        }
+        validate_contract_and_storage_format(
+            "metadata",
+            &self.contract_version,
+            &self.storage_format_version,
+            PREBUILT_ASSETS_CONTRACT_VERSION,
+        )?;
 
         if self.manifest_hash.trim().is_empty() {
             return Err(DbtNovaError::InvalidParams(
@@ -111,6 +117,12 @@ impl PrebuiltAssetsMetadata {
     pub fn has_models_artifact(&self) -> bool {
         !self.artifact_name_models.trim().is_empty()
     }
+
+    /// Effective persisted-storage format, including the legacy v1 default.
+    #[must_use]
+    pub fn effective_storage_format_version(&self) -> &str {
+        effective_storage_format_version(&self.contract_version, &self.storage_format_version)
+    }
 }
 
 impl PrebuiltAssetsBootstrap {
@@ -133,12 +145,12 @@ impl PrebuiltAssetsBootstrap {
     ///
     /// Returns an error when required contract fields are missing/invalid.
     pub fn validate(&self) -> Result<()> {
-        if self.contract_version != PREBUILT_BOOTSTRAP_CONTRACT_VERSION {
-            return Err(DbtNovaError::InvalidParams(format!(
-                "unsupported prebuilt bootstrap contract_version '{}' (expected '{}')",
-                self.contract_version, PREBUILT_BOOTSTRAP_CONTRACT_VERSION
-            )));
-        }
+        validate_contract_and_storage_format(
+            "bootstrap",
+            &self.contract_version,
+            &self.storage_format_version,
+            PREBUILT_BOOTSTRAP_CONTRACT_VERSION,
+        )?;
 
         if self.storage_instance_id.trim().is_empty() {
             return Err(DbtNovaError::InvalidParams(
@@ -182,6 +194,55 @@ impl PrebuiltAssetsBootstrap {
             ));
         }
         Ok(())
+    }
+
+    /// Effective persisted-storage format, including the legacy v1 default.
+    #[must_use]
+    pub fn effective_storage_format_version(&self) -> &str {
+        effective_storage_format_version(&self.contract_version, &self.storage_format_version)
+    }
+}
+
+fn validate_contract_and_storage_format(
+    label: &str,
+    contract_version: &str,
+    storage_format_version: &str,
+    current_contract_version: &str,
+) -> Result<()> {
+    match contract_version {
+        LEGACY_PREBUILT_CONTRACT_VERSION => {
+            if !storage_format_version.trim().is_empty()
+                && storage_format_version != LEGACY_STORAGE_FORMAT_VERSION
+            {
+                return Err(DbtNovaError::InvalidParams(format!(
+                    "prebuilt {label} contract_version '{LEGACY_PREBUILT_CONTRACT_VERSION}' must use storage_format_version '{LEGACY_STORAGE_FORMAT_VERSION}' when specified"
+                )));
+            }
+        }
+        version if version == current_contract_version => {
+            if storage_format_version != STORAGE_FORMAT_VERSION {
+                return Err(DbtNovaError::InvalidParams(format!(
+                    "prebuilt {label} storage_format_version '{storage_format_version}' is incompatible with this Nova binary (expected '{STORAGE_FORMAT_VERSION}')"
+                )));
+            }
+        }
+        _ => {
+            return Err(DbtNovaError::InvalidParams(format!(
+                "unsupported prebuilt {label} contract_version '{contract_version}' (supported: '{LEGACY_PREBUILT_CONTRACT_VERSION}', '{current_contract_version}')"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn effective_storage_format_version<'a>(
+    contract_version: &str,
+    storage_format_version: &'a str,
+) -> &'a str {
+    if contract_version == LEGACY_PREBUILT_CONTRACT_VERSION {
+        LEGACY_STORAGE_FORMAT_VERSION
+    } else {
+        storage_format_version
     }
 }
 
@@ -230,11 +291,13 @@ mod tests {
         PREBUILT_ASSETS_CONTRACT_VERSION, PREBUILT_BOOTSTRAP_CONTRACT_VERSION,
         PrebuiltAssetsBootstrap, PrebuiltAssetsMetadata,
     };
+    use crate::config::search::STORAGE_FORMAT_VERSION;
 
     fn valid_contract_json() -> String {
         format!(
             r#"{{
   "contract_version": "{PREBUILT_ASSETS_CONTRACT_VERSION}",
+  "storage_format_version": "{STORAGE_FORMAT_VERSION}",
   "manifest_hash": "abcd1234",
   "manifest_version": "v12",
   "entity_count": 42,
@@ -251,6 +314,7 @@ mod tests {
         format!(
             r#"{{
   "contract_version": "{PREBUILT_BOOTSTRAP_CONTRACT_VERSION}",
+  "storage_format_version": "{STORAGE_FORMAT_VERSION}",
   "profile": "prod",
   "storage_instance_id": "analytics-prod",
   "manifest_uri": "dbfs:/FileStore/manifests/prod/manifest.json",
@@ -269,13 +333,48 @@ mod tests {
         let metadata = PrebuiltAssetsMetadata::from_json_str(&valid_contract_json())
             .expect("valid contract should parse");
         assert_eq!(metadata.contract_version, PREBUILT_ASSETS_CONTRACT_VERSION);
+        assert_eq!(
+            metadata.effective_storage_format_version(),
+            STORAGE_FORMAT_VERSION
+        );
         assert!(metadata.has_models_artifact());
+    }
+
+    #[test]
+    fn from_json_str_accepts_legacy_v1_contract() {
+        let legacy = valid_contract_json()
+            .replace(
+                &format!("\"contract_version\": \"{PREBUILT_ASSETS_CONTRACT_VERSION}\""),
+                "\"contract_version\": \"v1\"",
+            )
+            .replace(
+                &format!("  \"storage_format_version\": \"{STORAGE_FORMAT_VERSION}\",\n"),
+                "",
+            );
+        let metadata =
+            PrebuiltAssetsMetadata::from_json_str(&legacy).expect("legacy contract should parse");
+        assert_eq!(
+            metadata.effective_storage_format_version(),
+            "nova-storage-v1"
+        );
+    }
+
+    #[test]
+    fn from_json_str_rejects_incompatible_storage_format() {
+        let invalid = valid_contract_json().replace(
+            &format!("\"storage_format_version\": \"{STORAGE_FORMAT_VERSION}\""),
+            "\"storage_format_version\": \"nova-storage-v999\"",
+        );
+        let error = PrebuiltAssetsMetadata::from_json_str(&invalid)
+            .expect_err("incompatible storage format should fail");
+        assert!(error.to_string().contains("storage_format_version"));
+        assert!(error.to_string().contains(STORAGE_FORMAT_VERSION));
     }
 
     #[test]
     fn from_json_str_rejects_invalid_contract_version() {
         let invalid = valid_contract_json().replace(
-            "\"contract_version\": \"v1\"",
+            &format!("\"contract_version\": \"{PREBUILT_ASSETS_CONTRACT_VERSION}\""),
             "\"contract_version\": \"v999\"",
         );
         let error = PrebuiltAssetsMetadata::from_json_str(&invalid)
@@ -322,12 +421,16 @@ mod tests {
             bootstrap.contract_version,
             PREBUILT_BOOTSTRAP_CONTRACT_VERSION
         );
+        assert_eq!(
+            bootstrap.effective_storage_format_version(),
+            STORAGE_FORMAT_VERSION
+        );
     }
 
     #[test]
     fn bootstrap_from_json_str_rejects_invalid_contract_version() {
         let invalid = valid_bootstrap_json().replace(
-            "\"contract_version\": \"v1\"",
+            &format!("\"contract_version\": \"{PREBUILT_BOOTSTRAP_CONTRACT_VERSION}\""),
             "\"contract_version\": \"v999\"",
         );
         let error = PrebuiltAssetsBootstrap::from_json_str(&invalid)

--- a/src/manifest/prebuilt_assets_resolver.rs
+++ b/src/manifest/prebuilt_assets_resolver.rs
@@ -8,6 +8,7 @@ use flate2::read::GzDecoder;
 use tar::Archive;
 use tracing::{info, warn};
 
+use crate::config::search::LEGACY_STORAGE_FORMAT_VERSION;
 use crate::config::{ArtifactFetchPolicy, DbtNovaConfig, SearchConfig};
 use crate::error::{DbtNovaError, Result};
 use crate::manifest::prebuilt_assets::PrebuiltAssetsMetadata;
@@ -68,6 +69,18 @@ pub fn materialize_file_artifacts(
     config: &DbtNovaConfig,
     expected_manifest_hash: &str,
 ) -> Result<Option<FileArtifactMaterialization>> {
+    materialize_file_artifacts_with_legacy_hash(
+        config,
+        expected_manifest_hash,
+        expected_manifest_hash,
+    )
+}
+
+pub(crate) fn materialize_file_artifacts_with_legacy_hash(
+    config: &DbtNovaConfig,
+    expected_manifest_hash: &str,
+    legacy_manifest_hash: &str,
+) -> Result<Option<FileArtifactMaterialization>> {
     if !config.remote_artifact_mode_enabled() {
         return Ok(None);
     }
@@ -93,7 +106,12 @@ pub fn materialize_file_artifacts(
     ensure_regular_file("DBT_NOVA_METADATA_ARTIFACT_URI", &metadata_path)?;
     let metadata_raw = read_small_text_file(&metadata_path, config.manifest_max_bytes)?;
     let metadata = PrebuiltAssetsMetadata::from_json_str(&metadata_raw)?;
-    validate_metadata_against_runtime(&metadata, config, expected_manifest_hash)?;
+    validate_metadata_against_runtime(
+        &metadata,
+        config,
+        expected_manifest_hash,
+        legacy_manifest_hash,
+    )?;
 
     if !config.models_artifact_uri.trim().is_empty() && !metadata.has_models_artifact() {
         return Err(DbtNovaError::InvalidParams(
@@ -104,7 +122,7 @@ pub fn materialize_file_artifacts(
 
     let storage_materialized = materialize_storage_artifact(config, &storage_target)?;
     let models_materialized =
-        materialize_models_artifact(config, &models_target, expected_manifest_hash)?;
+        materialize_models_artifact(config, &models_target, metadata.manifest_hash.trim())?;
 
     info!(
         storage_uri = %sanitize_uri(&config.storage_artifact_uri),
@@ -463,10 +481,18 @@ fn validate_metadata_against_runtime(
     metadata: &PrebuiltAssetsMetadata,
     config: &DbtNovaConfig,
     expected_manifest_hash: &str,
+    legacy_manifest_hash: &str,
 ) -> Result<()> {
+    let expected_manifest_hash =
+        if metadata.effective_storage_format_version() == LEGACY_STORAGE_FORMAT_VERSION {
+            legacy_manifest_hash
+        } else {
+            expected_manifest_hash
+        };
     let instance_id = config.storage_instance_id.trim();
     info!(
         contract_version = %metadata.contract_version,
+        storage_format_version = %metadata.effective_storage_format_version(),
         metadata_storage_instance_id = %metadata.storage_instance_id,
         runtime_storage_instance_id = %instance_id,
         metadata_manifest_hash = %metadata.manifest_hash,

--- a/src/manifest/search/core.rs
+++ b/src/manifest/search/core.rs
@@ -86,6 +86,7 @@ pub struct ManifestSearch {
     pub(crate) manifest_len: u64,
     pub(crate) manifest_modified_ms: u128,
     pub(crate) manifest_version: String,
+    pub(crate) storage_format_version: String,
     pub(crate) loaded_at_ms: u128,
 
     // === Circuit breakers for optional search components ===
@@ -519,6 +520,7 @@ impl ManifestSearch {
                 "len": self.manifest_len,
                 "modified_ms": self.manifest_modified_ms,
                 "version": self.manifest_version,
+                "storage_format_version": self.storage_format_version,
                 "age_ms": manifest_age_ms,
                 "loaded_at_ms": self.loaded_at_ms,
                 "loaded_age_ms": loaded_age_ms,
@@ -1322,7 +1324,7 @@ mod tests {
     }
 
     #[test]
-    fn scoped_refresh_hash_includes_prune_and_search_fingerprints() {
+    fn scoped_refresh_hash_includes_storage_prune_and_search_fingerprints() {
         let signature = ManifestSignature {
             content_hash: "same-content".to_string(),
             ..ManifestSignature::default()
@@ -1348,7 +1350,8 @@ mod tests {
         let pruned_hash = scoped_refresh_manifest_hash(signature.clone(), &pruned);
         let search_scoped_hash = scoped_refresh_manifest_hash(signature, &search_scoped);
 
-        assert_eq!(unscoped_hash, "same-content");
+        assert_ne!(unscoped_hash, "same-content");
+        assert_eq!(unscoped_hash.len(), 64);
         assert_ne!(pruned_hash, unscoped_hash);
         assert_ne!(search_scoped_hash, unscoped_hash);
         assert_ne!(pruned_hash, search_scoped_hash);

--- a/src/manifest/source/mod.rs
+++ b/src/manifest/source/mod.rs
@@ -1099,23 +1099,25 @@ fn fetch_gcs_manifest_sdk(
         let object = object.clone();
         run_async_fetch_blocking(move || async move {
             let fetch = async {
-                let gcs_config = google_cloud_storage::client::ClientConfig::default()
-                    .with_auth()
+                let client = google_cloud_storage::client::Storage::builder()
+                    .build()
                     .await
                     .map_err(|e| DbtNovaError::ServerError(format!("GCS auth failed: {e}")))?;
-                let client = google_cloud_storage::client::Client::new(gcs_config);
-                let req = google_cloud_storage::http::objects::get::GetObjectRequest {
-                    bucket: bucket.clone(),
-                    object: object.clone(),
-                    ..Default::default()
-                };
-                client
-                    .download_object(
-                        &req,
-                        &google_cloud_storage::http::objects::download::Range::default(),
-                    )
+                let bucket_resource = format!("projects/_/buckets/{bucket}");
+                let mut response = client
+                    .read_object(bucket_resource, object)
+                    .send()
                     .await
-                    .map_err(|e| DbtNovaError::ServerError(format!("GCS download failed: {e}")))
+                    .map_err(|e| DbtNovaError::ServerError(format!("GCS download failed: {e}")))?;
+                let mut data = Vec::new();
+                while let Some(chunk) =
+                    response.next().await.transpose().map_err(|e| {
+                        DbtNovaError::ServerError(format!("GCS download failed: {e}"))
+                    })?
+                {
+                    data.extend_from_slice(&chunk);
+                }
+                Ok::<_, DbtNovaError>(data)
             };
             if timeout_secs > 0 {
                 tokio::time::timeout(Duration::from_secs(timeout_secs), fetch)

--- a/src/manifest/source/mod.rs
+++ b/src/manifest/source/mod.rs
@@ -19,6 +19,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use tracing::warn;
 
 use crate::config::DbtNovaConfig;
+use crate::config::search::{LEGACY_STORAGE_FORMAT_VERSION, STORAGE_FORMAT_VERSION};
 use crate::error::{DbtNovaError, Result};
 use crate::utils::unique_suffix;
 
@@ -133,7 +134,18 @@ pub(crate) struct ManifestSignature {
     pub content_hash: String,
     pub prune_fingerprint: String,
     pub search_index_fingerprint: String,
+    pub storage_format_version: String,
     pub source_uri: String,
+}
+
+impl ManifestSignature {
+    pub(crate) fn effective_storage_format_version(&self) -> &str {
+        if self.storage_format_version.is_empty() {
+            LEGACY_STORAGE_FORMAT_VERSION
+        } else {
+            &self.storage_format_version
+        }
+    }
 }
 
 static CACHE_HITS: AtomicU64 = AtomicU64::new(0);
@@ -171,6 +183,7 @@ pub(crate) fn manifest_signature(path: &Path, source_uri: &str) -> Result<Manife
         content_hash,
         prune_fingerprint: String::new(),
         search_index_fingerprint: String::new(),
+        storage_format_version: STORAGE_FORMAT_VERSION.to_string(),
         source_uri: source_uri.to_string(),
     })
 }

--- a/src/manifest/tantivy_search.rs
+++ b/src/manifest/tantivy_search.rs
@@ -861,7 +861,10 @@ impl TantivySearcher {
                 .saturating_mul(config.dedup_fetch_multiplier.max(1)),
             MAX_FETCH_LIMIT,
         );
-        let top_docs = searcher.search(&final_query, &TopDocs::with_limit(fetch_limit))?;
+        let top_docs = searcher.search(
+            &final_query,
+            &TopDocs::with_limit(fetch_limit).order_by_score(),
+        )?;
 
         let highlight_enabled = request.include_highlights
             && config.highlight_max_fields > 0

--- a/tests/prebuilt_artifact_lifecycle.rs
+++ b/tests/prebuilt_artifact_lifecycle.rs
@@ -135,12 +135,13 @@ fn to_file_uri(path: &Path) -> String {
     format!("file://{}", path.display())
 }
 
-fn manifest_content_hash() -> String {
-    let raw = fs::read(fixture_manifest_path()).expect("read fixture manifest");
-    blake3::hash(&raw).to_hex().to_string()
+struct SourceStorageFixture {
+    root: PathBuf,
+    manifest_hash: String,
+    manifest_version: String,
 }
 
-fn build_source_storage(workspace: &TempDir) -> PathBuf {
+fn build_source_storage(workspace: &TempDir) -> SourceStorageFixture {
     let source_storage_dir = workspace.path().join("source-storage");
     let source_config = build_config(&source_storage_dir);
     let source_storage_root = source_config
@@ -152,19 +153,44 @@ fn build_source_storage(workspace: &TempDir) -> PathBuf {
         source_storage_root.is_dir(),
         "source storage root should exist"
     );
-    source_storage_root
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let health = runtime.block_on(load.search.health_snapshot());
+    assert_eq!(
+        health["manifest"]["storage_format_version"],
+        serde_json::json!("nova-storage-v2")
+    );
+    SourceStorageFixture {
+        root: source_storage_root,
+        manifest_hash: health["manifest"]["hash"]
+            .as_str()
+            .expect("manifest hash")
+            .to_string(),
+        manifest_version: health["manifest"]["version"]
+            .as_str()
+            .expect("manifest version")
+            .to_string(),
+    }
 }
 
-fn write_metadata(path: &Path, manifest_hash: &str, include_models_artifact: bool) {
+fn write_metadata(
+    path: &Path,
+    manifest_hash: &str,
+    manifest_version: &str,
+    include_models_artifact: bool,
+) {
     let artifact_name_models = if include_models_artifact {
         "models-asset"
     } else {
         ""
     };
     let payload = serde_json::json!({
-        "contract_version": "v1",
+        "contract_version": "v2",
+        "storage_format_version": "nova-storage-v2",
         "manifest_hash": manifest_hash,
-        "manifest_version": "v12",
+        "manifest_version": manifest_version,
         "entity_count": 1,
         "storage_instance_id": "analytics-prod",
         "dbt_nova_version": "0.0.2",
@@ -186,13 +212,18 @@ fn manifest_load_materializes_file_artifacts_before_reuse() {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let workspace = TempDir::new().expect("tempdir");
-    let source_storage_dir = build_source_storage(&workspace);
+    let source = build_source_storage(&workspace);
 
     let storage_archive_path = workspace.path().join("storage.tar.gz");
-    create_archive_from_dir(&source_storage_dir, &storage_archive_path);
+    create_archive_from_dir(&source.root, &storage_archive_path);
 
     let metadata_path = workspace.path().join("nova-build-metadata.json");
-    write_metadata(&metadata_path, &manifest_content_hash(), false);
+    write_metadata(
+        &metadata_path,
+        &source.manifest_hash,
+        &source.manifest_version,
+        false,
+    );
 
     let destination_storage_dir = workspace.path().join("destination-storage");
     let mut destination_config = build_config(&destination_storage_dir);
@@ -243,13 +274,18 @@ fn manifest_load_rejects_artifact_metadata_hash_mismatch() {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let workspace = TempDir::new().expect("tempdir");
-    let source_storage_dir = build_source_storage(&workspace);
+    let source = build_source_storage(&workspace);
 
     let storage_archive_path = workspace.path().join("storage.tar.gz");
-    create_archive_from_dir(&source_storage_dir, &storage_archive_path);
+    create_archive_from_dir(&source.root, &storage_archive_path);
 
     let metadata_path = workspace.path().join("nova-build-metadata.json");
-    write_metadata(&metadata_path, "mismatched-hash", false);
+    write_metadata(
+        &metadata_path,
+        "mismatched-hash",
+        &source.manifest_version,
+        false,
+    );
 
     let destination_storage_dir = workspace.path().join("destination-storage");
     let mut destination_config = build_config(&destination_storage_dir);
@@ -270,13 +306,18 @@ fn manifest_load_read_only_rejects_artifact_materialization_when_missing() {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let workspace = TempDir::new().expect("tempdir");
-    let source_storage_dir = build_source_storage(&workspace);
+    let source = build_source_storage(&workspace);
 
     let storage_archive_path = workspace.path().join("storage.tar.gz");
-    create_archive_from_dir(&source_storage_dir, &storage_archive_path);
+    create_archive_from_dir(&source.root, &storage_archive_path);
 
     let metadata_path = workspace.path().join("nova-build-metadata.json");
-    write_metadata(&metadata_path, &manifest_content_hash(), false);
+    write_metadata(
+        &metadata_path,
+        &source.manifest_hash,
+        &source.manifest_version,
+        false,
+    );
 
     let destination_storage_dir = workspace.path().join("destination-storage");
     let mut destination_config = build_config(&destination_storage_dir);


### PR DESCRIPTION
## Summary

- Update the vulnerable Rust and documentation dependency graph, including JSON Web Token handling, Tantivy/LRU, Google Cloud Storage, OpenSSL, Rand, Tar, Rkyv, Quinn, MkDocs Material, and PyMdown Extensions.
- Add a Nova-owned persisted-storage format identity and emit v2 prebuilt metadata/bootstrap contracts.
- Preserve deliberate migration paths: current consumers can reuse retained v1 storage in strict read-only mode or hydrate and rebuild v1 artifacts into v2 in writable mode.
- Add an exact released-v0.0.6 compatibility gate covering upgrade, cold hydration, retained-version rollback, and old-consumer rejection of v2 artifacts.
- Remove whole inherited-secret serialization from both reusable workflows. Mapped dbt credentials now resolve only from an explicitly constructed `DBT_NOVA_SECRET_BUNDLE_JSON`.
- Resolve installer refs to detached commits with step-scoped credentials and no retained Git metadata.
- Refresh the changelog and operational, CI, security, metadata-audit, manifest-source, and prebuilt-asset documentation.

## Compatibility and rollout

The Tantivy upgrade changes persisted index compatibility, so this PR makes that boundary explicit instead of silently reusing or overwriting incompatible storage.

Use a consumer-first rollout:

1. Deploy the updated Nova consumer.
2. Confirm it can read retained v1 storage or hydrate/rebuild v1 artifacts.
3. Publish v2 producer artifacts.
4. Keep the prior v1 generation available for rollback until the rollout is complete.

Current Nova accepts v1 and v2 prebuilt contracts. A v0.0.6 consumer rejects v2 metadata before archive extraction. The active format is exposed additively through manifest-load output, health, bootstrap status, and artifact-consumer status.

`manifest_hash` remains the storage-scoped identity used by persisted assets; the v2 storage identity intentionally changes it so old and new index generations cannot collide.

One workflow caller migration is intentional: callers that previously relied on `secrets: inherit` plus dynamic lookup must now construct and pass `DBT_NOVA_SECRET_BUNDLE_JSON`. This removes unrelated repository and organization secrets from the job environment.

## Security result

- Removes the two `actions/excessive-secrets-exposure` sources.
- Replaces the untrusted installer checkout path with validated, detached fetch behavior.
- Removes obsolete RustSec ignores and the resolved reqwest watchlist item.
- The 18 default-branch Dependabot alerts are patched by this branch and will close after merge.

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo check --locked --no-default-features --all-targets`
- `cargo deny check`
- `uv pip install -r docs/requirements.txt` in an isolated environment, then `mkdocs build --strict`
- `actionlint .github/workflows/ci.yml .github/workflows/nova-build-assets.yml .github/workflows/nova-metadata-audit.yml`
- `shellcheck scripts/check_storage_format_compatibility.sh`
- `bash scripts/check_storage_format_compatibility.sh <current> <v0.0.6> tests/fixtures/nova_manifest.json`
- `bash scripts/check_config_reference.sh`
- `bash scripts/check_dependency_watchlist.sh`
- `bash scripts/check_advisory_ignores.sh`
- `bash scripts/check_module_size.sh`
- `git diff --check`